### PR TITLE
Add `ReportingObserver` report type `permissions-policy-violation`

### DIFF
--- a/api/ReportingObserver.json
+++ b/api/ReportingObserver.json
@@ -321,6 +321,41 @@
                   "deprecated": false
                 }
               }
+            },
+            "permissions-policy-violation": {
+              "__compat": {
+                "description": "`permissions-policy-violation` report type",
+                "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#reporting",
+                "tags": [
+                  "web-features:reporting"
+                ],
+                "support": {
+                  "chrome": {
+                    "version_added": "120"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
This adds the `permissions-policy-violation` report type to the `ReportingObserver()` constructor. I've verified it works on Chrome as an observer and a server endpoint in the latest versions. 

This https://chromestatus.com/feature/5105435227455488 says it was added in Chrome 120. I have verified this by running the https://wpt.live/permissions-policy/reporting/midi-report-only.https.html test - which works in that version and later, but not before.

WPT dashboard indicates not support in FF and macOS (which matches my testing): https://wpt.fyi/results/permissions-policy/reporting?label=experimental&label=master&aligned

Related docs work can be tracked in: https://github.com/mdn/content/pull/43783