### PR TITLE
Chromium: XSLTProcessor is not yet unshipped

### DIFF
--- a/api/XSLTProcessor.json
+++ b/api/XSLTProcessor.json
@@ -9,8 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "1",
-            "version_removed": "147"
+            "version_added": "1"
           },
           "chrome_android": "mirror",
           "edge": {
@@ -53,8 +52,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": "147"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -97,8 +95,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": "147"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -142,7 +139,6 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "version_removed": "147",
               "notes": "Chrome only supports string values."
             },
             "chrome_android": "mirror",
@@ -191,8 +187,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": "147"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -235,8 +230,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": "147"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -279,8 +273,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "version_removed": "147"
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
@@ -324,7 +317,6 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "version_removed": "147",
               "notes": "Chrome only supports string values."
             },
             "chrome_android": "mirror",
@@ -374,7 +366,6 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "version_removed": "147",
               "notes": "Chrome returns `null` if an error occurs."
             },
             "chrome_android": "mirror",
@@ -431,7 +422,6 @@
           "support": {
             "chrome": {
               "version_added": "1",
-              "version_removed": "147",
               "notes": "Chrome returns `null` if an error occurs."
             },
             "chrome_android": "mirror",


### PR DESCRIPTION
#### Summary

https://github.com/mdn/browser-compat-data/pull/29244 marked XSLTProcessor as unshipped, but that seems wrong.

#### Test results and supporting details

https://collector.openwebdocs.org/tests/api/XSLTProcessor
Works in release and beta channels.

#### Related issues

https://github.com/web-platform-dx/web-features/pull/3951