### PR TITLE
PlatformArch values support details

### DIFF
--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -331,6 +331,88 @@
                 "version_added": "15"
               }
             }
+          },
+          "aarch64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48",
+                  "notes": "Equivalent of `arm64` on Chrome."
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "armm64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58",
+                  "notes": "Equivalent of `aarch64` on Firefox."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "mips": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58",
+                  "notes": "Not supported on any official Chrome release."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "mips64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58",
+                  "notes": "Not supported on any official Chrome release."
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "PlatformInfo": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -438,6 +438,27 @@
               }
             }
           },
+          "noarch": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "ppc64": {
             "__compat": {
               "support": {
@@ -519,6 +540,27 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
+              }
+            }
+          },
+          "unknown": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -340,7 +340,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "45"
+                  "version_added": "45",
+                  "notes": "Equivalent of `arm64` on Chrome."
                 },
                 "firefox_android": {
                   "version_added": "48",
@@ -351,6 +352,29 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
+              }
+            }
+          },
+          "arm": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           },
@@ -411,6 +435,134 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
+              }
+            }
+          },
+          "ppc64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "riscv64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "s390x": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "sparc64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "x86-32": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "x86-64": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "≤58"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
               }
             }
           }

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -354,7 +354,7 @@
               }
             }
           },
-          "armm64": {
+          "arm64": {
             "__compat": {
               "support": {
                 "chrome": {


### PR DESCRIPTION
### Summary

As a result of [[WebExtensions] Deprecate runtime.PlatformInfo.nacl_arch](https://github.com/mdn/content/pull/43799#top) #43799, it was identified that a number of the `PlatformArch` values were missing. This PR adds those values.

### Related pull requests

Content changes in https://github.com/mdn/content/pull/43847.
