### PR TITLE
Chrome 146 adds `texture_and_sampler_let` WGSL feature

### DIFF
--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -294,6 +294,43 @@
           }
         }
       },
+      "extension_texture_and_sampler_let": {
+        "__compat": {
+          "description": "`texture_and_sampler_let` extension",
+          "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-texture_and_sampler_let",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "146",
+              "partial_implementation": true,
+              "notes": "Supported on ChromeOS, macOS, Windows, and Linux (Intel Gen12+ GPUs only)."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "extension_uniform_buffer_standard_layout": {
         "__compat": {
           "description": "`uniform_buffer_standard_layout` extension",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 146 adds support for the `texture_and_sampler_let` WGSL feature/extension. See https://chromestatus.com/feature/5102334940151808.

This PR adds a data point for the new extension.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
