### PR TITLE
Overscroll behavior: add partial to Safari and support notes

### DIFF
--- a/css/properties/overscroll-behavior-block.json
+++ b/css/properties/overscroll-behavior-block.json
@@ -17,7 +17,7 @@
                 "version_added": "77",
                 "version_removed": "144",
                 "partial_implementation": true,
-                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "chrome_android": "mirror",
@@ -30,7 +30,7 @@
                 "version_added": "73",
                 "version_removed": "150",
                 "partial_implementation": true,
-                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/overscroll-behavior-block.json
+++ b/css/properties/overscroll-behavior-block.json
@@ -9,20 +9,39 @@
             "web-features:overscroll-behavior"
           ],
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "144"
+              },
+              {
+                "version_added": "77",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "73"
-            },
+            "firefox": [
+              {
+                "version_added": "150"
+              },
+              {
+                "version_added": "73",
+                "version_removed": "150",
+                "partial_implementation": true,
+                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "16",
+              "impl_url": "https://webkit.org/b/243452",
+              "partial_implementation": true,
+              "notes": "The property has no effect on scroll containers that have no scrollable overflow."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/overscroll-behavior-inline.json
+++ b/css/properties/overscroll-behavior-inline.json
@@ -17,7 +17,7 @@
                 "version_added": "77",
                 "version_removed": "144",
                 "partial_implementation": true,
-                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "chrome_android": "mirror",
@@ -30,7 +30,7 @@
                 "version_added": "73",
                 "version_removed": "150",
                 "partial_implementation": true,
-                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/overscroll-behavior-inline.json
+++ b/css/properties/overscroll-behavior-inline.json
@@ -9,20 +9,39 @@
             "web-features:overscroll-behavior"
           ],
           "support": {
-            "chrome": {
-              "version_added": "77"
-            },
+            "chrome": [
+              {
+                "version_added": "144"
+              },
+              {
+                "version_added": "77",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "73"
-            },
+            "firefox": [
+              {
+                "version_added": "150"
+              },
+              {
+                "version_added": "73",
+                "version_removed": "150",
+                "partial_implementation": true,
+                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "16",
+              "impl_url": "https://webkit.org/b/243452",
+              "partial_implementation": true,
+              "notes": "The property has no effect on scroll containers that have no scrollable overflow."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/overscroll-behavior-x.json
+++ b/css/properties/overscroll-behavior-x.json
@@ -9,22 +9,41 @@
             "web-features:overscroll-behavior"
           ],
           "support": {
-            "chrome": {
-              "version_added": "63"
-            },
+            "chrome": [
+              {
+                "version_added": "144"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": "59"
-            },
+            "firefox": [
+              {
+                "version_added": "150"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "150",
+                "partial_implementation": true,
+                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "16",
+              "impl_url": "https://webkit.org/b/243452",
+              "partial_implementation": true,
+              "notes": "The property has no effect on scroll containers that have no scrollable overflow."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/overscroll-behavior-x.json
+++ b/css/properties/overscroll-behavior-x.json
@@ -17,7 +17,7 @@
                 "version_added": "63",
                 "version_removed": "144",
                 "partial_implementation": true,
-                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "chrome_android": "mirror",
@@ -32,7 +32,7 @@
                 "version_added": "59",
                 "version_removed": "150",
                 "partial_implementation": true,
-                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/overscroll-behavior-y.json
+++ b/css/properties/overscroll-behavior-y.json
@@ -9,22 +9,41 @@
             "web-features:overscroll-behavior"
           ],
           "support": {
-            "chrome": {
-              "version_added": "63"
-            },
+            "chrome": [
+              {
+                "version_added": "144"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": "59"
-            },
+            "firefox": [
+              {
+                "version_added": "150"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "150",
+                "partial_implementation": true,
+                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "16",
+              "impl_url": "https://webkit.org/b/243452",
+              "partial_implementation": true,
+              "notes": "The property has no effect on scroll containers that have no scrollable overflow."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/overscroll-behavior-y.json
+++ b/css/properties/overscroll-behavior-y.json
@@ -17,7 +17,7 @@
                 "version_added": "63",
                 "version_removed": "144",
                 "partial_implementation": true,
-                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "chrome_android": "mirror",
@@ -32,7 +32,7 @@
                 "version_added": "59",
                 "version_removed": "150",
                 "partial_implementation": true,
-                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "firefox_android": "mirror",

--- a/css/properties/overscroll-behavior.json
+++ b/css/properties/overscroll-behavior.json
@@ -9,22 +9,41 @@
             "web-features:overscroll-behavior"
           ],
           "support": {
-            "chrome": {
-              "version_added": "63"
-            },
+            "chrome": [
+              {
+                "version_added": "144"
+              },
+              {
+                "version_added": "63",
+                "version_removed": "144",
+                "partial_implementation": true,
+                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": {
               "version_added": "18"
             },
-            "firefox": {
-              "version_added": "59"
-            },
+            "firefox": [
+              {
+                "version_added": "150"
+              },
+              {
+                "version_added": "59",
+                "version_removed": "150",
+                "partial_implementation": true,
+                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16"
+              "version_added": "16",
+              "impl_url": "https://webkit.org/b/243452",
+              "partial_implementation": true,
+              "notes": "The property has no effect on scroll containers that have no scrollable overflow."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/overscroll-behavior.json
+++ b/css/properties/overscroll-behavior.json
@@ -17,7 +17,7 @@
                 "version_added": "63",
                 "version_removed": "144",
                 "partial_implementation": true,
-                "notes": "Before version 144, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "chrome_android": "mirror",
@@ -32,7 +32,7 @@
                 "version_added": "59",
                 "version_removed": "150",
                 "partial_implementation": true,
-                "notes": "Before version 150, the property has no effect on scroll containers that have no scrollable overflow."
+                "notes": "The property has no effect on scroll containers that have no scrollable overflow."
               }
             ],
             "firefox_android": "mirror",


### PR DESCRIPTION
#### Summary

Overscroll behavior has changed since Chrome 144 and Firefox 150 and stayed the same in Safari.

I would say it deserves the partial implementation flag.

#### Test results and supporting details

- Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=1837436
- Chrome https://issues.chromium.org/issues/41371072
- WebKit https://bugs.webkit.org/show_bug.cgi?id=243452

#### Related issues

- https://github.com/mdn/content/pull/43813