### PR TITLE
Deno 2.6 has transferable `{Readable,Writable,Transform}Stream`

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -424,7 +424,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -203,7 +203,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -315,7 +315,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.6"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Deno [supports transferable {Readable,Writable,Transform}Streams since 2.6.0](https://github.com/denoland/deno/releases/tag/v2.6.0). I've updated the support table accordingly.

