### PR TITLE
Firefox does not yet fully implement WebGPU `*In*Stage` limits

### DIFF
--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -1300,7 +1300,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "151"
+              "version_added": "151",
+              "partial_implementation": true,
+              "notes": "max*In*Stage limits report the values of max*Per*Stage. Requested max*In*Stage values are ignored."
             },
             "firefox_android": {
               "version_added": false
@@ -1333,7 +1335,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "151"
+              "version_added": "151",
+              "partial_implementation": true,
+              "notes": "max*In*Stage limits report the values of max*Per*Stage. Requested max*In*Stage values are ignored."
             },
             "firefox_android": {
               "version_added": false
@@ -1434,7 +1438,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "151"
+              "version_added": "151",
+              "partial_implementation": true,
+              "notes": "max*In*Stage limits report the values of max*Per*Stage. Requested max*In*Stage values are ignored."
             },
             "firefox_android": {
               "version_added": false
@@ -1467,7 +1473,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "151"
+              "version_added": "151",
+              "partial_implementation": true,
+              "notes": "max*In*Stage limits report the values of max*Per*Stage. Requested max*In*Stage values are ignored."
             },
             "firefox_android": {
               "version_added": false


### PR DESCRIPTION
Reverts one change in #29530. See https://bugzilla.mozilla.org/show_bug.cgi?id=2006720#c6.