### PR TITLE
Update SVG2 draft spec_url domain

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8282,7 +8282,7 @@
       "rootElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/rootElement",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGDocument__rootElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGDocument__rootElement",
           "support": {
             "chrome": {
               "version_added": "34"

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -3,7 +3,7 @@
     "SVGAElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement",
-        "spec_url": "https://svgwg.org/svg2-draft/linking.html#InterfaceSVGAElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "download": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/download",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__download",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__download",
           "tags": [
             "web-features:download"
           ],
@@ -85,7 +85,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -133,7 +133,7 @@
       "hreflang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/hreflang",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__hreflang",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__hreflang",
           "tags": [
             "web-features:svg"
           ],
@@ -202,7 +202,7 @@
       "ping": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/ping",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__ping",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__ping",
           "tags": [
             "web-features:ping"
           ],
@@ -238,7 +238,7 @@
       },
       "referrerPolicy": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__referrerPolicy",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__referrerPolicy",
           "tags": [
             "web-features:svg"
           ],
@@ -273,7 +273,7 @@
       "rel": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/rel",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__rel",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__rel",
           "tags": [
             "web-features:svg"
           ],
@@ -308,7 +308,7 @@
       "relList": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/relList",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__relList",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__relList",
           "tags": [
             "web-features:svg"
           ],
@@ -343,7 +343,7 @@
       "target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/target",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__target",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__target",
           "tags": [
             "web-features:svg"
           ],
@@ -391,7 +391,7 @@
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/text",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__text",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__text",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -427,7 +427,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/type",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#__svg__SVGAElement__type",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#__svg__SVGAElement__type",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGAngle.json
+++ b/api/SVGAngle.json
@@ -3,7 +3,7 @@
     "SVGAngle": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAngle",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAngle",
         "tags": [
           "web-features:svg"
         ],
@@ -48,7 +48,7 @@
       "convertToSpecifiedUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle/convertToSpecifiedUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__convertToSpecifiedUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAngle__convertToSpecifiedUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -94,7 +94,7 @@
       "newValueSpecifiedUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle/newValueSpecifiedUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__newValueSpecifiedUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAngle__newValueSpecifiedUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -140,7 +140,7 @@
       "unitType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle/unitType",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__unitType",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAngle__unitType",
           "tags": [
             "web-features:svg"
           ],
@@ -186,7 +186,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle/value",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__value",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAngle__value",
           "tags": [
             "web-features:svg"
           ],
@@ -232,7 +232,7 @@
       "valueAsString": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle/valueAsString",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__valueAsString",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAngle__valueAsString",
           "tags": [
             "web-features:svg"
           ],
@@ -278,7 +278,7 @@
       "valueInSpecifiedUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAngle/valueInSpecifiedUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAngle__valueInSpecifiedUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAngle__valueInSpecifiedUnits",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGAnimatedAngle.json
+++ b/api/SVGAnimatedAngle.json
@@ -3,7 +3,7 @@
     "SVGAnimatedAngle": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedAngle",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedAngle",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedAngle",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedAngle/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedAngle__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedAngle__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedAngle/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedAngle__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedAngle__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedBoolean.json
+++ b/api/SVGAnimatedBoolean.json
@@ -3,7 +3,7 @@
     "SVGAnimatedBoolean": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedBoolean",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedBoolean",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedBoolean",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -48,7 +48,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedBoolean/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedBoolean__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedBoolean__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -92,7 +92,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedBoolean/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedBoolean__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedBoolean__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedEnumeration.json
+++ b/api/SVGAnimatedEnumeration.json
@@ -3,7 +3,7 @@
     "SVGAnimatedEnumeration": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedEnumeration",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedEnumeration",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedEnumeration/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedEnumeration__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedEnumeration__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedEnumeration/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedEnumeration__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedEnumeration__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedInteger.json
+++ b/api/SVGAnimatedInteger.json
@@ -3,7 +3,7 @@
     "SVGAnimatedInteger": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedInteger",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedInteger",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedInteger",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -48,7 +48,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedInteger/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedInteger__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedInteger__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -92,7 +92,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedInteger/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedInteger__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedInteger__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedLength.json
+++ b/api/SVGAnimatedLength.json
@@ -3,7 +3,7 @@
     "SVGAnimatedLength": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLength",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedLength",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedLength__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedLength__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLength/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedLength__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedLength__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedLengthList.json
+++ b/api/SVGAnimatedLengthList.json
@@ -3,7 +3,7 @@
     "SVGAnimatedLengthList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLengthList",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedLengthList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedLengthList",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLengthList/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedLengthList__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedLengthList__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedLengthList/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedLengthList__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedLengthList__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedNumber.json
+++ b/api/SVGAnimatedNumber.json
@@ -3,7 +3,7 @@
     "SVGAnimatedNumber": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumber",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumber",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedNumber",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumber/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedNumber__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedNumber__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumber/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedNumber__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedNumber__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedNumberList.json
+++ b/api/SVGAnimatedNumberList.json
@@ -3,7 +3,7 @@
     "SVGAnimatedNumberList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumberList",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumberList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedNumberList",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -48,7 +48,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumberList/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedNumberList__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedNumberList__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -92,7 +92,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedNumberList/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedNumberList__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedNumberList__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedPreserveAspectRatio.json
+++ b/api/SVGAnimatedPreserveAspectRatio.json
@@ -3,7 +3,7 @@
     "SVGAnimatedPreserveAspectRatio": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedPreserveAspectRatio",
-        "spec_url": "https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedPreserveAspectRatio",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGAnimatedPreserveAspectRatio",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -48,7 +48,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedPreserveAspectRatio/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -92,7 +92,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedPreserveAspectRatio/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGAnimatedPreserveAspectRatio__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedRect.json
+++ b/api/SVGAnimatedRect.json
@@ -3,7 +3,7 @@
     "SVGAnimatedRect": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedRect",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedRect",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedRect",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedRect/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedRect__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedRect__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedRect/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedRect__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedRect__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedString.json
+++ b/api/SVGAnimatedString.json
@@ -3,7 +3,7 @@
     "SVGAnimatedString": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedString",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGAnimatedString",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedString__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedString__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedString/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGAnimatedString__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGAnimatedString__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimatedTransformList.json
+++ b/api/SVGAnimatedTransformList.json
@@ -3,7 +3,7 @@
     "SVGAnimatedTransformList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedTransformList",
-        "spec_url": "https://svgwg.org/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGAnimatedTransformList",
         "tags": [
           "web-features:smil-svg-animations"
         ],
@@ -50,7 +50,7 @@
       "animVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedTransformList/animVal",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedTransformList__animVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGAnimatedTransformList__animVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "baseVal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimatedTransformList/baseVal",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGAnimatedTransformList__baseVal",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGAnimatedTransformList__baseVal",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -128,7 +128,7 @@
         "__compat": {
           "description": "`beginEvent` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/beginEvent_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#BeginEvent",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#BeginEvent",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -270,7 +270,7 @@
         "__compat": {
           "description": "`endEvent` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/endEvent_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#EndEvent",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#EndEvent",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -447,7 +447,7 @@
         "__compat": {
           "description": "`repeatEvent` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/repeatEvent_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#RepeatEvent",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#RepeatEvent",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -506,7 +506,7 @@
       "requiredExtensions": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/requiredExtensions",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__requiredExtensions",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__requiredExtensions",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -549,7 +549,7 @@
       "systemLanguage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAnimationElement/systemLanguage",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
           "tags": [
             "web-features:smil-svg-animations"
           ],

--- a/api/SVGCircleElement.json
+++ b/api/SVGCircleElement.json
@@ -3,7 +3,7 @@
     "SVGCircleElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGCircleElement",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGCircleElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGCircleElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "cx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGCircleElement/cx",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGCircleElement__cx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGCircleElement__cx",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "cy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGCircleElement/cy",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGCircleElement__cy",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGCircleElement__cy",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "r": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGCircleElement/r",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGCircleElement__r",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGCircleElement__r",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGDefsElement.json
+++ b/api/SVGDefsElement.json
@@ -3,7 +3,7 @@
     "SVGDefsElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGDefsElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGDefsElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGDefsElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGDescElement.json
+++ b/api/SVGDescElement.json
@@ -3,7 +3,7 @@
     "SVGDescElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGDescElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGDescElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGDescElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -3,7 +3,7 @@
     "SVGElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGElement",
         "tags": [
           "web-features:svg"
         ],
@@ -167,7 +167,7 @@
       },
       "className": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__className",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGElement__className",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -257,7 +257,7 @@
         "__compat": {
           "description": "`error` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/error_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#ErrorEvent",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#ErrorEvent",
           "tags": [
             "web-features:svg"
           ],
@@ -379,7 +379,7 @@
         "__compat": {
           "description": "`load` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/load_event",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#LoadEvent",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#LoadEvent",
           "tags": [
             "web-features:svg"
           ],
@@ -462,7 +462,7 @@
       "ownerSVGElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/ownerSVGElement",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGElement__ownerSVGElement",
           "tags": [
             "web-features:svg"
           ],
@@ -625,7 +625,7 @@
       "viewportElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGElement/viewportElement",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGElement__viewportElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGElement__viewportElement",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGEllipseElement.json
+++ b/api/SVGEllipseElement.json
@@ -3,7 +3,7 @@
     "SVGEllipseElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGEllipseElement",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGEllipseElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGEllipseElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "cx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGEllipseElement/cx",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGEllipseElement__cx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGEllipseElement__cx",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "cy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGEllipseElement/cy",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGEllipseElement__cy",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGEllipseElement__cy",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "rx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGEllipseElement/rx",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGEllipseElement__rx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGEllipseElement__rx",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "ry": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGEllipseElement/ry",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGEllipseElement__ry",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGEllipseElement__ry",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGFEImageElement.json
+++ b/api/SVGFEImageElement.json
@@ -124,7 +124,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFEImageElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg-filters"
           ],

--- a/api/SVGFilterElement.json
+++ b/api/SVGFilterElement.json
@@ -134,7 +134,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGFilterElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg-filters"
           ],

--- a/api/SVGForeignObjectElement.json
+++ b/api/SVGForeignObjectElement.json
@@ -3,7 +3,7 @@
     "SVGForeignObjectElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGForeignObjectElement",
-        "spec_url": "https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGForeignObjectElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#InterfaceSVGForeignObjectElement",
         "tags": [
           "web-features:svg"
         ],
@@ -47,7 +47,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGForeignObjectElement/height",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__height",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__height",
           "tags": [
             "web-features:svg"
           ],
@@ -90,7 +90,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGForeignObjectElement/width",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__width",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__width",
           "tags": [
             "web-features:svg"
           ],
@@ -133,7 +133,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGForeignObjectElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -176,7 +176,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGForeignObjectElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGForeignObjectElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGGElement.json
+++ b/api/SVGGElement.json
@@ -3,7 +3,7 @@
     "SVGGElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGGElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGGElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGGeometryElement.json
+++ b/api/SVGGeometryElement.json
@@ -3,7 +3,7 @@
     "SVGGeometryElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGeometryElement",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGGeometryElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGeometryElement",
         "tags": [
           "web-features:svg"
         ],
@@ -106,7 +106,7 @@
       "getPointAtLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGeometryElement/getPointAtLength",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getPointAtLength",
           "tags": [
             "web-features:svg"
           ],
@@ -210,7 +210,7 @@
       "getTotalLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGeometryElement/getTotalLength",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__getTotalLength",
           "tags": [
             "web-features:svg"
           ],
@@ -314,7 +314,7 @@
       "isPointInFill": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGeometryElement/isPointInFill",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInFill",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInFill",
           "tags": [
             "web-features:svg"
           ],
@@ -386,7 +386,7 @@
       "isPointInStroke": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGeometryElement/isPointInStroke",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__isPointInStroke",
           "tags": [
             "web-features:svg"
           ],
@@ -458,7 +458,7 @@
       "pathLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGeometryElement/pathLength",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGeometryElement__pathLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGeometryElement__pathLength",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGGradientElement.json
+++ b/api/SVGGradientElement.json
@@ -3,7 +3,7 @@
     "SVGGradientElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGradientElement",
-        "spec_url": "https://svgwg.org/svg2-draft/pservers.html#InterfaceSVGGradientElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#InterfaceSVGGradientElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "gradientTransform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGradientElement/gradientTransform",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGGradientElement__gradientTransform",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGGradientElement__gradientTransform",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "gradientUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGradientElement/gradientUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGGradientElement__gradientUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGGradientElement__gradientUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGradientElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "spreadMethod": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGradientElement/spreadMethod",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGGradientElement__spreadMethod",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGGradientElement__spreadMethod",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -3,7 +3,7 @@
     "SVGGraphicsElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGGraphicsElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGGraphicsElement",
         "tags": [
           "web-features:svg"
         ],
@@ -108,7 +108,7 @@
       "getBBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/getBBox",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox",
           "tags": [
             "web-features:svg"
           ],
@@ -160,7 +160,7 @@
       "getCTM": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/getCTM",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getCTM",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getCTM",
           "tags": [
             "web-features:svg"
           ],
@@ -208,7 +208,7 @@
       "getScreenCTM": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/getScreenCTM",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getScreenCTM",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getScreenCTM",
           "tags": [
             "web-features:svg"
           ],
@@ -258,7 +258,7 @@
       "requiredExtensions": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/requiredExtensions",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__requiredExtensions",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__requiredExtensions",
           "tags": [
             "web-features:svg"
           ],
@@ -306,7 +306,7 @@
       "systemLanguage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/systemLanguage",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
           "tags": [
             "web-features:svg"
           ],
@@ -354,7 +354,7 @@
       "transform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGGraphicsElement/transform",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__transform",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__transform",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGImageElement.json
+++ b/api/SVGImageElement.json
@@ -3,7 +3,7 @@
     "SVGImageElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement",
-        "spec_url": "https://svgwg.org/svg2-draft/embedded.html#InterfaceSVGImageElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#InterfaceSVGImageElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "crossOrigin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/crossOrigin",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__crossOrigin",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGImageElement__crossOrigin",
           "tags": [
             "web-features:svg"
           ],
@@ -156,7 +156,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/height",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__height",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGImageElement__height",
           "tags": [
             "web-features:svg"
           ],
@@ -204,7 +204,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -252,7 +252,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/preserveAspectRatio",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#PreserveAspectRatioAttribute",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#PreserveAspectRatioAttribute",
           "tags": [
             "web-features:svg"
           ],
@@ -300,7 +300,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/width",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__width",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGImageElement__width",
           "tags": [
             "web-features:svg"
           ],
@@ -348,7 +348,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGImageElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -396,7 +396,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGImageElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#__svg__SVGImageElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#__svg__SVGImageElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGLength.json
+++ b/api/SVGLength.json
@@ -3,7 +3,7 @@
     "SVGLength": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGLength",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGLength",
         "tags": [
           "web-features:svg"
         ],
@@ -48,7 +48,7 @@
       "convertToSpecifiedUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength/convertToSpecifiedUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__convertToSpecifiedUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__convertToSpecifiedUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -94,7 +94,7 @@
       "newValueSpecifiedUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength/newValueSpecifiedUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__newValueSpecifiedUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__newValueSpecifiedUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -140,7 +140,7 @@
       "unitType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength/unitType",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__unitType",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__unitType",
           "tags": [
             "web-features:svg"
           ],
@@ -186,7 +186,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength/value",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__value",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__value",
           "tags": [
             "web-features:svg"
           ],
@@ -232,7 +232,7 @@
       "valueAsString": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength/valueAsString",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__valueAsString",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__valueAsString",
           "tags": [
             "web-features:svg"
           ],
@@ -278,7 +278,7 @@
       "valueInSpecifiedUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLength/valueInSpecifiedUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGLength__valueInSpecifiedUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGLength__valueInSpecifiedUnits",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGLengthList.json
+++ b/api/SVGLengthList.json
@@ -3,7 +3,7 @@
     "SVGLengthList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGLengthList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGLengthList",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "appendItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/appendItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/clear",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__clear",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "getItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/getItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "initialize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/initialize",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "tags": [
             "web-features:svg"
           ],
@@ -242,7 +242,7 @@
       "insertItemBefore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/insertItemBefore",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "tags": [
             "web-features:svg"
           ],
@@ -290,7 +290,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/length",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__length",
           "tags": [
             "web-features:svg"
           ],
@@ -329,7 +329,7 @@
       "numberOfItems": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/numberOfItems",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "tags": [
             "web-features:svg"
           ],
@@ -377,7 +377,7 @@
       "removeItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/removeItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "tags": [
             "web-features:svg"
           ],
@@ -425,7 +425,7 @@
       "replaceItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLengthList/replaceItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGLineElement.json
+++ b/api/SVGLineElement.json
@@ -3,7 +3,7 @@
     "SVGLineElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLineElement",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGLineElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGLineElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "x1": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLineElement/x1",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGLineElement__x1",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGLineElement__x1",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "x2": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLineElement/x2",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGLineElement__x2",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGLineElement__x2",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "y1": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLineElement/y1",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGLineElement__y1",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGLineElement__y1",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "y2": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLineElement/y2",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGLineElement__y2",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGLineElement__y2",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGLinearGradientElement.json
+++ b/api/SVGLinearGradientElement.json
@@ -3,7 +3,7 @@
     "SVGLinearGradientElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLinearGradientElement",
-        "spec_url": "https://svgwg.org/svg2-draft/pservers.html#InterfaceSVGLinearGradientElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#InterfaceSVGLinearGradientElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "x1": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLinearGradientElement/x1",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__x1",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__x1",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "x2": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLinearGradientElement/x2",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__x2",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__x2",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "y1": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLinearGradientElement/y1",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__y1",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__y1",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "y2": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGLinearGradientElement/y2",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__y2",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGLinearGradientElement__y2",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGMPathElement.json
+++ b/api/SVGMPathElement.json
@@ -41,7 +41,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMPathElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGMarkerElement.json
+++ b/api/SVGMarkerElement.json
@@ -3,7 +3,7 @@
     "SVGMarkerElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement",
-        "spec_url": "https://svgwg.org/svg2-draft/painting.html#InterfaceSVGMarkerElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#InterfaceSVGMarkerElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "markerHeight": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerHeight",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__markerHeight",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__markerHeight",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "markerUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__markerUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__markerUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "markerWidth": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/markerWidth",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__markerWidth",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__markerWidth",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "orient": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orient",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__orient",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__orient",
           "tags": [
             "web-features:svg"
           ],
@@ -229,7 +229,7 @@
       "orientAngle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orientAngle",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__orientAngle",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__orientAngle",
           "tags": [
             "web-features:svg"
           ],
@@ -277,7 +277,7 @@
       "orientType": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/orientType",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__orientType",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__orientType",
           "tags": [
             "web-features:svg"
           ],
@@ -325,7 +325,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/preserveAspectRatio",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "tags": [
             "web-features:svg"
           ],
