### PR TITLE
[WebExtensions] Chrome limits for alarms.create()

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -101,7 +101,11 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/create",
             "support": {
               "chrome": {
-                "version_added": "22"
+                "version_added": "22",
+                "notes": [
+                  "From Chrome 117, alarms are limited to 500 per extension.",
+                  "From Chrome 150, alarm names are limited to 1024 bytes."
+                ]
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 117+ limits the number of alarms extensions can create via `alarms.create()`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Chrome 117 limited extensions to 500 alarms each.[1] This is already described in the MDN article.[2] Chromium source is here.[3] 

[1] https://groups.google.com/a/chromium.org/g/chromium-extensions/c/8ZFwgCg-DvU/m/AxLjInQWAQAJ
[2] https://github.com/mdn/content/blob/main/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
[3] https://github.com/chromium/chromium/commit/96b950168c0f85db3738e0215e5126fc2b305227

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/w3c/webextensions/issues/422

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
