### PR TITLE
Safari 16.4 supports `hanging-punctuation: force-end`

### DIFF
--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -111,6 +111,40 @@
             }
           }
         },
+        "force-end": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text/#valdef-hanging-punctuation-force-end",
+            "tags": [
+              "web-features:hanging-punctuation"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.6"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "last": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-text/#valdef-hanging-punctuation-last",

--- a/css/properties/hanging-punctuation.json
+++ b/css/properties/hanging-punctuation.json
@@ -131,7 +131,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "17.6"
+                "version_added": "16.4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add the missing `force-end` value to the CSS `hanging-punctuation` property.

#### Test results and supporting details

See [Safari 16.4 Release Notes](https://developer.apple.com/documentation/safari-release-notes/safari-16_4-release-notes#:~:text=Added%20support%20for%20the%20force%2Dend%20value%20of%20the%20hanging%2Dpunctuation%20property.).