### PR TITLE
Add `position-anchor: normal`

### DIFF
--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -116,6 +116,41 @@
               "deprecated": false
             }
           }
+        },
+        "normal": {
+          "__compat": {
+            "description": "`normal` value",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-anchor-normal",
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/501399489"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2030351"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/311941"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -12,6 +12,7 @@
             "chrome": [
               {
                 "version_added": "144",
+                "partial_implementation": true,
                 "notes": "The initial value is `none` instead of `normal` (see [bug 501399489](https://crbug.com/501399489))."
               },
               {
@@ -31,6 +32,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "147",
+              "partial_implementation": true,
               "notes": "The initial value is `auto` instead of `normal` (see [bug 2030351](https://bugzil.la/2030351)."
             },
             "firefox_android": "mirror",

--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -11,19 +11,27 @@
           "support": {
             "chrome": [
               {
-                "version_added": "144"
+                "version_added": "144",
+                "notes": "The initial value is `none` instead of `normal` (see [bug 501399489](https://crbug.com/501399489))."
+              },
+              {
+                "version_added": "127",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "The initial value is `auto` instead of `normal` (see [bug 460415950](https://crbug.com/460415950))."
               },
               {
                 "version_added": "125",
-                "version_removed": "144",
+                "version_removed": "127",
                 "partial_implementation": true,
-                "notes": "The initial value is `normal` instead of `none` (see [bug 460415950](https://crbug.com/460415950))."
+                "notes": "The initial value is `implicit` instead of `normal` (see [bug 340878604](https://crbug.com/340878604))."
               }
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "147"
+              "version_added": "147",
+              "notes": "The initial value is `auto` instead of `normal` (see [bug 2030351](https://bugzil.la/2030351)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -32,7 +40,7 @@
             "safari": {
               "version_added": "26",
               "partial_implementation": true,
-              "notes": "The initial value is `normal` instead of `none` (see [bug 308981](https://webkit.org/b/308981))."
+              "notes": "The initial value is `auto` instead of `normal` (see [bug 308981](https://webkit.org/b/308981) and [bug 311941](https://webkit.org/b/311941))."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This adds an entry for `position-anchor: normal`, even though it's not implemented anywhere yet.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Ordinarily, I would not track something that does not have an implementation. However, it makes the existing notes difficult to understand, citing behaviors that were, at one time, standard but are no longer. Since there's no consensus implementation, I think it's easier to understand what's going on here with these changes.

While I was here, I corrected the data for Chrome's initial value and note for Safari. I had previously erred in writing the notes in https://github.com/mdn/browser-compat-data/pull/29272/. To "test" the initial value, I used the browsers' dev tools to inspect the computed value on an unstyled element.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/issues/3558#issuecomment-4171684032
- [Firefox bug 2030351 — Implement position-anchor: normal](https://bugzilla.mozilla.org/show_bug.cgi?id=2030351)
- [WebKit bug 311941 — Implement `position-anchor: normal`](https://bugs.webkit.org/show_bug.cgi?id=311941)
- [Chromium bug 501399489 — [css-anchor-position-1] Implement `position-anchor: normal` ](https://issues.chromium.org/issues/501399489)

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
