### PR TITLE
Fix querySelectorAll to querySelector

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -7207,7 +7207,7 @@
                 "version_added": "8",
                 "version_removed": "9",
                 "partial_implementation": true,
-                "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
+                "notes": "`querySelector()` is supported, but only for CSS 2.1 selectors."
               }
             ],
             "oculus": "mirror",

--- a/api/DocumentFragment.json
+++ b/api/DocumentFragment.json
@@ -405,7 +405,7 @@
                 "version_added": "8",
                 "version_removed": "9",
                 "partial_implementation": true,
-                "notes": "`querySelectorAll()` is supported, but only for CSS 2.1 selectors."
+                "notes": "`querySelector()` is supported, but only for CSS 2.1 selectors."
               }
             ],
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -8259,7 +8259,7 @@
       "querySelector": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/querySelector",
-          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-parentnode-queryselectorall①",
+          "spec_url": "https://dom.spec.whatwg.org/#ref-for-dom-parentnode-queryselector①",
           "tags": [
             "web-features:dom"
           ],


### PR DESCRIPTION
#### Summary

Fixes the spec url for Element.querySelector which pointed to querySelectorAll instead.
Also fixes the Internet Explorer note that was talking about querySelectorAll instead of querySelector for Document and DocumentFragment.