### PR TITLE
Firefox 150 adds `animation-range` properties

### DIFF
--- a/css/properties/animation-range-end.json
+++ b/css/properties/animation-range-end.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1676779"
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1676779"
+                "version_added": "150"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range-start.json
+++ b/css/properties/animation-range-start.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1676779"
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1676779"
+                "version_added": "150"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range.json
+++ b/css/properties/animation-range.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1676779"
+              "version_added": "150"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "150"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

Ships `animation-range`, `animation-range-start`, `animation-range-end` in Firefox 150

#### Test results and supporting details

- Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=1825427

#### Related issues

Part of the mdn/content#43565