### PR TITLE
Add Reporting-Endpoints header data on default endpoints usage

### DIFF
--- a/http/headers/Reporting-Endpoints.json
+++ b/http/headers/Reporting-Endpoints.json
@@ -4,7 +4,7 @@
       "Reporting-Endpoints": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Reporting-Endpoints",
-          "spec_url": "https://w3c.github.io/reporting/#header-field-registration",
+          "spec_url": "https://w3c.github.io/reporting/#header",
           "tags": [
             "web-features:reporting"
           ],
@@ -64,6 +64,102 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          }
+        },
+        "default": {
+          "__compat": {
+            "description": "`default` endpoint name",
+            "spec_url": "https://w3c.github.io/reporting/#header",
+            "support": {
+              "chrome": {
+                "version_added": "96"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "receives_crash_type": {
+            "__compat": {
+              "description": "Receives `crash` reports",
+              "spec_url": "https://wicg.github.io/crash-reporting/#delivery-priority",
+              "support": {
+                "chrome": {
+                  "version_added": "96"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "130"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "receives_deprecation_type": {
+            "__compat": {
+              "description": "Receives `deprecation` reports",
+              "spec_url": "https://wicg.github.io/deprecation-reporting/#deprecation-report:~:text=Deprecation%20reports%20are%20always%20delivered%20to%20the%20endpoint%20named%20default",
+              "support": {
+                "chrome": {
+                  "version_added": "96"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "130"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As per https://github.com/mdn/browser-compat-data/pull/29475#discussion_r3130491248, we have decided to update the `Reporting-Endpoints` data to add data points for the `default` endpoint, and sub-data points to state when each report type started to be sent to the default endpoint.

I have added the structure, but am finding it difficult to complete this work:

- It is hard to find anywhere where the endpoint named `default` is actually defined.
- It is also hard to find data for the report types being sent to that endpoint. For example, the crash report type was implemented in Chrome in v72 (https://chromestatus.com/feature/6683949661159424), but the header itself wasn't implemented until v96 (https://chromestatus.com/feature/5712172409683968), so I'm guessing the data point for the crash report type being sent to the default endpoint is 96?
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
