### PR TITLE
Add `Permissions-Policy-Report-Only` header

### DIFF
--- a/http/headers/Permissions-Policy-Report-Only.json
+++ b/http/headers/Permissions-Policy-Report-Only.json
@@ -1,0 +1,37 @@
+{
+  "http": {
+    "headers": {
+      "Permissions-Policy-Report-Only": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#permissions-policy-report-only-http-header-field",
+          "support": {
+            "chrome": {
+              "version_added": "120"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This adds data for `Permissions-Policy-Report-Only` header, to complement the `"permissions-policy-violation"` report type.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I trusted https://chromestatus.com/feature/5105435227455488 for the version number.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/29500
- https://github.com/mdn/browser-compat-data/pull/29399 and https://github.com/mdn/browser-compat-data/pull/29399#issuecomment-4269015055
- https://github.com/mdn/content/issues/43688

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
