### PR TITLE
Remove duplicated Sec-CH-DeviceMemory notes

### DIFF
--- a/http/headers/Sec-CH-Device-Memory.json
+++ b/http/headers/Sec-CH-Device-Memory.json
@@ -20,11 +20,7 @@
               },
               {
                 "alternative_name": "Device-Memory",
-                "version_added": "61",
-                "notes": [
-                  "Before Chrome 147, reported values were 0.25, 0.5, 1, 2, 4, and 8.",
-                  "From Chrome 147, reported values are 2, 4, 8, 16, and 32."
-                ]
+                "version_added": "61"
               }
             ],
             "chrome_android": [


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Just noticed I duplicated a note in #28900 and [it looks a little messy in MDN](https://developer.mozilla.org/en-US/docs/Web/API/Device_Memory_API#http.headers.Sec-CH-Device-Memory):

<img width="641" height="497" alt="screnshot of MDN datya" src="https://github.com/user-attachments/assets/478525e0-00dd-4489-9def-24b807552186" />

63 is before 147 so no need for notes then.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

N/A

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Clean up of data added by myself in #28900

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