@@ -373,7 +373,7 @@
       "refX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/refX",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__refX",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__refX",
           "tags": [
             "web-features:svg"
           ],
@@ -421,7 +421,7 @@
       "refY": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/refY",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__refY",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__refY",
           "tags": [
             "web-features:svg"
           ],
@@ -469,7 +469,7 @@
       "setOrientToAngle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/setOrientToAngle",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__setOrientToAngle",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__setOrientToAngle",
           "tags": [
             "web-features:svg"
           ],
@@ -517,7 +517,7 @@
       "setOrientToAuto": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/setOrientToAuto",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#__svg__SVGMarkerElement__setOrientToAuto",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#__svg__SVGMarkerElement__setOrientToAuto",
           "tags": [
             "web-features:svg"
           ],
@@ -565,7 +565,7 @@
       "viewBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMarkerElement/viewBox",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGMetadataElement.json
+++ b/api/SVGMetadataElement.json
@@ -3,7 +3,7 @@
     "SVGMetadataElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGMetadataElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGMetadataElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGMetadataElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGNumber.json
+++ b/api/SVGNumber.json
@@ -3,7 +3,7 @@
     "SVGNumber": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumber",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGNumber",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGNumber",
         "tags": [
           "web-features:svg"
         ],
@@ -48,7 +48,7 @@
       "value": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumber/value",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNumber__value",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNumber__value",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGNumberList.json
+++ b/api/SVGNumberList.json
@@ -3,7 +3,7 @@
     "SVGNumberList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGNumberList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGNumberList",
         "tags": [
           "web-features:svg"
         ],
@@ -48,7 +48,7 @@
       "appendItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/appendItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "tags": [
             "web-features:svg"
           ],
@@ -92,7 +92,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/clear",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__clear",
           "tags": [
             "web-features:svg"
           ],
@@ -136,7 +136,7 @@
       "getItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/getItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "tags": [
             "web-features:svg"
           ],
@@ -180,7 +180,7 @@
       "initialize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/initialize",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "tags": [
             "web-features:svg"
           ],
@@ -224,7 +224,7 @@
       "insertItemBefore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/insertItemBefore",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "tags": [
             "web-features:svg"
           ],
@@ -268,7 +268,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/length",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__length",
           "tags": [
             "web-features:svg"
           ],
@@ -307,7 +307,7 @@
       "numberOfItems": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/numberOfItems",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "tags": [
             "web-features:svg"
           ],
@@ -351,7 +351,7 @@
       "removeItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/removeItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "tags": [
             "web-features:svg"
           ],
@@ -395,7 +395,7 @@
       "replaceItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGNumberList/replaceItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGPathElement.json
+++ b/api/SVGPathElement.json
@@ -3,7 +3,7 @@
     "SVGPathElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPathElement",
-        "spec_url": "https://svgwg.org/svg2-draft/paths.html#InterfaceSVGPathElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#InterfaceSVGPathElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGPatternElement.json
+++ b/api/SVGPatternElement.json
@@ -3,7 +3,7 @@
     "SVGPatternElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement",
-        "spec_url": "https://svgwg.org/svg2-draft/pservers.html#InterfaceSVGPatternElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#InterfaceSVGPatternElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/height",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__height",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__height",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "patternContentUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/patternContentUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__patternContentUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__patternContentUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "patternTransform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/patternTransform",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__patternTransform",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__patternTransform",
           "tags": [
             "web-features:svg"
           ],
@@ -242,7 +242,7 @@
       "patternUnits": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/patternUnits",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__patternUnits",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__patternUnits",
           "tags": [
             "web-features:svg"
           ],
@@ -290,7 +290,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/preserveAspectRatio",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "tags": [
             "web-features:svg"
           ],
@@ -338,7 +338,7 @@
       "viewBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/viewBox",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
           "tags": [
             "web-features:svg"
           ],
@@ -386,7 +386,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/width",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__width",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__width",
           "tags": [
             "web-features:svg"
           ],
@@ -434,7 +434,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -482,7 +482,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPatternElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGPatternElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGPatternElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGPointList.json
+++ b/api/SVGPointList.json
@@ -3,7 +3,7 @@
     "SVGPointList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGPointList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGPointList",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "appendItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/appendItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/clear",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__clear",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "getItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/getItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "initialize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/initialize",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "tags": [
             "web-features:svg"
           ],
@@ -242,7 +242,7 @@
       "insertItemBefore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/insertItemBefore",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "tags": [
             "web-features:svg"
           ],
@@ -290,7 +290,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/length",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__length",
           "tags": [
             "web-features:svg"
           ],
