### PR TITLE
FF151 @media rule picture-in-picture value supported

### DIFF
--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -818,8 +818,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "impl_url": "https://bugzil.la/1858562"
+                  "version_added": "151"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",

--- a/css/at-rules/media.json
+++ b/css/at-rules/media.json
@@ -833,7 +833,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
FF151 adds support for the [Document Picture in Picture API](https://developer.mozilla.org/en-US/docs/Web/API/Document_Picture-in-Picture_API) on desktop in https://bugzilla.mozilla.org/show_bug.cgi?id=2006594 

#29530 updated most of the API but missed the `@media` value of `picture-in-picture`. PIcked up by comparison to the original nightly update #28849

Related docs work can be tracked in https://github.com/mdn/content/issues/43861




