### PR TITLE
FF151 template element shadowrootassignment attribute

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -292,14 +292,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "dom.shadowdom.shadowRootSlotAssignment.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "151"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF151 added support for `shadowrootassignment` in https://bugzilla.mozilla.org/show_bug.cgi?id=2031295.

#29530 updated `HTMLTemplateElement.shadowRootSlotAssignment`.
This updates the mirrored  `<template>`  attribute `shadowrootassignment`. Caught by comparision to the preview PR #29457.

Related docs work can be tracked in https://github.com/mdn/content/issues/43866