@@ -329,7 +329,7 @@
       "numberOfItems": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/numberOfItems",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "tags": [
             "web-features:svg"
           ],
@@ -377,7 +377,7 @@
       "removeItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/removeItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "tags": [
             "web-features:svg"
           ],
@@ -425,7 +425,7 @@
       "replaceItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPointList/replaceItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGPolygonElement.json
+++ b/api/SVGPolygonElement.json
@@ -3,7 +3,7 @@
     "SVGPolygonElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPolygonElement",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGPolygonElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGPolygonElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "animatedPoints": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPolygonElement/animatedPoints",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__animatedPoints",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__animatedPoints",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "points": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPolygonElement/points",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__points",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__points",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGPolylineElement.json
+++ b/api/SVGPolylineElement.json
@@ -3,7 +3,7 @@
     "SVGPolylineElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPolylineElement",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGPolylineElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGPolylineElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "animatedPoints": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPolylineElement/animatedPoints",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__animatedPoints",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__animatedPoints",
           "tags": [
             "web-features:smil-svg-animations"
           ],
@@ -98,7 +98,7 @@
       "points": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPolylineElement/points",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__points",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGAnimatedPoints__points",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGPreserveAspectRatio.json
+++ b/api/SVGPreserveAspectRatio.json
@@ -3,7 +3,7 @@
     "SVGPreserveAspectRatio": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPreserveAspectRatio",
-        "spec_url": "https://svgwg.org/svg2-draft/coords.html#InterfaceSVGPreserveAspectRatio",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGPreserveAspectRatio",
         "tags": [
           "web-features:svg"
         ],
@@ -48,7 +48,7 @@
       "align": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPreserveAspectRatio/align",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGPreserveAspectRatio__align",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGPreserveAspectRatio__align",
           "tags": [
             "web-features:svg"
           ],
@@ -96,7 +96,7 @@
       "meetOrSlice": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGPreserveAspectRatio/meetOrSlice",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGPreserveAspectRatio__meetOrSlice",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGPreserveAspectRatio__meetOrSlice",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGRadialGradientElement.json
+++ b/api/SVGRadialGradientElement.json
@@ -3,7 +3,7 @@
     "SVGRadialGradientElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement",
-        "spec_url": "https://svgwg.org/svg2-draft/pservers.html#InterfaceSVGRadialGradientElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#InterfaceSVGRadialGradientElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "cx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement/cx",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__cx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__cx",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "cy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement/cy",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__cy",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__cy",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "fr": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement/fr",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__fr",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__fr",
           "tags": [
             "web-features:svg"
           ],
@@ -181,7 +181,7 @@
       "fx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement/fx",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__fx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__fx",
           "tags": [
             "web-features:svg"
           ],
@@ -229,7 +229,7 @@
       "fy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement/fy",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__fy",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__fy",
           "tags": [
             "web-features:svg"
           ],
@@ -277,7 +277,7 @@
       "r": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRadialGradientElement/r",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__r",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGRadialGradientElement__r",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGRectElement.json
+++ b/api/SVGRectElement.json
@@ -3,7 +3,7 @@
     "SVGRectElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement",
-        "spec_url": "https://svgwg.org/svg2-draft/shapes.html#InterfaceSVGRectElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#InterfaceSVGRectElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement/height",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGRectElement__height",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGRectElement__height",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "rx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement/rx",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGRectElement__rx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGRectElement__rx",
           "tags": [
             "web-features:svg"
           ],
@@ -144,7 +144,7 @@
       "ry": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement/ry",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGRectElement__ry",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGRectElement__ry",
           "tags": [
             "web-features:svg"
           ],
@@ -190,7 +190,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement/width",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGRectElement__width",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGRectElement__width",
           "tags": [
             "web-features:svg"
           ],
@@ -238,7 +238,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGRectElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGRectElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -286,7 +286,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGRectElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#__svg__SVGRectElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#__svg__SVGRectElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGSVGElement.json
+++ b/api/SVGSVGElement.json
@@ -3,7 +3,7 @@
     "SVGSVGElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGSVGElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGSVGElement",
         "tags": [
           "web-features:svg"
         ],
@@ -93,7 +93,7 @@
       "checkEnclosure": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/checkEnclosure",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__checkEnclosure",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__checkEnclosure",
           "tags": [
             "web-features:svg"
           ],
@@ -142,7 +142,7 @@
       "checkIntersection": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/checkIntersection",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__checkIntersection",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__checkIntersection",
           "tags": [
             "web-features:svg"
           ],
@@ -191,7 +191,7 @@
       "createSVGAngle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGAngle",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGAngle",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGAngle",
           "tags": [
             "web-features:svg"
           ],
@@ -239,7 +239,7 @@
       "createSVGLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGLength",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGLength",
           "tags": [
             "web-features:svg"
           ],
@@ -287,7 +287,7 @@
       "createSVGMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGMatrix",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGMatrix",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGMatrix",
           "tags": [
             "web-features:svg"
           ],
@@ -335,7 +335,7 @@
       "createSVGNumber": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGNumber",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGNumber",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGNumber",
           "tags": [
             "web-features:svg"
           ],
@@ -383,7 +383,7 @@
       "createSVGPoint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGPoint",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGPoint",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGPoint",
           "tags": [
             "web-features:svg"
           ],
@@ -431,7 +431,7 @@
       "createSVGRect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGRect",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGRect",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGRect",
           "tags": [
             "web-features:svg"
           ],
@@ -479,7 +479,7 @@
       "createSVGTransform": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGTransform",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGTransform",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGTransform",
           "tags": [
             "web-features:svg"
           ],
@@ -527,7 +527,7 @@
       "createSVGTransformFromMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/createSVGTransformFromMatrix",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__createSVGTransformFromMatrix",
           "tags": [
             "web-features:svg"
           ],
@@ -575,7 +575,7 @@
       "currentScale": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/currentScale",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__currentScale",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__currentScale",
           "tags": [
             "web-features:svg"
           ],
@@ -623,7 +623,7 @@
       "currentTranslate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/currentTranslate",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__currentTranslate",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__currentTranslate",
           "tags": [
             "web-features:svg"
           ],
@@ -707,7 +707,7 @@
       "deselectAll": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/deselectAll",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__deselectAll",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__deselectAll",
           "tags": [
             "web-features:svg"
           ],
@@ -754,7 +754,7 @@
       },
       "forceRedraw": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__forceRedraw",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__forceRedraw",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -850,7 +850,7 @@
       "getElementById": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/getElementById",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getElementById",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__getElementById",
           "tags": [
             "web-features:svg"
           ],
@@ -895,7 +895,7 @@
       },
       "getEnclosureList": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getEnclosureList",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__getEnclosureList",
           "tags": [
             "web-features:svg"
           ],
@@ -942,7 +942,7 @@
       },
       "getIntersectionList": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__getIntersectionList",
           "tags": [
             "web-features:svg"
           ],
@@ -990,7 +990,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/height",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__height",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__height",
           "tags": [
             "web-features:svg"
           ],
@@ -1086,7 +1086,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/preserveAspectRatio",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "tags": [
             "web-features:svg"
           ],
@@ -1181,7 +1181,7 @@
       },
       "suspendRedraw": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__suspendRedraw",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__suspendRedraw",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -1276,7 +1276,7 @@
       },
       "unsuspendRedraw": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__unsuspendRedraw",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__unsuspendRedraw",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -1323,7 +1323,7 @@
       },
       "unsuspendRedrawAll": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__unsuspendRedrawAll",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__unsuspendRedrawAll",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -1416,7 +1416,7 @@
       "viewBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/viewBox",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
           "tags": [
             "web-features:svg"
           ],
@@ -1464,7 +1464,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/width",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__width",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__width",
           "tags": [
             "web-features:svg"
           ],
@@ -1512,7 +1512,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -1560,7 +1560,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSVGElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGSVGElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGSVGElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGScriptElement.json
+++ b/api/SVGScriptElement.json
@@ -3,7 +3,7 @@
     "SVGScriptElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGScriptElement",
-        "spec_url": "https://svgwg.org/svg2-draft/interact.html#InterfaceSVGScriptElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#InterfaceSVGScriptElement",
         "tags": [
           "web-features:svg"
         ],
@@ -82,7 +82,7 @@
       },
       "crossOrigin": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#__svg__SVGScriptElement__crossOrigin",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#__svg__SVGScriptElement__crossOrigin",
           "tags": [
             "web-features:svg"
           ],
@@ -150,7 +150,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGScriptElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -198,7 +198,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGScriptElement/type",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#__svg__SVGScriptElement__type",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#__svg__SVGScriptElement__type",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGStopElement.json
+++ b/api/SVGStopElement.json
@@ -3,7 +3,7 @@
     "SVGStopElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStopElement",
-        "spec_url": "https://svgwg.org/svg2-draft/pservers.html#InterfaceSVGStopElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#InterfaceSVGStopElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "offset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStopElement/offset",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#__svg__SVGStopElement__offset",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#__svg__SVGStopElement__offset",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGStringList.json
+++ b/api/SVGStringList.json
@@ -3,7 +3,7 @@
     "SVGStringList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGStringList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGStringList",
         "tags": [
           "web-features:svg"
         ],
@@ -54,7 +54,7 @@
       "appendItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/appendItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "tags": [
             "web-features:svg"
           ],
@@ -102,7 +102,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/clear",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__clear",
           "tags": [
             "web-features:svg"
           ],
@@ -150,7 +150,7 @@
       "getItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/getItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "tags": [
             "web-features:svg"
           ],
@@ -198,7 +198,7 @@
       "initialize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/initialize",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "tags": [
             "web-features:svg"
           ],
@@ -246,7 +246,7 @@
       "insertItemBefore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/insertItemBefore",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "tags": [
             "web-features:svg"
           ],
@@ -294,7 +294,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/length",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__length",
           "tags": [
             "web-features:svg"
           ],
@@ -333,7 +333,7 @@
       "numberOfItems": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/numberOfItems",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "tags": [
             "web-features:svg"
           ],
@@ -381,7 +381,7 @@
       "removeItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/removeItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "tags": [
             "web-features:svg"
           ],
@@ -429,7 +429,7 @@
       "replaceItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStringList/replaceItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGStyleElement.json
+++ b/api/SVGStyleElement.json
@@ -3,7 +3,7 @@
     "SVGStyleElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement",
-        "spec_url": "https://svgwg.org/svg2-draft/styling.html#InterfaceSVGStyleElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#InterfaceSVGStyleElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "disabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/disabled",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__disabled",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#__svg__SVGStyleElement__disabled",
           "tags": [
             "web-features:svg"
           ],
@@ -85,7 +85,7 @@
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/media",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__media",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#__svg__SVGStyleElement__media",
           "tags": [
             "web-features:svg"
           ],
@@ -189,7 +189,7 @@
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/title",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__title",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#__svg__SVGStyleElement__title",
           "tags": [
             "web-features:svg"
           ],
@@ -237,7 +237,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGStyleElement/type",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#__svg__SVGStyleElement__type",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#__svg__SVGStyleElement__type",
           "tags": [
             "web-features:svg-discouraged"
           ],

--- a/api/SVGSwitchElement.json
+++ b/api/SVGSwitchElement.json
@@ -3,7 +3,7 @@
     "SVGSwitchElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSwitchElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGSwitchElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGSwitchElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGSymbolElement.json
+++ b/api/SVGSymbolElement.json
@@ -3,7 +3,7 @@
     "SVGSymbolElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSymbolElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGSymbolElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGSymbolElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSymbolElement/preserveAspectRatio",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "viewBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGSymbolElement/viewBox",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGTSpanElement.json
+++ b/api/SVGTSpanElement.json
@@ -3,7 +3,7 @@
     "SVGTSpanElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTSpanElement",
