### PR TITLE
[WebExtensions] Deprecate Native Client info in runtime API

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -360,7 +360,8 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "≤58"
+                  "version_added": "28",
+                  "notes": "This attribute is deprecated and is being removed from Google Chrome, following removal of Google Native Client."
                 },
                 "edge": "mirror",
                 "firefox": {
@@ -381,7 +382,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime/PlatformNaclArch",
             "support": {
               "chrome": {
-                "version_added": "≤58"
+                "version_added": "28",
+                "notes": "This enum is deprecated and is being removed from Google Chrome, following removal of Google Native Client."
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Add notes to `runtime.PlatformInfo.nacl_arch` and `runtime.PlatformNaclArch` describing their deprecation. 

#### Test results and supporting details

Google Chrome plans to run a deprecation experiment removing `runtime.PlatformInfo.nacl_arch` on all platforms.[1] Shortly after conclusion of `runtime.PlatformInfo.nacl_arch` removal experiment Chrome plans to remove enum `runtime.PlatformNaclArch` without any experiment.

Google Chrome already removed `runtime.PlatformInfo.nacl_arch` on unofficial builds for RISC-V[2] and Android Desktop[3].

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[1] https://chromium-review.googlesource.com/c/chromium/src/+/7090141
[2] https://github.com/chromium/chromium/commit/913e0c02f12a758e69b3a5effff0d725f38556d3
[3] https://github.com/chromium/chromium/commit/6e62e12f5ec58a0d830f72b61e09fb2c6ea4962a

#### Related issues

https://github.com/mdn/content/pull/43799
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
