### PR TITLE
Make CSS `currentColor` data consistent

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -73,6 +73,37 @@
               "deprecated": false
             }
           }
+        },
+        "currentColor": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
+            "support": {
+              "chrome": {
+                "version_added": "93"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "92"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/background-color.json
+++ b/css/properties/background-color.json
@@ -48,25 +48,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -361,25 +361,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-bottom-color.json
+++ b/css/properties/border-bottom-color.json
@@ -49,25 +49,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-bottom.json
+++ b/css/properties/border-bottom.json
@@ -47,25 +47,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-color.json
+++ b/css/properties/border-color.json
@@ -54,25 +54,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-left-color.json
+++ b/css/properties/border-left-color.json
@@ -49,25 +49,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-left.json
+++ b/css/properties/border-left.json
@@ -47,25 +47,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-right-color.json
+++ b/css/properties/border-right-color.json
@@ -49,25 +49,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-right.json
+++ b/css/properties/border-right.json
@@ -49,25 +49,34 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
-              "firefox_android": "mirror",
+              "firefox_android": {
+                "version_added": "14"
+              },
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-top-color.json
+++ b/css/properties/border-top-color.json
@@ -49,25 +49,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border-top.json
+++ b/css/properties/border-top.json
@@ -47,25 +47,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/border.json
+++ b/css/properties/border.json
@@ -47,25 +47,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
-                "version_added": "≤50"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "≤9.1"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/color.json
+++ b/css/properties/color.json
@@ -47,6 +47,46 @@
             "deprecated": false
           }
         },
+        "currentColor": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "transparent": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-transparent",

--- a/css/properties/column-rule-color.json
+++ b/css/properties/column-rule-color.json
@@ -97,6 +97,42 @@
             "deprecated": false
           }
         },
+        "currentColor": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "10"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "transparent": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-transparent",

--- a/css/properties/column-rule.json
+++ b/css/properties/column-rule.json
@@ -98,6 +98,42 @@
             "deprecated": false
           }
         },
+        "currentColor": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "10"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "dashed": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-backgrounds/#valdef-line-style-dashed",

--- a/css/properties/outline-color.json
+++ b/css/properties/outline-color.json
@@ -49,6 +49,46 @@
             "deprecated": false
           }
         },
+        "currentColor": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "transparent": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-transparent",

--- a/css/properties/outline.json
+++ b/css/properties/outline.json
@@ -137,25 +137,32 @@
             "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
             "support": {
               "chrome": {
-                "version_added": "≤31"
+                "version_added": "1"
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "1"
+                "version_added": "1.5"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
-              "opera": "mirror",
+              "opera": {
+                "version_added": "9.5"
+              },
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.2"
+                "version_added": "4"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
               "webview_ios": "mirror"
             },
             "status": {

--- a/css/properties/stop-color.json
+++ b/css/properties/stop-color.json
@@ -36,6 +36,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "currentColor": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-color-4/#valdef-color-currentcolor",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "≤15"
+              },
+              "firefox": {
+                "version_added": "3"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "37"
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/utils/walk.test.js
+++ b/utils/walk.test.js
@@ -38,7 +38,7 @@ describe('walk()', () => {
     const results = Array.from(
       walk(['api.Notification', 'css.properties.color']),
     );
-    assert.equal(results.length, 31);
+    assert.equal(results.length, 32);
     assert.equal(results[0].path, 'api.Notification');
     assert.equal(
       results[results.length - 1].path,


### PR DESCRIPTION
#### Summary

Currently, the `currentColor` value is only added to some but to every `*color` property. The support data is also varying when it can be made consistent.

#### Test results and supporting details

Collector results.

#### Related issues

We could potentially follow-up and add some keys to https://github.com/web-platform-dx/web-features/blob/main/features/currentcolor.yml.