-        "spec_url": "https://svgwg.org/svg2-draft/text.html#InterfaceSVGTSpanElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#InterfaceSVGTSpanElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGTextContentElement.json
+++ b/api/SVGTextContentElement.json
@@ -3,7 +3,7 @@
     "SVGTextContentElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement",
-        "spec_url": "https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextContentElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#InterfaceSVGTextContentElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "getCharNumAtPosition": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getCharNumAtPosition",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getCharNumAtPosition",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getCharNumAtPosition",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "getComputedTextLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getComputedTextLength",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getComputedTextLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getComputedTextLength",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "getEndPositionOfChar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getEndPositionOfChar",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getEndPositionOfChar",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getEndPositionOfChar",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "getExtentOfChar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getExtentOfChar",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getExtentOfChar",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getExtentOfChar",
           "tags": [
             "web-features:svg"
           ],
@@ -242,7 +242,7 @@
       "getNumberOfChars": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getNumberOfChars",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getNumberOfChars",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getNumberOfChars",
           "tags": [
             "web-features:svg"
           ],
@@ -290,7 +290,7 @@
       "getRotationOfChar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getRotationOfChar",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getRotationOfChar",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getRotationOfChar",
           "tags": [
             "web-features:svg"
           ],
@@ -338,7 +338,7 @@
       "getStartPositionOfChar": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getStartPositionOfChar",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar",
           "tags": [
             "web-features:svg"
           ],
@@ -386,7 +386,7 @@
       "getSubStringLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/getSubStringLength",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getSubStringLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__getSubStringLength",
           "tags": [
             "web-features:svg"
           ],
@@ -434,7 +434,7 @@
       "lengthAdjust": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/lengthAdjust",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__lengthAdjust",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__lengthAdjust",
           "tags": [
             "web-features:svg"
           ],
