### PR TITLE
Firefox 149 fixes bug in CSS `::highlight()` and `text-shadow`

### DIFF
--- a/css/selectors/highlight.json
+++ b/css/selectors/highlight.json
@@ -18,14 +18,20 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "140",
-              "partial_implementation": true,
-              "notes": [
-                "Cannot yet be used with `text-shadow`. See [bug 1845447](https://bugzil.la/1845447).",
-                "Before Firefox 146, cannot be used with `text-decoration`. See [bug 1845446](https://bugzil.la/1845446)."
-              ]
-            },
+            "firefox": [
+              {
+                "version_added": "149"
+              },
+              {
+                "version_added": "140",
+                "version_removed": "149",
+                "partial_implementation": true,
+                "notes": [
+                  "Before Firefox 149, cannot be used with `text-shadow`. See [bug 1845447](https://bugzil.la/1845447).",
+                  "Before Firefox 146, cannot be used with `text-decoration`. See [bug 1845446](https://bugzil.la/1845446)."
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
#### Summary
Switched Firefox to fully supporting `::highlight()` as of version 149.

#### Test results and supporting details
The [linked bug](https://bugzil.la/1845447) was fixed in version 149, so if the two listed bugs were the thing making the implementation "partial", that no longer applies.

I confirmed that it works in Firefox 149 on macOS with [this Codepen](https://codepen.io/editor/cpmsmith/pen/019d9737-e4d8-7dee-a248-b51524519342), which is just a modification of [this MDN demo](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Selectors/::highlight#highlighting_characters) with a `text-shadow` added to one of the highlights:

<img width="550" height="145" alt="image" src="https://github.com/user-attachments/assets/bcbaf202-9557-498a-961d-2ac48825f2a1" />

#### Related issues
This more or less supersedes mdn/browser-compat-data#28375, which was under some debate concerning this bug, and which is not as important if the bug is fixed.