@@ -481,7 +481,7 @@
       },
       "selectSubString": {
         "__compat": {
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__selectSubString",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__selectSubString",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -529,7 +529,7 @@
       "textLength": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextContentElement/textLength",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__textLength",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextContentElement__textLength",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGTextElement.json
+++ b/api/SVGTextElement.json
@@ -3,7 +3,7 @@
     "SVGTextElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextElement",
-        "spec_url": "https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#InterfaceSVGTextElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -3,7 +3,7 @@
     "SVGTextPathElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPathElement",
-        "spec_url": "https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextPathElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#InterfaceSVGTextPathElement",
         "tags": [
           "web-features:svg"
         ],
@@ -48,7 +48,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPathElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -94,7 +94,7 @@
       "method": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPathElement/method",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPathElement__method",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPathElement__method",
           "tags": [
             "web-features:svg"
           ],
@@ -140,7 +140,7 @@
       "spacing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPathElement/spacing",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPathElement__spacing",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPathElement__spacing",
           "tags": [
             "web-features:svg"
           ],
@@ -186,7 +186,7 @@
       "startOffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPathElement/startOffset",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPathElement__startOffset",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPathElement__startOffset",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGTextPositioningElement.json
+++ b/api/SVGTextPositioningElement.json
@@ -3,7 +3,7 @@
     "SVGTextPositioningElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPositioningElement",
-        "spec_url": "https://svgwg.org/svg2-draft/text.html#InterfaceSVGTextPositioningElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#InterfaceSVGTextPositioningElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "dx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPositioningElement/dx",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPositioningElement__dx",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPositioningElement__dx",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "dy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPositioningElement/dy",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPositioningElement__dy",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPositioningElement__dy",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "rotate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPositioningElement/rotate",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPositioningElement__rotate",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPositioningElement__rotate",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPositioningElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPositioningElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPositioningElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -242,7 +242,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPositioningElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#__svg__SVGTextPositioningElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#__svg__SVGTextPositioningElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGTitleElement.json
+++ b/api/SVGTitleElement.json
@@ -3,7 +3,7 @@
     "SVGTitleElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTitleElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGTitleElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGTitleElement",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGTransform.json
+++ b/api/SVGTransform.json
@@ -3,7 +3,7 @@
     "SVGTransform": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform",
-        "spec_url": "https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransform",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGTransform",
         "tags": [
           "web-features:svg"
         ],
@@ -46,7 +46,7 @@
       "angle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/angle",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__angle",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__angle",
           "tags": [
             "web-features:svg"
           ],
@@ -134,7 +134,7 @@
       "setMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/setMatrix",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__setMatrix",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__setMatrix",
           "tags": [
             "web-features:svg"
           ],
@@ -178,7 +178,7 @@
       "setRotate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/setRotate",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__setRotate",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__setRotate",
           "tags": [
             "web-features:svg"
           ],
@@ -222,7 +222,7 @@
       "setScale": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/setScale",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__setScale",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__setScale",
           "tags": [
             "web-features:svg"
           ],
@@ -266,7 +266,7 @@
       "setSkewX": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/setSkewX",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__setSkewX",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__setSkewX",
           "tags": [
             "web-features:svg"
           ],
@@ -310,7 +310,7 @@
       "setSkewY": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/setSkewY",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__setSkewY",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__setSkewY",
           "tags": [
             "web-features:svg"
           ],
@@ -354,7 +354,7 @@
       "setTranslate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/setTranslate",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__setTranslate",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__setTranslate",
           "tags": [
             "web-features:svg"
           ],
@@ -398,7 +398,7 @@
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransform/type",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransform__type",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransform__type",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGTransformList.json
+++ b/api/SVGTransformList.json
@@ -3,7 +3,7 @@
     "SVGTransformList": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList",
-        "spec_url": "https://svgwg.org/svg2-draft/coords.html#InterfaceSVGTransformList",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#InterfaceSVGTransformList",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "appendItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/appendItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__appendItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__appendItem",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/clear",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__clear",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__clear",
           "tags": [
             "web-features:svg"
           ],
@@ -146,7 +146,7 @@
       "consolidate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/consolidate",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransformList__consolidate",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransformList__consolidate",
           "tags": [
             "web-features:svg"
           ],
@@ -194,7 +194,7 @@
       "createSVGTransformFromMatrix": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/createSVGTransformFromMatrix",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#__svg__SVGTransformList__createSVGTransformFromMatrix",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#__svg__SVGTransformList__createSVGTransformFromMatrix",
           "tags": [
             "web-features:svg"
           ],
@@ -242,7 +242,7 @@
       "getItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/getItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__getItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__getItem",
           "tags": [
             "web-features:svg"
           ],
@@ -290,7 +290,7 @@
       "initialize": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/initialize",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__initialize",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__initialize",
           "tags": [
             "web-features:svg"
           ],
@@ -338,7 +338,7 @@
       "insertItemBefore": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/insertItemBefore",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__insertItemBefore",
           "tags": [
             "web-features:svg"
           ],
@@ -386,7 +386,7 @@
       "length": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/length",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__length",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__length",
           "tags": [
             "web-features:svg"
           ],
@@ -427,7 +427,7 @@
       "numberOfItems": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/numberOfItems",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__numberOfItems",
           "tags": [
             "web-features:svg"
           ],
@@ -475,7 +475,7 @@
       "removeItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/removeItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__removeItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__removeItem",
           "tags": [
             "web-features:svg"
           ],
@@ -523,7 +523,7 @@
       "replaceItem": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTransformList/replaceItem",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGNameList__replaceItem",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGUnitTypes.json
+++ b/api/SVGUnitTypes.json
@@ -3,7 +3,7 @@
     "SVGUnitTypes": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUnitTypes",
-        "spec_url": "https://svgwg.org/svg2-draft/types.html#InterfaceSVGUnitTypes",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#InterfaceSVGUnitTypes",
         "tags": [
           "web-features:svg"
         ],

--- a/api/SVGUseElement.json
+++ b/api/SVGUseElement.json
@@ -3,7 +3,7 @@
     "SVGUseElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement",
-        "spec_url": "https://svgwg.org/svg2-draft/struct.html#InterfaceSVGUseElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#InterfaceSVGUseElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement/height",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGUseElement__height",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGUseElement__height",
           "tags": [
             "web-features:svg"
           ],
@@ -96,7 +96,7 @@
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement/href",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGURIReference__href",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGURIReference__href",
           "tags": [
             "web-features:svg"
           ],
@@ -144,7 +144,7 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement/width",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGUseElement__width",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGUseElement__width",
           "tags": [
             "web-features:svg"
           ],
@@ -190,7 +190,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement/x",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGUseElement__x",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGUseElement__x",
           "tags": [
             "web-features:svg"
           ],
@@ -236,7 +236,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGUseElement/y",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#__svg__SVGUseElement__y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#__svg__SVGUseElement__y",
           "tags": [
             "web-features:svg"
           ],

--- a/api/SVGViewElement.json
+++ b/api/SVGViewElement.json
@@ -3,7 +3,7 @@
     "SVGViewElement": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGViewElement",
-        "spec_url": "https://svgwg.org/svg2-draft/linking.html#InterfaceSVGViewElement",
+        "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGViewElement",
         "tags": [
           "web-features:svg"
         ],
@@ -50,7 +50,7 @@
       "preserveAspectRatio": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGViewElement/preserveAspectRatio",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__preserveAspectRatio",
           "tags": [
             "web-features:svg"
           ],
@@ -98,7 +98,7 @@
       "viewBox": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGViewElement/viewBox",
-          "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGFitToViewBox__viewBox",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/alignment-baseline",
           "spec_url": [
             "https://drafts.csswg.org/css-inline/#alignment-baseline-property",
-            "https://svgwg.org/svg2-draft/text.html#AlignmentBaselineProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#AlignmentBaselineProperty"
           ],
           "tags": [
             "web-features:alignment-baseline"

--- a/css/properties/baseline-shift.json
+++ b/css/properties/baseline-shift.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/baseline-shift",
           "spec_url": [
             "https://drafts.csswg.org/css-inline/#baseline-shift-property",
-            "https://svgwg.org/svg2-draft/text.html#BaselineShiftProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#BaselineShiftProperty"
           ],
           "tags": [
             "web-features:baseline-shift"

--- a/css/properties/color-interpolation.json
+++ b/css/properties/color-interpolation.json
@@ -4,7 +4,7 @@
       "color-interpolation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/color-interpolation",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -38,7 +38,7 @@
         "auto": {
           "__compat": {
             "description": "`auto` value",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty:~:text=auto,-%7C%20sRGB",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty:~:text=auto,-%7C%20sRGB",
             "tags": [
               "web-features:svg"
             ],
@@ -107,7 +107,7 @@
         "linearRGB": {
           "__compat": {
             "description": "`linearRGB` value",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty:~:text=linearRGB",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty:~:text=linearRGB",
             "support": {
               "chrome": {
                 "version_added": "≤31"
@@ -139,7 +139,7 @@
         "sRGB": {
           "__compat": {
             "description": "`sRGB` value",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty:~:text=sRGB",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty:~:text=sRGB",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/color",
           "spec_url": [
             "https://drafts.csswg.org/css-color/#the-color-property",
-            "https://svgwg.org/svg2-draft/painting.html#ColorProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorProperty"
           ],
           "tags": [
             "web-features:color"

--- a/css/properties/cx.json
+++ b/css/properties/cx.json
@@ -4,7 +4,7 @@
       "cx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/cx",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#CX",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#CX",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/cy.json
+++ b/css/properties/cy.json
@@ -4,7 +4,7 @@
       "cy": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/cy",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#CY",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#CY",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/d.json
+++ b/css/properties/d.json
@@ -4,7 +4,7 @@
       "d": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/d",
-          "spec_url": "https://svgwg.org/svg2-draft/paths.html#TheDProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -38,7 +38,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/paths.html#TheDProperty:~:text=Value%3A-,none,-%7C%20%3Cstring%3E",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#TheDProperty:~:text=Value%3A-,none,-%7C%20%3Cstring%3E",
             "support": {
               "chrome": {
                 "version_added": "52"

--- a/css/properties/direction.json
+++ b/css/properties/direction.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/direction",
           "spec_url": [
             "https://drafts.csswg.org/css-writing-modes/#direction",
-            "https://svgwg.org/svg2-draft/text.html#DirectionProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#DirectionProperty"
           ],
           "tags": [
             "web-features:layout-direction-override"

--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/display",
           "spec_url": [
             "https://drafts.csswg.org/css-display/#the-display-properties",
-            "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#VisibilityControl"
           ],
           "tags": [
             "web-features:display"

--- a/css/properties/dominant-baseline.json
+++ b/css/properties/dominant-baseline.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/dominant-baseline",
           "spec_url": [
             "https://drafts.csswg.org/css-inline/#dominant-baseline-property",
-            "https://svgwg.org/svg2-draft/text.html#DominantBaselineProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty"
           ],
           "tags": [
             "web-features:dominant-baseline"

--- a/css/properties/fill.json
+++ b/css/properties/fill.json
@@ -4,7 +4,7 @@
       "fill": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/fill",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#FillProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#FillProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint:~:text=none",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint:~:text=none",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/font-variant.json
+++ b/css/properties/font-variant.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-variant",
           "spec_url": [
             "https://drafts.csswg.org/css-fonts/#font-variant-prop",
-            "https://svgwg.org/svg2-draft/text.html#FontVariantProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#FontVariantProperty"
           ],
           "tags": [
             "web-features:font-variant"

--- a/css/properties/image-rendering.json
+++ b/css/properties/image-rendering.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/image-rendering",
           "spec_url": [
             "https://drafts.csswg.org/css-images/#the-image-rendering",
-            "https://svgwg.org/svg2-draft/painting.html#ImageRendering"
+            "https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRendering"
           ],
           "tags": [
             "web-features:image-rendering"

--- a/css/properties/letter-spacing.json
+++ b/css/properties/letter-spacing.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/letter-spacing",
           "spec_url": [
             "https://drafts.csswg.org/css-text/#letter-spacing-property",
-            "https://svgwg.org/svg2-draft/text.html#LetterSpacingProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#LetterSpacingProperty"
           ],
           "tags": [
             "web-features:letter-spacing"

--- a/css/properties/marker-end.json
+++ b/css/properties/marker-end.json
@@ -4,7 +4,7 @@
       "marker-end": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker-end",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerEndProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty:~:text=none,-%7C%20%3Cmarker",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerEndProperty:~:text=none,-%7C%20%3Cmarker",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/marker-mid.json
+++ b/css/properties/marker-mid.json
@@ -4,7 +4,7 @@
       "marker-mid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker-mid",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerMidProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty:~:text=none,-%7C%20%3Cmarker",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerMidProperty:~:text=none,-%7C%20%3Cmarker",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/marker-start.json
+++ b/css/properties/marker-start.json
@@ -4,7 +4,7 @@
       "marker-start": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker-start",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerStartProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty:~:text=none,-%7C%20%3Cmarker",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerStartProperty:~:text=none,-%7C%20%3Cmarker",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/marker.json
+++ b/css/properties/marker.json
@@ -4,7 +4,7 @@
       "marker": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/marker",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerShorthand",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerShorthand",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerProperty:~:text=marker-,Value",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerProperty:~:text=marker-,Value",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/opacity.json
+++ b/css/properties/opacity.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/opacity",
           "spec_url": [
             "https://drafts.csswg.org/css-color/#propdef-opacity",
-            "https://svgwg.org/svg2-draft/render.html#ObjectAndGroupOpacityProperties"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#ObjectAndGroupOpacityProperties"
           ],
           "tags": [
             "web-features:opacity"

--- a/css/properties/overflow.json
+++ b/css/properties/overflow.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/overflow",
           "spec_url": [
             "https://drafts.csswg.org/css-overflow/#propdef-overflow",
-            "https://svgwg.org/svg2-draft/render.html#OverflowAndClipProperties"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties"
           ],
           "tags": [
             "web-features:overflow-shorthand"

--- a/css/properties/paint-order.json
+++ b/css/properties/paint-order.json
@@ -4,7 +4,7 @@
       "paint-order": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/paint-order",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty",
           "tags": [
             "web-features:paint-order"
           ],
@@ -53,7 +53,7 @@
         },
         "fill": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty:~:text=normal%20%7C%20%5B-,fill,-%7C%7C%20stroke%20%7C%7C%20markers%20%5D",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty:~:text=normal%20%7C%20%5B-,fill,-%7C%7C%20stroke%20%7C%7C%20markers%20%5D",
             "support": {
               "chrome": {
                 "version_added": "35"
@@ -84,7 +84,7 @@
         },
         "markers": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty:~:text=normal%20%7C%20%5B%20fill%20%7C%7C%20stroke%20%7C%7C-,markers,-%5D",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty:~:text=normal%20%7C%20%5B%20fill%20%7C%7C%20stroke%20%7C%7C-,markers,-%5D",
             "support": {
               "chrome": {
                 "version_added": "35"
@@ -115,7 +115,7 @@
         },
         "normal": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty:~:text=Value%3A-,normal,-%7C%20%5B%20fill%20%7C%7C%20stroke%20%7C%7C%20markers",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty:~:text=Value%3A-,normal,-%7C%20%5B%20fill%20%7C%7C%20stroke%20%7C%7C%20markers",
             "support": {
               "chrome": {
                 "version_added": "35"
@@ -146,7 +146,7 @@
         },
         "stroke": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty:~:text=normal%20%7C%20%5B%20fill%20%7C%7C-,stroke,-%7C%7C%20markers%20%5D",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty:~:text=normal%20%7C%20%5B%20fill%20%7C%7C-,stroke,-%7C%7C%20markers%20%5D",
             "support": {
               "chrome": {
                 "version_added": "35"

--- a/css/properties/pointer-events.json
+++ b/css/properties/pointer-events.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/pointer-events",
           "spec_url": [
             "https://drafts.csswg.org/css-ui/#pointer-events-control",
-            "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty"
           ],
           "tags": [
             "web-features:pointer-events"
@@ -49,7 +49,7 @@
         },
         "all": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=all,-The%20given",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=all,-The%20given",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -82,7 +82,7 @@
         },
         "auto": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=auto,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=auto,-The",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -115,7 +115,7 @@
         },
         "bounding-box": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=bounding%2Dbox,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=bounding%2Dbox,-The",
             "support": {
               "chrome": {
                 "version_added": "33"
@@ -146,7 +146,7 @@
         },
         "fill": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=fill,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=fill,-The",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -220,7 +220,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=none,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=none,-The",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -253,7 +253,7 @@
         },
         "painted": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=painted,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=painted,-The",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -286,7 +286,7 @@
         },
         "stroke": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=stroke,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=stroke,-The",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -319,7 +319,7 @@
         },
         "visible": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=affect%20event%20processing.-,visible,-The%20given%20element",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=affect%20event%20processing.-,visible,-The%20given%20element",
             "support": {
               "chrome": {
                 "version_added": "1"
@@ -352,7 +352,7 @@
         },
         "visibleFill": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=visibleFill,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=visibleFill,-The",
             "support": {
               "chrome": {
                 "version_added": "≤31"
@@ -385,7 +385,7 @@
         },
         "visiblePainted": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=visiblePainted,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=visiblePainted,-The",
             "support": {
               "chrome": {
                 "version_added": "≤31"
@@ -418,7 +418,7 @@
         },
         "visibleStroke": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty:~:text=visibleStroke,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty:~:text=visibleStroke,-The",
             "support": {
               "chrome": {
                 "version_added": "≤31"

--- a/css/properties/r.json
+++ b/css/properties/r.json
@@ -4,7 +4,7 @@
       "r": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/r",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#R",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#R",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/rx.json
+++ b/css/properties/rx.json
@@ -4,7 +4,7 @@
       "rx": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/rx",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#RX",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX",
           "tags": [
             "web-features:svg"
           ],
@@ -38,7 +38,7 @@
         },
         "auto": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#RX:~:text=rx-,Value%3A,%3Clength%2Dpercentage%3E%20%7C%20auto,-Initial%3A",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#RX:~:text=rx-,Value%3A,%3Clength%2Dpercentage%3E%20%7C%20auto,-Initial%3A",
             "support": {
               "chrome": {
                 "version_added": "53"

--- a/css/properties/ry.json
+++ b/css/properties/ry.json
@@ -4,7 +4,7 @@
       "ry": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/ry",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#RY",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY",
           "tags": [
             "web-features:svg"
           ],
@@ -38,7 +38,7 @@
         },
         "auto": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#RY:~:text=ry-,Value%3A,%3Clength%2Dpercentage%3E%20%7C%20auto,-Initial%3A",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#RY:~:text=ry-,Value%3A,%3Clength%2Dpercentage%3E%20%7C%20auto,-Initial%3A",
             "support": {
               "chrome": {
                 "version_added": "53"

--- a/css/properties/shape-rendering.json
+++ b/css/properties/shape-rendering.json
@@ -4,7 +4,7 @@
       "shape-rendering": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/shape-rendering",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRendering",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRendering",
           "tags": [
             "web-features:svg"
           ],
@@ -37,7 +37,7 @@
         },
         "auto": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty:~:text=auto,-%7C%20optimizeSpeed",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty:~:text=auto,-%7C%20optimizeSpeed",
             "tags": [
               "web-features:svg"
             ],
@@ -71,7 +71,7 @@
         },
         "crispEdges": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty:~:text=crispEdges",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty:~:text=crispEdges",
             "support": {
               "chrome": {
                 "version_added": "≤31"
@@ -102,7 +102,7 @@
         },
         "geometricPrecision": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty:~:text=geometricPrecision",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty:~:text=geometricPrecision",
             "support": {
               "chrome": {
                 "version_added": "≤31"
@@ -133,7 +133,7 @@
         },
         "optimizeSpeed": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRenderingProperty:~:text=optimizeSpeed",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRenderingProperty:~:text=optimizeSpeed",
             "support": {
               "chrome": {
                 "version_added": "≤31"

--- a/css/properties/stop-color.json
+++ b/css/properties/stop-color.json
@@ -4,7 +4,7 @@
       "stop-color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stop-color",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/stop-opacity.json
+++ b/css/properties/stop-opacity.json
@@ -4,7 +4,7 @@
       "stop-opacity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stop-opacity",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/stroke.json
+++ b/css/properties/stroke.json
@@ -4,7 +4,7 @@
       "stroke": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/stroke",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint:~:text=none,-No",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint:~:text=none,-No",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/text-anchor.json
+++ b/css/properties/text-anchor.json
@@ -4,7 +4,7 @@
       "text-anchor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-anchor",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "end": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty:~:text=end,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty:~:text=end,-The",
             "tags": [
               "web-features:svg"
             ],
@@ -75,7 +75,7 @@
         },
         "middle": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty:~:text=middle,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty:~:text=middle,-The",
             "tags": [
               "web-features:svg"
             ],
@@ -111,7 +111,7 @@
         },
         "start": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty:~:text=start,-The",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty:~:text=start,-The",
             "tags": [
               "web-features:svg"
             ],

--- a/css/properties/text-decoration.json
+++ b/css/properties/text-decoration.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration",
           "spec_url": [
             "https://drafts.csswg.org/css-text-decor-4/#text-decoration-property",
-            "https://svgwg.org/svg2-draft/text.html#TextDecorationProperties"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#TextDecorationProperties"
           ],
           "tags": [
             "web-features:text-decoration"

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-overflow",
           "spec_url": [
             "https://drafts.csswg.org/css-overflow/#text-overflow",
-            "https://svgwg.org/svg2-draft/text.html#TextOverflowProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#TextOverflowProperty"
           ],
           "tags": [
             "web-features:text-overflow"

--- a/css/properties/text-rendering.json
+++ b/css/properties/text-rendering.json
@@ -4,7 +4,7 @@
       "text-rendering": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-rendering",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -134,7 +134,7 @@
         },
         "optimizeLegibility": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty:~:text=optimizeLegibility",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty:~:text=optimizeLegibility",
             "support": {
               "chrome": {
                 "version_added": "≤31"
@@ -165,7 +165,7 @@
         },
         "optimizeSpeed": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty:~:text=optimizeSpeed,-%7C%20optimizeLegibility",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty:~:text=optimizeSpeed,-%7C%20optimizeLegibility",
             "support": {
               "chrome": {
                 "version_added": "≤31"

--- a/css/properties/transform.json
+++ b/css/properties/transform.json
@@ -7,7 +7,7 @@
           "spec_url": [
             "https://drafts.csswg.org/css-transforms-2/#transform-functions",
             "https://drafts.csswg.org/css-transforms/#transform-property",
-            "https://svgwg.org/svg2-draft/coords.html#TransformProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/coords.html#TransformProperty"
           ],
           "tags": [
             "web-features:transforms2d"

--- a/css/properties/vector-effect.json
+++ b/css/properties/vector-effect.json
@@ -4,7 +4,7 @@
       "vector-effect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/vector-effect",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffectProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -37,7 +37,7 @@
         },
         "non-scaling-stroke": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty:~:text=non%2Dscaling%2Dstroke,-%7C%20non",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffectProperty:~:text=non%2Dscaling%2Dstroke,-%7C%20non",
             "support": {
               "chrome": {
                 "version_added": "6"
@@ -68,7 +68,7 @@
         },
         "none": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty:~:text=none,-%7C%20non",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffectProperty:~:text=none,-%7C%20non",
             "support": {
               "chrome": {
                 "version_added": "6"

--- a/css/properties/visibility.json
+++ b/css/properties/visibility.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/visibility",
           "spec_url": [
             "https://drafts.csswg.org/css-display/#visibility",
-            "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#VisibilityControl"
           ],
           "tags": [
             "web-features:visibility"

--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/white-space",
           "spec_url": [
             "https://drafts.csswg.org/css-text-4/#white-space-property",
-            "https://svgwg.org/svg2-draft/text.html#TextWhiteSpace"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#TextWhiteSpace"
           ],
           "tags": [
             "web-features:white-space"

--- a/css/properties/word-spacing.json
+++ b/css/properties/word-spacing.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/word-spacing",
           "spec_url": [
             "https://drafts.csswg.org/css-text/#word-spacing-property",
-            "https://svgwg.org/svg2-draft/text.html#WordSpacingProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#WordSpacingProperty"
           ],
           "tags": [
             "web-features:word-spacing"

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/writing-mode",
           "spec_url": [
             "https://drafts.csswg.org/css-writing-modes/#block-flow",
-            "https://svgwg.org/svg2-draft/text.html#WritingModeProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#WritingModeProperty"
           ],
           "tags": [
             "web-features:writing-mode"

--- a/css/properties/x.json
+++ b/css/properties/x.json
@@ -4,7 +4,7 @@
       "x": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/x",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#X",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#X",
           "tags": [
             "web-features:svg"
           ],

--- a/css/properties/y.json
+++ b/css/properties/y.json
@@ -4,7 +4,7 @@
       "y": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/y",
-          "spec_url": "https://svgwg.org/svg2-draft/geometry.html#Y",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#Y",
           "tags": [
             "web-features:svg"
           ],

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -284,7 +284,7 @@
             "__compat": {
               "description": "In `d` as CSS property",
               "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/d",
-              "spec_url": "https://svgwg.org/svg2-draft/paths.html#DProperty",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#DProperty",
               "tags": [
                 "web-features:path-shape"
               ],

--- a/mediatypes/image/svg.json
+++ b/mediatypes/image/svg.json
@@ -5,7 +5,7 @@
         "__compat": {
           "description": "Scalable Vector Graphics (SVG)",
           "mdn_url": "https://developer.mozilla.org/docs/Web/Media/Guides/Formats/Image_types#svg_scalable_vector_graphics",
-          "spec_url": "https://svgwg.org/svg2-draft/intro.html#AboutSVG",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/intro.html#AboutSVG",
           "support": {
             "chrome": {
               "version_added": "1"

--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -4,7 +4,7 @@
       "a": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/a",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElement",
           "tags": [
             "web-features:svg"
           ],
@@ -46,7 +46,7 @@
         },
         "download": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementDownloadAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementDownloadAttribute",
             "tags": [
               "web-features:download"
             ],
@@ -81,7 +81,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -120,7 +120,7 @@
         },
         "hreflang": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementHreflangAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementHreflangAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -190,7 +190,7 @@
         },
         "ping": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementPingAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementPingAttribute",
             "tags": [
               "web-features:ping"
             ],
@@ -226,7 +226,7 @@
         },
         "referrerpolicy": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementReferrerpolicyAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementReferrerpolicyAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -373,7 +373,7 @@
         },
         "rel": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementRelAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementRelAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -411,7 +411,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],
@@ -455,7 +455,7 @@
         "target": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/target",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementTargetAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementTargetAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -498,7 +498,7 @@
         },
         "type": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#AElementTypeAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#AElementTypeAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -571,7 +571,7 @@
           "__compat": {
             "description": "`xlink:href`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/xlink:href",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkHrefAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],
@@ -651,7 +651,7 @@
           "__compat": {
             "description": "`xlink:title`",
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/xlink:title",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkTitleAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkTitleAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],

--- a/svg/elements/animate.json
+++ b/svg/elements/animate.json
@@ -286,7 +286,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:smil-svg-animations"
             ],

--- a/svg/elements/animateMotion.json
+++ b/svg/elements/animateMotion.json
@@ -280,7 +280,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:smil-svg-animations"
             ],

--- a/svg/elements/animateTransform.json
+++ b/svg/elements/animateTransform.json
@@ -184,7 +184,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:smil-svg-animations"
             ],

--- a/svg/elements/circle.json
+++ b/svg/elements/circle.json
@@ -4,7 +4,7 @@
       "circle": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/circle",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#CircleElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#CircleElement",
           "tags": [
             "web-features:svg"
           ],
@@ -125,7 +125,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -162,7 +162,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -237,7 +237,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/clipPath.json
+++ b/svg/elements/clipPath.json
@@ -89,7 +89,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:clip-path"
             ],

--- a/svg/elements/defs.json
+++ b/svg/elements/defs.json
@@ -4,7 +4,7 @@
       "defs": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/defs",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#Head",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#Head",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/desc.json
+++ b/svg/elements/desc.json
@@ -4,7 +4,7 @@
       "desc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/desc",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#DescriptionAndTitleElements",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#DescriptionAndTitleElements",
           "tags": [
             "web-features:svg"
           ],

--- a/svg/elements/ellipse.json
+++ b/svg/elements/ellipse.json
@@ -4,7 +4,7 @@
       "ellipse": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/ellipse",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#EllipseElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#EllipseElement",
           "tags": [
             "web-features:svg"
           ],
@@ -139,7 +139,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -178,7 +178,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -304,7 +304,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/foreignObject.json
+++ b/svg/elements/foreignObject.json
@@ -4,7 +4,7 @@
       "foreignObject": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/foreignObject",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ForeignObjectElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#ForeignObjectElement",
           "tags": [
             "web-features:svg"
           ],
@@ -47,7 +47,7 @@
         },
         "height": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#Sizing",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing",
             "tags": [
               "web-features:svg"
             ],
@@ -92,7 +92,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],
@@ -136,7 +136,7 @@
         },
         "width": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#Sizing",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing",
             "tags": [
               "web-features:svg"
             ],
@@ -180,7 +180,7 @@
         },
         "x": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#XProperty",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#XProperty",
             "tags": [
               "web-features:svg"
             ],
@@ -224,7 +224,7 @@
         },
         "y": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#YProperty",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#YProperty",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/g.json
+++ b/svg/elements/g.json
@@ -4,7 +4,7 @@
       "g": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/g",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#GElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#GElement",
           "tags": [
             "web-features:svg"
           ],
@@ -47,7 +47,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/image.json
+++ b/svg/elements/image.json
@@ -4,7 +4,7 @@
       "image": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/image",
-          "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ImageElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#ImageElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "crossorigin": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/crossorigin",
-            "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ImageElementCrossoriginAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#ImageElementCrossoriginAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -152,7 +152,7 @@
         },
         "height": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#Sizing",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing",
             "tags": [
               "web-features:svg"
             ],
@@ -187,7 +187,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/embedded.html#ImageElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/embedded.html#ImageElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -226,7 +226,7 @@
         },
         "preserveAspectRatio": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/coords.html#PreserveAspectRatioAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#PreserveAspectRatioAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -261,7 +261,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],
@@ -306,7 +306,7 @@
         },
         "width": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#Sizing",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#Sizing",
             "tags": [
               "web-features:svg"
             ],
@@ -340,7 +340,7 @@
         },
         "x": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#XProperty",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#XProperty",
             "tags": [
               "web-features:svg"
             ],
@@ -375,7 +375,7 @@
         "xlink_href": {
           "__compat": {
             "description": "`xlink:href`",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkHrefAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],
@@ -409,7 +409,7 @@
         },
         "y": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/geometry.html#YProperty",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/geometry.html#YProperty",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/line.json
+++ b/svg/elements/line.json
@@ -4,7 +4,7 @@
       "line": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/line",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#LineElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#LineElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/linearGradient.json
+++ b/svg/elements/linearGradient.json
@@ -4,7 +4,7 @@
       "linearGradient": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/linearGradient",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "gradientTransform": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/gradientTransform",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementGradientTransformAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -84,7 +84,7 @@
         "gradientUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/gradientUnits",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementGradientUnitsAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementGradientUnitsAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -119,7 +119,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -159,7 +159,7 @@
         "spreadMethod": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/spreadMethod",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementSpreadMethodAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementSpreadMethodAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -194,7 +194,7 @@
         "x1": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/x1",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX1Attribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementX1Attribute",
             "tags": [
               "web-features:svg"
             ],
@@ -229,7 +229,7 @@
         "x2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/x2",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementX2Attribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementX2Attribute",
             "tags": [
               "web-features:svg"
             ],
@@ -264,7 +264,7 @@
         "xlink_href": {
           "__compat": {
             "description": "`xlink:href`",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkHrefAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],
@@ -299,7 +299,7 @@
         "y1": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/y1",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY1Attribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementY1Attribute",
             "tags": [
               "web-features:svg"
             ],
@@ -334,7 +334,7 @@
         "y2": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/y2",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#LinearGradientElementY2Attribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#LinearGradientElementY2Attribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/marker.json
+++ b/svg/elements/marker.json
@@ -4,7 +4,7 @@
       "marker": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/marker",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerElement",
           "tags": [
             "web-features:svg"
           ],
@@ -47,7 +47,7 @@
         "markerHeight": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/markerHeight",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerHeightAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerHeightAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -87,7 +87,7 @@
         "markerUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/markerUnits",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerUnitsAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerUnitsAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -127,7 +127,7 @@
         "markerWidth": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/markerWidth",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerWidthAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerWidthAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -167,7 +167,7 @@
         "orient": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/orient",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#OrientAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#OrientAttribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/mask.json
+++ b/svg/elements/mask.json
@@ -151,7 +151,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/metadata.json
+++ b/svg/elements/metadata.json
@@ -4,7 +4,7 @@
       "metadata": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/metadata",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#MetadataElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#MetadataElement",
           "tags": [
             "web-features:svg"
           ],

--- a/svg/elements/path.json
+++ b/svg/elements/path.json
@@ -4,7 +4,7 @@
       "path": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/path",
-          "spec_url": "https://svgwg.org/svg2-draft/paths.html#PathElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#PathElement",
           "tags": [
             "web-features:svg"
           ],
@@ -50,7 +50,7 @@
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/d",
             "spec_url": [
-              "https://svgwg.org/svg2-draft/paths.html#DProperty",
+              "https://w3c.github.io/svgwg/svg2-draft/paths.html#DProperty",
               "https://www.w3.org/TR/SVG11/fonts.html#GlyphElementDAttribute",
               "https://www.w3.org/TR/SVG11/paths.html#DAttribute"
             ],
@@ -139,7 +139,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -178,7 +178,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -214,7 +214,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/pattern.json
+++ b/svg/elements/pattern.json
@@ -4,7 +4,7 @@
       "pattern": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/pattern",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElement",
           "tags": [
             "web-features:svg"
           ],
@@ -44,7 +44,7 @@
         },
         "height": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementHeightAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementHeightAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -86,7 +86,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -124,7 +124,7 @@
         "patternContentUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/patternContentUnits",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementPatternContentUnitsAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -161,7 +161,7 @@
         "patternTransform": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/patternTransform",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternTransformAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementPatternTransformAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -198,7 +198,7 @@
         "patternUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/patternUnits",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementPatternUnitsAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementPatternUnitsAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -235,7 +235,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],
@@ -276,7 +276,7 @@
         },
         "width": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementWidthAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementWidthAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -317,7 +317,7 @@
         },
         "x": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementXAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementXAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -359,7 +359,7 @@
         "xlink_href": {
           "__compat": {
             "description": "`xlink:href`",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkHrefAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],
@@ -400,7 +400,7 @@
         },
         "y": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#PatternElementYAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#PatternElementYAttribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/polygon.json
+++ b/svg/elements/polygon.json
@@ -4,7 +4,7 @@
       "polygon": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/polygon",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#PolygonElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolygonElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -88,7 +88,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -168,7 +168,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/polyline.json
+++ b/svg/elements/polyline.json
@@ -4,7 +4,7 @@
       "polyline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/polyline",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#PolylineElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#PolylineElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -88,7 +88,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -168,7 +168,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/radialGradient.json
+++ b/svg/elements/radialGradient.json
@@ -4,7 +4,7 @@
       "radialGradient": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/radialGradient",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "cx": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/cx",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCXAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementCXAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -84,7 +84,7 @@
         "cy": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/cy",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementCYAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementCYAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -119,7 +119,7 @@
         "fr": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fr",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFRAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementFRAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -154,7 +154,7 @@
         "fx": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fx",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFXAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementFXAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -189,7 +189,7 @@
         "fy": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fy",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementFYAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementFYAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -224,7 +224,7 @@
         "gradientTransform": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/gradientTransform",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientTransformAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementGradientTransformAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -259,7 +259,7 @@
         "gradientUnits": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/gradientUnits",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementGradientUnitsAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementGradientUnitsAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -294,7 +294,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -334,7 +334,7 @@
         "r": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/r",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementRAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementRAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -369,7 +369,7 @@
         "spreadMethod": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/spreadMethod",
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#RadialGradientElementSpreadMethodAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#RadialGradientElementSpreadMethodAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -404,7 +404,7 @@
         "xlink_href": {
           "__compat": {
             "description": "`xlink:href`",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkHrefAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],

--- a/svg/elements/rect.json
+++ b/svg/elements/rect.json
@@ -4,7 +4,7 @@
       "rect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/rect",
-          "spec_url": "https://svgwg.org/svg2-draft/shapes.html#RectElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/shapes.html#RectElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -86,7 +86,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -254,7 +254,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/script.json
+++ b/svg/elements/script.json
@@ -4,7 +4,7 @@
       "script": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/script",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#ScriptElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElement",
           "tags": [
             "web-features:svg"
           ],
@@ -149,7 +149,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#ScriptElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -188,7 +188,7 @@
         },
         "type": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/interact.html#ScriptElementTypeAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#ScriptElementTypeAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -257,7 +257,7 @@
         "xlink_href": {
           "__compat": {
             "description": "xlink:href",
-            "spec_url": "https://svgwg.org/svg2-draft/linking.html#XLinkHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#XLinkHrefAttribute",
             "tags": [
               "web-features:svg-discouraged"
             ],

--- a/svg/elements/set.json
+++ b/svg/elements/set.json
@@ -118,7 +118,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/stop.json
+++ b/svg/elements/stop.json
@@ -4,7 +4,7 @@
       "stop": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/stop",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopElement",
           "tags": [
             "web-features:svg"
           ],
@@ -50,7 +50,7 @@
         },
         "offset": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopElementOffsetAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopElementOffsetAttribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/style.json
+++ b/svg/elements/style.json
@@ -4,7 +4,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/style",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#StyleElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#StyleElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "media": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/media",
-            "spec_url": "https://svgwg.org/svg2-draft/styling.html#StyleElementMediaAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#StyleElementMediaAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -83,7 +83,7 @@
         },
         "title": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/styling.html#StyleElementTitleAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#StyleElementTitleAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -117,7 +117,7 @@
         },
         "type": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/styling.html#StyleElementTypeAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#StyleElementTypeAttribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/svg.json
+++ b/svg/elements/svg.json
@@ -4,7 +4,7 @@
       "svg": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/svg",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#NewDocument",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#NewDocument",
           "tags": [
             "web-features:svg"
           ],
@@ -177,7 +177,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/switch.json
+++ b/svg/elements/switch.json
@@ -4,7 +4,7 @@
       "switch": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/switch",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#SwitchElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#SwitchElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/symbol.json
+++ b/svg/elements/symbol.json
@@ -4,7 +4,7 @@
       "symbol": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/symbol",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#SymbolElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#SymbolElement",
           "tags": [
             "web-features:svg"
           ],

--- a/svg/elements/text.json
+++ b/svg/elements/text.json
@@ -4,7 +4,7 @@
       "text": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/text",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElement",
           "tags": [
             "web-features:svg"
           ],
@@ -49,7 +49,7 @@
         "dx": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/dx",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementDXAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementDXAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -89,7 +89,7 @@
         "dy": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/dy",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementDYAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementDYAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -129,7 +129,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -166,7 +166,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -202,7 +202,7 @@
         "lengthAdjust": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/lengthAdjust",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementLengthAdjustAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementLengthAdjustAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -282,7 +282,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],
@@ -328,7 +328,7 @@
         "textLength": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/textLength",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementTextLengthAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementTextLengthAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -368,7 +368,7 @@
         "x": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/x",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementXAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementXAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -408,7 +408,7 @@
         "y": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/y",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElementYAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElementYAttribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/textPath.json
+++ b/svg/elements/textPath.json
@@ -4,7 +4,7 @@
       "textPath": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/textPath",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElement",
           "tags": [
             "web-features:svg"
           ],
@@ -44,7 +44,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -81,7 +81,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -117,7 +117,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -192,7 +192,7 @@
         "side": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/side",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementSideAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSideAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -227,7 +227,7 @@
         "spacing": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/spacing",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementSpacingAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementSpacingAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -262,7 +262,7 @@
         "startOffset": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/startOffset",
-            "spec_url": "https://svgwg.org/svg2-draft/text.html#TextPathElementStartOffsetAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextPathElementStartOffsetAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -302,7 +302,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/title.json
+++ b/svg/elements/title.json
@@ -4,7 +4,7 @@
       "title": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/title",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#TitleElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#TitleElement",
           "tags": [
             "web-features:svg"
           ],

--- a/svg/elements/tspan.json
+++ b/svg/elements/tspan.json
@@ -4,7 +4,7 @@
       "tspan": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/tspan",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#TextElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextElement",
           "tags": [
             "web-features:svg"
           ],
@@ -123,7 +123,7 @@
         "fill": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingFillPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingFillPaint",
             "tags": [
               "web-features:svg"
             ],
@@ -160,7 +160,7 @@
           "context-fill": {
             "__compat": {
               "description": "`context-fill` value",
-              "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+              "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
               "tags": [
                 "web-features:context-fill-stroke"
               ],
@@ -264,7 +264,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/use.json
+++ b/svg/elements/use.json
@@ -4,7 +4,7 @@
       "use": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/use",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#UseElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElement",
           "tags": [
             "web-features:svg"
           ],
@@ -172,7 +172,7 @@
         "href": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/href",
-            "spec_url": "https://svgwg.org/svg2-draft/struct.html#UseElementHrefAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#UseElementHrefAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -212,7 +212,7 @@
         "omit_external_fragment": {
           "__compat": {
             "description": "Reference an external document's root element by omitting the fragment.",
-            "spec_url": "https://svgwg.org/svg2-draft/struct.html#:~:text=Allow%20%E2%80%98use%E2%80%99%20to%20reference%20an%20external%20document's%20root%20element%20by%20omitting%20the%20fragment.",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#:~:text=Allow%20%E2%80%98use%E2%80%99%20to%20reference%20an%20external%20document's%20root%20element%20by%20omitting%20the%20fragment.",
             "tags": [
               "web-features:svg"
             ],
@@ -247,7 +247,7 @@
         "systemLanguage": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/systemLanguage",
-            "spec_url": "https://svgwg.org/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGTests__systemLanguage",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/elements/view.json
+++ b/svg/elements/view.json
@@ -4,7 +4,7 @@
       "view": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Element/view",
-          "spec_url": "https://svgwg.org/svg2-draft/linking.html#ViewElement",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#ViewElement",
           "tags": [
             "web-features:svg"
           ],
@@ -39,7 +39,7 @@
         },
         "preserveAspectRatio": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/coords.html#PreserveAspectRatioAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#PreserveAspectRatioAttribute",
             "tags": [
               "web-features:svg"
             ],
@@ -73,7 +73,7 @@
         },
         "viewBox": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#ViewBoxAttribute",
             "tags": [
               "web-features:svg"
             ],

--- a/svg/global_attributes.json
+++ b/svg/global_attributes.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/alignment-baseline",
           "spec_url": [
             "https://drafts.csswg.org/css-inline/#alignment-baseline-property",
-            "https://svgwg.org/svg2-draft/text.html#AlignmentBaselineProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#AlignmentBaselineProperty"
           ],
           "tags": [
             "web-features:svg"
@@ -42,7 +42,7 @@
       "autofocus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/autofocus",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#autofocusattribute",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#autofocusattribute",
           "tags": [
             "web-features:autofocus"
           ],
@@ -87,7 +87,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/baseline-shift",
           "spec_url": [
             "https://drafts.csswg.org/css-inline/#baseline-shift-property",
-            "https://svgwg.org/svg2-draft/text.html#BaselineShiftProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#BaselineShiftProperty"
           ],
           "tags": [
             "web-features:svg"
@@ -123,7 +123,7 @@
       "class": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/class",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#ElementSpecificStyling",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#ElementSpecificStyling",
           "tags": [
             "web-features:svg"
           ],
@@ -320,7 +320,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/color",
           "spec_url": [
             "https://drafts.csswg.org/css-color/#the-color-property",
-            "https://svgwg.org/svg2-draft/painting.html#ColorProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorProperty"
           ],
           "tags": [
             "web-features:svg"
@@ -365,7 +365,7 @@
       "color-interpolation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/color-interpolation",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolationProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolationProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -402,7 +402,7 @@
         },
         "linearGradient": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolation",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolation",
             "tags": [
               "web-features:svg"
             ],
@@ -436,7 +436,7 @@
         },
         "sRGB": {
           "__compat": {
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#ColorInterpolation",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ColorInterpolation",
             "tags": [
               "web-features:svg"
             ],
@@ -553,7 +553,7 @@
         "__compat": {
           "description": "`data-*` attributes",
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/data-*",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#DataAttributes",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#DataAttributes",
           "tags": [
             "web-features:svg"
           ],
@@ -590,7 +590,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/direction",
           "spec_url": [
             "https://drafts.csswg.org/css-writing-modes/#direction",
-            "https://svgwg.org/svg2-draft/text.html#DirectionProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#DirectionProperty"
           ],
           "tags": [
             "web-features:svg"
@@ -637,7 +637,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/display",
           "spec_url": [
             "https://drafts.csswg.org/css-display/#the-display-properties",
-            "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#VisibilityControl"
           ],
           "tags": [
             "web-features:svg"
@@ -684,7 +684,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/dominant-baseline",
           "spec_url": [
             "https://drafts.csswg.org/css-inline/#dominant-baseline-property",
-            "https://svgwg.org/svg2-draft/text.html#DominantBaselineProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#DominantBaselineProperty"
           ],
           "tags": [
             "web-features:svg"
@@ -720,7 +720,7 @@
       "fill-opacity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill-opacity",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#FillOpacity",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#FillOpacity",
           "tags": [
             "web-features:opacity-svg"
           ],
@@ -755,7 +755,7 @@
       "fill-rule": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/fill-rule",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#WindingRule",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#WindingRule",
           "tags": [
             "web-features:svg"
           ],
@@ -1042,7 +1042,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/font-stretch",
           "spec_url": [
             "https://drafts.csswg.org/css-fonts/#font-stretch-prop",
-            "https://svgwg.org/svg2-draft/styling.html#:~:text=font-stretch"
+            "https://w3c.github.io/svgwg/svg2-draft/styling.html#:~:text=font-stretch"
           ],
           "tags": [
             "web-features:font-stretch"
@@ -1131,7 +1131,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/font-variant",
           "spec_url": [
             "https://drafts.csswg.org/css-fonts/#font-variant-prop",
-            "https://svgwg.org/svg2-draft/text.html#FontVariantProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#FontVariantProperty"
           ],
           "tags": [
             "web-features:font-variant"
@@ -1254,7 +1254,7 @@
       "glyph-orientation-horizontal": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/glyph-orientation-horizontal",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#GlyphOrientationHorizontalProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationHorizontalProperty",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -1289,7 +1289,7 @@
       "glyph-orientation-vertical": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/glyph-orientation-vertical",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#GlyphOrientationVerticalProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#GlyphOrientationVerticalProperty",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -1324,7 +1324,7 @@
       "id": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/id",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#Core.attrib",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#Core.attrib",
           "tags": [
             "web-features:svg"
           ],
@@ -1366,7 +1366,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/image-rendering",
           "spec_url": [
             "https://drafts.csswg.org/css-images/#the-image-rendering",
-            "https://svgwg.org/svg2-draft/painting.html#ImageRendering"
+            "https://w3c.github.io/svgwg/svg2-draft/painting.html#ImageRendering"
           ],
           "tags": [
             "web-features:svg"
@@ -1404,7 +1404,7 @@
       "lang": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/lang",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#LangSpaceAttrs",
           "tags": [
             "web-features:svg"
           ],
@@ -1446,7 +1446,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/letter-spacing",
           "spec_url": [
             "https://drafts.csswg.org/css-text/#letter-spacing-property",
-            "https://svgwg.org/svg2-draft/text.html#LetterSpacingProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#LetterSpacingProperty"
           ],
           "tags": [
             "web-features:letter-spacing"
@@ -1531,7 +1531,7 @@
       "marker-end": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/marker-end",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerEndProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerEndProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -1566,7 +1566,7 @@
       "marker-mid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/marker-mid",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerMidProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerMidProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -1601,7 +1601,7 @@
       "marker-start": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/marker-start",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#MarkerStartProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#MarkerStartProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -1741,7 +1741,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/opacity",
           "spec_url": [
             "https://drafts.csswg.org/css-color/#propdef-opacity",
-            "https://svgwg.org/svg2-draft/render.html#ObjectAndGroupOpacityProperties"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#ObjectAndGroupOpacityProperties"
           ],
           "tags": [
             "web-features:opacity"
@@ -1802,7 +1802,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/overflow",
           "spec_url": [
             "https://drafts.csswg.org/css-overflow/#propdef-overflow",
-            "https://svgwg.org/svg2-draft/render.html#OverflowAndClipProperties"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#OverflowAndClipProperties"
           ],
           "tags": [
             "web-features:svg"
@@ -1845,7 +1845,7 @@
       "paint-order": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/paint-order",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#PaintOrderProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#PaintOrderProperty",
           "tags": [
             "web-features:paint-order"
           ],
@@ -1884,7 +1884,7 @@
       "pointer-events": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/pointer-events",
-          "spec_url": "https://svgwg.org/svg2-draft/interact.html#PointerEventsProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/interact.html#PointerEventsProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -1996,7 +1996,7 @@
       "shape-rendering": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/shape-rendering",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#ShapeRendering",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#ShapeRendering",
           "tags": [
             "web-features:svg"
           ],
@@ -2031,7 +2031,7 @@
       "stop-color": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stop-color",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopColorProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopColorProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -2079,7 +2079,7 @@
       "stop-opacity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stop-opacity",
-          "spec_url": "https://svgwg.org/svg2-draft/pservers.html#StopOpacityProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/pservers.html#StopOpacityProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -2133,7 +2133,7 @@
       "stroke": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingStrokePaint",
           "tags": [
             "web-features:svg"
           ],
@@ -2167,7 +2167,7 @@
         "context-stroke": {
           "__compat": {
             "description": "`context-stroke` value",
-            "spec_url": "https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#SpecifyingPaint",
             "tags": [
               "web-features:context-fill-stroke"
             ],
@@ -2203,7 +2203,7 @@
       "stroke-dasharray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-dasharray",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashing",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashing",
           "tags": [
             "web-features:svg"
           ],
@@ -2238,7 +2238,7 @@
       "stroke-dashoffset": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-dashoffset",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeDashoffsetProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeDashoffsetProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -2273,7 +2273,7 @@
       "stroke-linecap": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-linecap",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#LineCaps",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#LineCaps",
           "tags": [
             "web-features:svg"
           ],
@@ -2308,7 +2308,7 @@
       "stroke-linejoin": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-linejoin",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#LineJoin",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#LineJoin",
           "tags": [
             "web-features:svg"
           ],
@@ -2343,7 +2343,7 @@
       "stroke-miterlimit": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-miterlimit",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeMiterlimitProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeMiterlimitProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -2378,7 +2378,7 @@
       "stroke-opacity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-opacity",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeOpacity",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeOpacity",
           "tags": [
             "web-features:opacity-svg"
           ],
@@ -2413,7 +2413,7 @@
       "stroke-width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/stroke-width",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#StrokeWidth",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#StrokeWidth",
           "tags": [
             "web-features:svg"
           ],
@@ -2448,7 +2448,7 @@
       "style": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/style",
-          "spec_url": "https://svgwg.org/svg2-draft/styling.html#ElementSpecificStyling",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/styling.html#ElementSpecificStyling",
           "tags": [
             "web-features:svg"
           ],
@@ -2488,7 +2488,7 @@
       "tabindex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/tabindex",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#tabindexattribute",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#tabindexattribute",
           "tags": [
             "web-features:svg"
           ],
@@ -2528,7 +2528,7 @@
       "text-anchor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/text-anchor",
-          "spec_url": "https://svgwg.org/svg2-draft/text.html#TextAnchorProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/text.html#TextAnchorProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -2565,7 +2565,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/text-decoration",
           "spec_url": [
             "https://drafts.csswg.org/css-text-decor/#text-decoration-property",
-            "https://svgwg.org/svg2-draft/text.html#TextDecorationProperties"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#TextDecorationProperties"
           ],
           "tags": [
             "web-features:svg"
@@ -2612,7 +2612,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/text-overflow",
           "spec_url": [
             "https://drafts.csswg.org/css-overflow/#text-overflow",
-            "https://svgwg.org/svg2-draft/text.html#TextOverflowProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#TextOverflowProperty"
           ],
           "tags": [
             "web-features:text-overflow"
@@ -2678,7 +2678,7 @@
       "text-rendering": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/text-rendering",
-          "spec_url": "https://svgwg.org/svg2-draft/painting.html#TextRenderingProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/painting.html#TextRenderingProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -2735,7 +2735,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/transform",
           "spec_url": [
             "https://drafts.csswg.org/css-transforms/#svg-transform",
-            "https://svgwg.org/svg2-draft/coords.html#TransformProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/coords.html#TransformProperty"
           ],
           "tags": [
             "web-features:svg"
@@ -2903,7 +2903,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/transform-origin",
           "spec_url": [
             "https://drafts.csswg.org/css-transforms/#transform-origin-property",
-            "https://svgwg.org/svg2-draft/styling.html#PresentationAttributes"
+            "https://w3c.github.io/svgwg/svg2-draft/styling.html#PresentationAttributes"
           ],
           "tags": [
             "web-features:svg"
@@ -2985,7 +2985,7 @@
       "vector-effect": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/vector-effect",
-          "spec_url": "https://svgwg.org/svg2-draft/coords.html#VectorEffectProperty",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/coords.html#VectorEffectProperty",
           "tags": [
             "web-features:svg"
           ],
@@ -3022,7 +3022,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/visibility",
           "spec_url": [
             "https://drafts.csswg.org/css-display/#visibility",
-            "https://svgwg.org/svg2-draft/render.html#VisibilityControl"
+            "https://w3c.github.io/svgwg/svg2-draft/render.html#VisibilityControl"
           ],
           "tags": [
             "web-features:svg"
@@ -3074,7 +3074,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/white-space",
           "spec_url": [
             "https://drafts.csswg.org/css-text-4/#white-space-property",
-            "https://svgwg.org/svg2-draft/text.html#TextWhiteSpace"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#TextWhiteSpace"
           ],
           "tags": [
             "web-features:white-space"
@@ -3121,7 +3121,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/word-spacing",
           "spec_url": [
             "https://drafts.csswg.org/css-text/#word-spacing-property",
-            "https://svgwg.org/svg2-draft/text.html#WordSpacingProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#WordSpacingProperty"
           ],
           "tags": [
             "web-features:word-spacing"
@@ -3166,7 +3166,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/writing-mode",
           "spec_url": [
             "https://drafts.csswg.org/css-writing-modes/#block-flow",
-            "https://svgwg.org/svg2-draft/text.html#WritingModeProperty"
+            "https://w3c.github.io/svgwg/svg2-draft/text.html#WritingModeProperty"
           ],
           "tags": [
             "web-features:writing-mode"
@@ -3243,7 +3243,7 @@
         "__compat": {
           "description": "xml:lang",
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/xml:lang",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#LangSpaceAttrs",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#LangSpaceAttrs",
           "tags": [
             "web-features:svg-discouraged"
           ],
@@ -3284,7 +3284,7 @@
         "__compat": {
           "description": "xml:space",
           "mdn_url": "https://developer.mozilla.org/docs/Web/SVG/Reference/Attribute/xml:space",
-          "spec_url": "https://svgwg.org/svg2-draft/struct.html#WhitespaceProcessingXMLSpaceAttribute",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/struct.html#WhitespaceProcessingXMLSpaceAttribute",
           "tags": [
             "web-features:svg-discouraged"
           ],


### PR DESCRIPTION
#### Summary

All SVG2 links in MDN are outdated.

#### Test results and supporting details

Currently all SVG2 specification references link to
https://svgwg.org/svg2-draft/
They need to be changed to
https://w3c.github.io/svgwg/svg2-draft/

#### Related issues

See https://github.com/mdn/content/issues/43676.