### PR TITLE
feat(browsers): add workerd to BCD

### DIFF
--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -99,7 +102,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -171,7 +177,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -220,7 +229,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -275,7 +287,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/AbortController.json
+++ b/api/AbortController.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -104,7 +104,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -179,7 +179,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -231,7 +231,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -289,7 +289,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -298,7 +298,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -39,7 +39,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -142,7 +142,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -194,7 +194,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -244,7 +244,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -351,7 +351,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -404,7 +404,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -466,7 +466,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/AbortSignal.json
+++ b/api/AbortSignal.json
@@ -37,7 +37,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -137,7 +140,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -186,7 +192,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -233,7 +242,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -284,7 +296,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -334,7 +349,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -384,7 +402,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -443,7 +464,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -234,7 +234,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -60,7 +60,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -125,7 +125,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -181,7 +181,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -296,7 +296,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -381,7 +381,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -429,7 +429,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -485,7 +485,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -547,7 +547,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -58,7 +58,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -120,7 +123,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -173,7 +179,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -223,7 +232,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -282,7 +294,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -364,7 +379,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -409,7 +427,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -462,7 +483,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -521,7 +545,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -91,7 +94,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -137,7 +143,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -183,7 +192,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ByteLengthQueuingStrategy.json
+++ b/api/ByteLengthQueuingStrategy.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -96,7 +96,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -145,7 +145,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -194,7 +194,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Cache.json
+++ b/api/Cache.json
@@ -36,7 +36,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -124,7 +124,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -168,7 +168,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -212,7 +212,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -255,7 +255,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -299,7 +299,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -345,7 +345,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -392,7 +392,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Cache.json
+++ b/api/Cache.json
@@ -34,7 +34,10 @@
             "version_added": "4.0"
           },
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -119,7 +122,10 @@
               "notes": "Requires HTTPS from Samsung Internet 5.0."
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -160,7 +166,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -201,7 +210,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -241,7 +253,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -282,7 +297,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -325,7 +343,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -369,7 +390,10 @@
               "notes": "Requires HTTPS from Samsung Internet 5.0."
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -39,7 +39,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -159,7 +162,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -199,7 +205,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -239,7 +248,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -287,7 +299,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -327,7 +342,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CacheStorage.json
+++ b/api/CacheStorage.json
@@ -41,7 +41,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -164,7 +164,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -207,7 +207,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -250,7 +250,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -301,7 +301,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -344,7 +344,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -52,7 +52,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -105,7 +105,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -161,7 +161,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -217,7 +217,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -273,7 +273,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/CloseEvent.json
+++ b/api/CloseEvent.json
@@ -50,7 +50,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -100,7 +103,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -153,7 +159,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -206,7 +215,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -259,7 +271,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -177,7 +183,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -226,7 +235,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -269,7 +281,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -361,7 +376,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -405,7 +423,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -185,7 +185,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -237,7 +237,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -283,7 +283,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -378,7 +378,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -425,7 +425,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -91,7 +94,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -137,7 +143,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -183,7 +192,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CountQueuingStrategy.json
+++ b/api/CountQueuingStrategy.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -96,7 +96,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -145,7 +145,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -194,7 +194,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -58,7 +58,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -110,7 +113,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -156,7 +162,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -212,7 +221,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Crypto.json
+++ b/api/Crypto.json
@@ -60,7 +60,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -115,7 +115,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -164,7 +164,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -223,7 +223,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -90,7 +93,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -144,7 +150,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -190,7 +199,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -236,7 +248,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -95,7 +95,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -152,7 +152,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -201,7 +201,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -250,7 +250,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -48,7 +48,10 @@
           "webview_android": {
             "version_added": "3"
           },
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -98,7 +101,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -200,7 +206,10 @@
             "webview_android": {
               "version_added": "3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/CustomEvent.json
+++ b/api/CustomEvent.json
@@ -50,7 +50,7 @@
           },
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -103,7 +103,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -208,7 +208,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -46,7 +46,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -93,7 +93,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -146,7 +146,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -202,7 +202,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -258,7 +258,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/DOMException.json
+++ b/api/DOMException.json
@@ -44,7 +44,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -88,7 +91,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -138,7 +144,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -191,7 +200,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -244,7 +256,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -177,7 +183,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -226,7 +235,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -269,7 +281,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -361,7 +376,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -405,7 +423,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -185,7 +185,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -237,7 +237,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -283,7 +283,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -378,7 +378,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -425,7 +425,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -40,7 +40,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -83,7 +83,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -129,7 +129,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -175,7 +175,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -225,7 +225,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -275,7 +275,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -325,7 +325,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ErrorEvent.json
+++ b/api/ErrorEvent.json
@@ -38,7 +38,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -78,7 +81,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -121,7 +127,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -164,7 +173,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -211,7 +223,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -258,7 +273,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -305,7 +323,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Event.json
+++ b/api/Event.json
@@ -54,7 +54,10 @@
           "webview_android": {
             "version_added": "1"
           },
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -104,7 +107,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -158,7 +164,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -211,7 +220,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -273,7 +285,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -319,7 +334,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -374,7 +392,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -435,7 +456,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -492,7 +516,10 @@
             "webview_android": {
               "version_added": "3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -545,7 +572,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -700,7 +730,10 @@
               "version_added": "46",
               "notes": "Starting with version 53, untrusted events do not invoke the default action."
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -790,7 +823,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -842,7 +878,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -892,7 +931,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -947,7 +989,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1001,7 +1046,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1054,7 +1102,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1116,7 +1167,10 @@
               "version_added": "1",
               "notes": "Starting with version 49, this property returns [`DOMHighResTimeStamp`](https://developer.mozilla.org/docs/Web/API/DOMHighResTimeStamp) instead of [`DOMTimeStamp`](https://developer.mozilla.org/docs/Web/API/DOMTimeStamp)."
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1169,7 +1223,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Event.json
+++ b/api/Event.json
@@ -56,7 +56,7 @@
           },
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -109,7 +109,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -166,7 +166,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -222,7 +222,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -287,7 +287,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -336,7 +336,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -394,7 +394,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -458,7 +458,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -518,7 +518,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -574,7 +574,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -732,7 +732,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -825,7 +825,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -880,7 +880,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -933,7 +933,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -991,7 +991,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1048,7 +1048,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1104,7 +1104,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1169,7 +1169,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1225,7 +1225,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -58,7 +58,10 @@
           "webview_android": {
             "version_added": "1"
           },
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -102,7 +105,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -167,7 +173,10 @@
               "version_added": "1",
               "notes": "Before Chrome 49, the `type` and `listener` parameters were optional."
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -211,7 +220,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -302,7 +314,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -466,7 +481,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -519,7 +537,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -585,7 +606,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -646,7 +670,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -742,7 +769,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/api/EventTarget.json
+++ b/api/EventTarget.json
@@ -60,7 +60,7 @@
           },
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -107,7 +107,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -175,7 +175,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -222,7 +222,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -316,7 +316,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -483,7 +483,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -539,7 +539,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -608,7 +608,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -672,7 +672,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -771,7 +771,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/api/File.json
+++ b/api/File.json
@@ -66,7 +66,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -113,7 +116,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -169,7 +175,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -275,7 +284,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/File.json
+++ b/api/File.json
@@ -68,7 +68,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -118,7 +118,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -177,7 +177,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -286,7 +286,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -52,7 +52,7 @@
           },
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -112,7 +112,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -255,7 +255,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -303,7 +303,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -353,7 +353,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -401,7 +401,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -448,7 +448,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -497,7 +497,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -546,7 +546,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -595,7 +595,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -643,7 +643,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -692,7 +692,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -740,7 +740,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -788,7 +788,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/FormData.json
+++ b/api/FormData.json
@@ -50,7 +50,10 @@
             "version_added": "3",
             "notes": "XHR in Android 4.0 sends empty content for `FormData` with `blob`."
           },
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -107,7 +110,10 @@
             "webview_android": {
               "version_added": "3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -247,7 +253,10 @@
               "version_added": "3",
               "notes": "XHR in Android 4.0 sends empty content for `FormData` with `blob`."
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -292,7 +301,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -339,7 +351,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -384,7 +399,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -428,7 +446,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -474,7 +495,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -520,7 +544,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -566,7 +593,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -611,7 +641,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -657,7 +690,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -702,7 +738,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -747,7 +786,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -380,7 +380,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -37,7 +37,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -83,7 +86,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -129,7 +135,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -175,7 +184,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -220,7 +232,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -265,7 +280,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -313,7 +331,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -357,7 +378,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -403,7 +427,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -490,7 +517,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -535,7 +565,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -581,7 +614,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -626,7 +662,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -671,7 +710,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -380,7 +380,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.04.26"
+              "version_added": "2023.03.01"
             }
           },
           "status": {

--- a/api/Headers.json
+++ b/api/Headers.json
@@ -39,7 +39,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -88,7 +88,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -137,7 +137,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -234,7 +234,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -282,7 +282,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -333,7 +333,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -429,7 +429,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -519,7 +519,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -567,7 +567,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -616,7 +616,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -664,7 +664,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -712,7 +712,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/MessageChannel.json
+++ b/api/MessageChannel.json
@@ -52,7 +52,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2025.08.15"
+          }
         },
         "status": {
           "experimental": false,
@@ -105,7 +108,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -158,7 +164,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -211,7 +220,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -44,7 +44,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -94,7 +97,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/MessageEvent.json
+++ b/api/MessageEvent.json
@@ -46,7 +46,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -99,7 +99,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/MessagePort.json
+++ b/api/MessagePort.json
@@ -61,7 +61,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2025.08.15"
+          }
         },
         "status": {
           "experimental": false,
@@ -112,7 +115,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -165,7 +171,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -230,7 +239,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -296,7 +308,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -361,7 +376,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,
@@ -451,7 +469,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.08.15"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2221,7 +2221,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.05.19"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -44,7 +44,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -1961,7 +1964,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -4919,7 +4925,10 @@
               "version_added": "40",
               "notes": "Starting in Chrome 59, this method cannot send a `Blob` whose type is not CORS safelisted. This is a temporary change until a mitigation can be found for the security issues that this creates. For more information, see [bug 40087600](https://crbug.com/40087600)."
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -5572,7 +5581,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -46,7 +46,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -1966,7 +1966,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -4927,7 +4927,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -5583,7 +5583,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -57,7 +57,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -1051,7 +1051,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1208,7 +1208,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Performance.json
+++ b/api/Performance.json
@@ -55,7 +55,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -1046,7 +1049,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1200,7 +1206,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -28,7 +28,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/PromiseRejectionEvent.json
+++ b/api/PromiseRejectionEvent.json
@@ -30,7 +30,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {

--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -54,7 +54,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -100,7 +100,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -147,7 +147,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -194,7 +194,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -241,7 +241,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -288,7 +288,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ReadableByteStreamController.json
+++ b/api/ReadableByteStreamController.json
@@ -52,7 +52,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -95,7 +98,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -139,7 +145,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -183,7 +192,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -227,7 +239,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -271,7 +286,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -89,7 +92,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -135,7 +141,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -177,7 +186,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": true,
@@ -223,7 +235,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -269,7 +284,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -313,7 +331,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -357,7 +378,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -402,7 +426,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -486,7 +513,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -531,7 +561,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -188,7 +188,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -515,7 +515,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -563,7 +563,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -94,7 +94,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -143,7 +143,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -237,7 +237,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -286,7 +286,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -333,7 +333,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -380,7 +380,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -428,7 +428,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -94,7 +94,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2022.09.27"
+              "version_added": "2022.11.30"
             }
           },
           "status": {

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -233,7 +233,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -328,7 +328,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ReadableStreamBYOBReader.json
+++ b/api/ReadableStreamBYOBReader.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -131,7 +137,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -175,7 +184,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -219,7 +231,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -311,7 +326,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -86,7 +89,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -130,7 +136,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -174,7 +183,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStreamBYOBRequest.json
+++ b/api/ReadableStreamBYOBRequest.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -91,7 +91,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -138,7 +138,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -185,7 +185,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -51,7 +51,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -94,7 +97,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -138,7 +144,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -182,7 +191,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -226,7 +238,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStreamDefaultController.json
+++ b/api/ReadableStreamDefaultController.json
@@ -53,7 +53,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -99,7 +99,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -146,7 +146,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -193,7 +193,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -240,7 +240,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -51,7 +51,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -95,7 +98,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -139,7 +145,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -183,7 +192,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -227,7 +239,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -271,7 +286,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/ReadableStreamDefaultReader.json
+++ b/api/ReadableStreamDefaultReader.json
@@ -53,7 +53,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -100,7 +100,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -147,7 +147,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -194,7 +194,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -241,7 +241,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -288,7 +288,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -102,7 +102,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -605,7 +605,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -654,7 +654,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -703,7 +703,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -752,7 +752,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -941,7 +941,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1233,7 +1233,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1282,7 +1282,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1331,7 +1331,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1421,7 +1421,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1467,7 +1467,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1516,7 +1516,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1660,7 +1660,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1803,7 +1803,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1894,7 +1894,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1947,7 +1947,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -805,7 +805,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/Request.json
+++ b/api/Request.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -97,7 +100,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -597,7 +603,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -643,7 +652,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -689,7 +701,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -735,7 +750,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -785,7 +803,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -918,7 +939,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1207,7 +1231,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1253,7 +1280,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1299,7 +1329,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1386,7 +1419,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1429,7 +1465,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1475,7 +1514,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1616,7 +1658,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1756,7 +1801,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1844,7 +1892,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1894,7 +1945,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Response.json
+++ b/api/Response.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -91,7 +94,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -133,7 +139,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -176,7 +185,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -223,7 +235,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -269,7 +284,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -315,7 +333,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -357,7 +378,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -404,7 +428,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -454,7 +481,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -500,7 +530,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -547,7 +580,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -601,7 +637,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -647,7 +686,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -693,7 +735,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -738,7 +783,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -784,7 +832,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -831,7 +882,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -881,7 +935,10 @@
             "webview_android": {
               "version_added": "60"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -927,7 +984,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -973,7 +1033,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1019,7 +1082,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1065,7 +1131,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1111,7 +1180,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/Response.json
+++ b/api/Response.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -96,7 +96,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -141,7 +141,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -187,7 +187,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -237,7 +237,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -286,7 +286,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -335,7 +335,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -430,7 +430,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -532,7 +532,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -582,7 +582,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -639,7 +639,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -688,7 +688,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -737,7 +737,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -785,7 +785,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -834,7 +834,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -884,7 +884,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -937,7 +937,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -986,7 +986,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1035,7 +1035,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1084,7 +1084,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1133,7 +1133,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1182,7 +1182,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/Response.json
+++ b/api/Response.json
@@ -380,7 +380,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -483,7 +483,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -55,7 +55,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -213,7 +216,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -282,7 +288,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -384,7 +393,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -427,7 +439,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -471,7 +486,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -515,7 +533,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -559,7 +580,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -668,7 +692,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -741,7 +768,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -822,7 +852,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -990,7 +1023,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1162,7 +1198,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1472,7 +1511,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1580,7 +1622,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1648,7 +1693,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1751,7 +1799,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -57,7 +57,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -218,7 +218,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -290,7 +290,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -395,7 +395,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -441,7 +441,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -488,7 +488,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -535,7 +535,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -582,7 +582,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -694,7 +694,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -770,7 +770,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -854,7 +854,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1025,7 +1025,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1200,7 +1200,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1513,7 +1513,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1624,7 +1624,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1695,7 +1695,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1801,7 +1801,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -51,7 +51,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -103,7 +106,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -199,7 +205,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -251,7 +260,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -295,7 +307,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -339,7 +354,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TextDecoder.json
+++ b/api/TextDecoder.json
@@ -53,7 +53,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -108,7 +108,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -207,7 +207,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -262,7 +262,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -309,7 +309,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -356,7 +356,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/TextDecoderStream.json
+++ b/api/TextDecoderStream.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -233,7 +233,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -280,7 +280,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -327,7 +327,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/TextDecoderStream.json
+++ b/api/TextDecoderStream.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -131,7 +137,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -175,7 +184,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -219,7 +231,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -263,7 +278,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -307,7 +325,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -182,7 +182,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -231,7 +231,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -278,7 +278,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/TextEncoder.json
+++ b/api/TextEncoder.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -174,7 +180,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -220,7 +229,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -264,7 +276,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TextEncoderStream.json
+++ b/api/TextEncoderStream.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -186,7 +186,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -233,7 +233,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/TextEncoderStream.json
+++ b/api/TextEncoderStream.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -131,7 +137,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -175,7 +184,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -219,7 +231,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -45,7 +45,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -189,7 +189,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -277,7 +277,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -43,7 +43,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -87,7 +90,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -181,7 +187,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -266,7 +275,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/TransformStream.json
+++ b/api/TransformStream.json
@@ -92,7 +92,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2022.09.27"
+              "version_added": "2022.11.30"
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -184,7 +184,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -535,7 +535,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -71,7 +71,7 @@
           ],
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -130,7 +130,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -239,7 +239,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -288,7 +288,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -337,7 +337,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -386,7 +386,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -435,7 +435,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -487,7 +487,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -586,7 +586,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -636,7 +636,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -732,7 +732,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -781,7 +781,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -835,7 +835,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -885,7 +885,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -946,7 +946,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1001,7 +1001,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1052,7 +1052,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1103,7 +1103,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/URL.json
+++ b/api/URL.json
@@ -69,7 +69,10 @@
               "version_added": "4"
             }
           ],
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -125,7 +128,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -176,7 +182,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -228,7 +237,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -274,7 +286,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -320,7 +335,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -366,7 +384,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -412,7 +433,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -461,7 +485,10 @@
               "version_added": "6.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -506,7 +533,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -554,7 +584,10 @@
               "version_added": "6.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -601,7 +634,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -694,7 +730,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -740,7 +779,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -791,7 +833,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -838,7 +883,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -896,7 +944,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -948,7 +999,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -996,7 +1050,10 @@
               "version_added": "6.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1044,7 +1101,10 @@
               "version_added": "6.0"
             },
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -121,7 +121,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -34,7 +34,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -78,7 +78,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -166,7 +166,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -210,7 +210,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -295,7 +295,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -339,7 +339,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -383,7 +383,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -427,7 +427,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -471,7 +471,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -515,7 +515,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -559,7 +559,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -603,7 +603,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -32,7 +32,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -73,7 +76,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -113,7 +119,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -155,7 +164,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -196,7 +208,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -278,7 +293,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -319,7 +337,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -360,7 +381,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -401,7 +425,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -442,7 +469,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -483,7 +513,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -524,7 +557,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -565,7 +601,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/URLPattern.json
+++ b/api/URLPattern.json
@@ -121,7 +121,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.04.26"
+                "version_added": "2025.05.01"
               }
             },
             "status": {

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -58,7 +58,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -104,7 +107,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -154,7 +160,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -199,7 +208,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -246,7 +258,10 @@
                 "version_added": "7.2"
               },
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -293,7 +308,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -347,7 +365,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -395,7 +416,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -448,7 +472,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -500,7 +527,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -546,7 +576,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -592,7 +625,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -638,7 +674,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -686,7 +725,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -739,7 +781,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -785,7 +830,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -835,7 +883,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -887,7 +938,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -933,7 +987,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -985,7 +1042,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -1031,7 +1091,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -418,7 +418,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -727,7 +727,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -885,7 +885,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -60,7 +60,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -109,7 +109,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -162,7 +162,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -210,7 +210,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -260,7 +260,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -310,7 +310,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -367,7 +367,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -474,7 +474,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -529,7 +529,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -578,7 +578,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -627,7 +627,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -676,7 +676,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -783,7 +783,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -832,7 +832,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -940,7 +940,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -989,7 +989,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1044,7 +1044,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -1093,7 +1093,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/URLSearchParams.json
+++ b/api/URLSearchParams.json
@@ -418,7 +418,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.04.26"
+                "version_added": "2023.07.01"
               }
             },
             "status": {
@@ -727,7 +727,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.04.26"
+                "version_added": "2023.07.01"
               }
             },
             "status": {

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -52,7 +52,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -112,7 +115,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -368,7 +374,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -529,7 +538,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -687,7 +699,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -788,7 +803,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -859,7 +877,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -909,7 +930,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -54,7 +54,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -117,7 +117,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -376,7 +376,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -540,7 +540,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -701,7 +701,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -805,7 +805,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -879,7 +879,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -932,7 +932,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -49,7 +49,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -99,7 +102,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -149,7 +155,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -193,7 +202,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -243,7 +255,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -293,7 +308,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -104,7 +104,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2022.09.27"
+              "version_added": "2022.11.30"
             }
           },
           "status": {

--- a/api/WritableStream.json
+++ b/api/WritableStream.json
@@ -51,7 +51,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -104,7 +104,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -157,7 +157,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -204,7 +204,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -257,7 +257,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -310,7 +310,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -95,7 +95,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -139,7 +139,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -90,7 +93,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -131,7 +137,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -45,7 +45,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,
@@ -89,7 +92,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -135,7 +141,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -181,7 +190,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -227,7 +239,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -273,7 +288,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -319,7 +337,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -365,7 +386,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -411,7 +435,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/WritableStreamDefaultWriter.json
+++ b/api/WritableStreamDefaultWriter.json
@@ -47,7 +47,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {
@@ -94,7 +94,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -143,7 +143,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -192,7 +192,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -241,7 +241,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -290,7 +290,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -339,7 +339,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -388,7 +388,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -437,7 +437,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {

--- a/api/_globals/atob.json
+++ b/api/_globals/atob.json
@@ -46,7 +46,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -93,7 +96,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/btoa.json
+++ b/api/_globals/btoa.json
@@ -46,7 +46,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -93,7 +96,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/caches.json
+++ b/api/_globals/caches.json
@@ -31,7 +31,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -106,7 +109,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/clearInterval.json
+++ b/api/_globals/clearInterval.json
@@ -47,7 +47,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -100,7 +103,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/clearTimeout.json
+++ b/api/_globals/clearTimeout.json
@@ -49,7 +49,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -102,7 +105,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/console.json
+++ b/api/_globals/console.json
@@ -49,7 +49,10 @@
           "webview_android": {
             "version_added": "3"
           },
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -100,7 +103,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -162,7 +168,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -216,7 +225,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -270,7 +282,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -315,7 +330,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -370,7 +388,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -424,7 +445,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -603,7 +627,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -659,7 +686,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -755,7 +785,10 @@
             "webview_android": {
               "version_added": "37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -812,7 +845,10 @@
             "webview_android": {
               "version_added": "3"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -868,7 +904,10 @@
             "webview_android": {
               "version_added": "37"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -925,7 +964,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -981,7 +1023,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1046,7 +1091,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1111,7 +1159,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1229,7 +1280,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1283,7 +1337,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1337,7 +1394,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1384,7 +1444,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1449,7 +1512,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1783,7 +1849,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -1840,7 +1909,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/crypto.json
+++ b/api/_globals/crypto.json
@@ -51,7 +51,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -90,7 +93,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -38,7 +38,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/_globals/origin.json
+++ b/api/_globals/origin.json
@@ -28,7 +28,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/_globals/performance.json
+++ b/api/_globals/performance.json
@@ -50,7 +50,10 @@
           },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -99,7 +102,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/queueMicrotask.json
+++ b/api/_globals/queueMicrotask.json
@@ -35,7 +35,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/_globals/reportError.json
+++ b/api/_globals/reportError.json
@@ -32,7 +32,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/_globals/scheduler.json
+++ b/api/_globals/scheduler.json
@@ -26,7 +26,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,

--- a/api/_globals/setInterval.json
+++ b/api/_globals/setInterval.json
@@ -49,7 +49,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -102,7 +105,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -186,7 +192,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/setTimeout.json
+++ b/api/_globals/setTimeout.json
@@ -49,7 +49,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,
@@ -102,7 +105,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,
@@ -186,7 +192,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2022.09.27"
+            }
           },
           "status": {
             "experimental": false,

--- a/api/_globals/structuredClone.json
+++ b/api/_globals/structuredClone.json
@@ -47,7 +47,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2022.09.27"
+          }
         },
         "status": {
           "experimental": false,

--- a/browsers/workerd.json
+++ b/browsers/workerd.json
@@ -12,6 +12,41 @@
           "release_notes": "https://blog.cloudflare.com/workerd-open-source-workers-runtime/",
           "status": "retired"
         },
+        "2022.11.30": {
+          "release_date": "2022-11-30",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
+        "2023.03.01": {
+          "release_date": "2023-03-01",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
+        "2023.07.01": {
+          "release_date": "2023-07-01",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
+        "2025.05.01": {
+          "release_date": "2025-05-01",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
+        "2025.05.05": {
+          "release_date": "2025-05-05",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
+        "2025.05.19": {
+          "release_date": "2025-05-19",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
+        "2025.08.15": {
+          "release_date": "2025-08-15",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "retired"
+        },
         "2026.04.26": {
           "release_date": "2026-04-26",
           "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",

--- a/browsers/workerd.json
+++ b/browsers/workerd.json
@@ -1,0 +1,23 @@
+{
+  "browsers": {
+    "workerd": {
+      "name": "workerd",
+      "type": "server",
+      "pref_url": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+      "accepts_flags": true,
+      "accepts_webextensions": false,
+      "releases": {
+        "2022.09.27": {
+          "release_date": "2022-09-27",
+          "release_notes": "https://blog.cloudflare.com/workerd-open-source-workers-runtime/",
+          "status": "retired"
+        },
+        "2026.05.03": {
+          "release_date": "2026-05-03",
+          "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
+          "status": "current"
+        }
+      }
+    }
+  }
+}

--- a/browsers/workerd.json
+++ b/browsers/workerd.json
@@ -12,8 +12,8 @@
           "release_notes": "https://blog.cloudflare.com/workerd-open-source-workers-runtime/",
           "status": "retired"
         },
-        "2026.05.03": {
-          "release_date": "2026-05-03",
+        "2026.04.26": {
+          "release_date": "2026-04-26",
           "release_notes": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
           "status": "current"
         }

--- a/docs/data-guidelines/README.md
+++ b/docs/data-guidelines/README.md
@@ -9,7 +9,7 @@ This file contains general guidelines that apply to all features added to BCD. F
 
 ## Choosing a version number
 
-Use version numbers to reflect which _release line_ (major or minor but not patch-level releases) first supported a feature, rather than absolute version numbers. The only exception to this is Bun (see below).
+Use version numbers to reflect which _release line_ (major or minor but not patch-level releases) first supported a feature, rather than absolute version numbers. The exceptions to this are Bun and workerd (see below).
 
 BCD does not record absolute version numbers, such as Chrome 76.0.3809.46; instead BCD records significant releases (such as Chrome 76). Use the earliest applicable release line for recording support for a given feature. For example, if a feature was not added in Chrome 76.0.3700.43, but added in Chrome 76.0.3809.46, then the supported version is 76. Likewise, if a feature was not available in Safari 10.1.1, but added in Safari 10.1.3, then the supported version is 10.1.
 
@@ -39,6 +39,10 @@ This versioning scheme came at [Apple's request, in #2006](https://github.com/md
 ### Bun versioning
 
 Since Bun upgrades the WebKit version also in patch releases, which may include new features, BCD tracks patch releases for Bun.
+
+### workerd versioning
+
+For workerd, BCD versions are compatibility-date checkpoints encoded as dotted dates, not npm package versions. For example, `2026.03.24` represents `compatibilityDate = "2026-03-24"`. A `workerd.version_added` value means the feature is available by default at that compatibility date unless the support statement includes `flags`.
 
 ### Choosing `"preview"` values
 

--- a/docs/data-guidelines/browsers.md
+++ b/docs/data-guidelines/browsers.md
@@ -48,6 +48,20 @@ To add a new Node.js release:
    - ...`"esr"`, if it is the latest version within that major version
 4. Set the `status` all other versions within that major version to `"retired"`
 
+### workerd
+
+workerd uses compatibility dates as BCD versions, encoded as `YYYY.MM.DD` because BCD version values cannot use hyphenated dates. Do not use npm package versions such as `1.20260425.1` as `version_added` values unless BCD changes this policy.
+
+For workerd, `current` is the latest compatibility-date checkpoint supported by the latest published runtime package. Older checkpoints are marked `retired` for BCD tooling, but this does not mean workerd stopped accepting those compatibility dates.
+
+To update workerd release data, run:
+
+```sh
+npm run update-browser-releases -- --workerd
+```
+
+The updater reads the latest published workerd package and the corresponding source compatibility metadata. Add date checkpoints when support data references them or when a default-on compatibility flag affects a BCD-tracked feature.
+
 ## Addition of browsers
 
 BCD's [owners](../../GOVERNANCE.md) may choose to adopt a new browser or engine. To add a new browser to BCD, we require machine-readable release information, including version numbers, release dates, links to release notes or changelogs, and (if applicable) underlying engine version numbers.

--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -82,7 +85,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -127,7 +133,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AggregateError.json
+++ b/javascript/builtins/AggregateError.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -135,7 +135,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -936,7 +936,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -2284,7 +2284,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -2332,7 +2332,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -2380,7 +2380,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -2602,7 +2602,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -50,7 +50,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -109,7 +109,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -157,7 +157,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -216,7 +216,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -266,7 +266,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -316,7 +316,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -375,7 +375,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -425,7 +425,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -484,7 +484,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -536,7 +536,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -588,7 +588,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -636,7 +636,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -684,7 +684,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -732,7 +732,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -780,7 +780,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -839,7 +839,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -889,7 +889,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -986,7 +986,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1045,7 +1045,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1102,7 +1102,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1161,7 +1161,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1211,7 +1211,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1270,7 +1270,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1329,7 +1329,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1388,7 +1388,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1442,7 +1442,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1501,7 +1501,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1560,7 +1560,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1615,7 +1615,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1670,7 +1670,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1729,7 +1729,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1788,7 +1788,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1847,7 +1847,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1906,7 +1906,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1963,7 +1963,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2065,7 +2065,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2126,7 +2126,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2439,7 +2439,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2498,7 +2498,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2554,7 +2554,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2667,7 +2667,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2716,7 +2716,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2767,7 +2767,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Array.json
+++ b/javascript/builtins/Array.json
@@ -48,7 +48,10 @@
             "webview_android": {
               "version_added": "1"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -104,7 +107,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -149,7 +155,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -205,7 +214,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -252,7 +264,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -299,7 +314,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -355,7 +373,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -402,7 +423,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -458,7 +482,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -507,7 +534,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -556,7 +586,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -601,7 +634,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -646,7 +682,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -691,7 +730,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -736,7 +778,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -792,7 +837,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -839,7 +887,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -883,7 +934,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -930,7 +984,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -986,7 +1043,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1040,7 +1100,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1096,7 +1159,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1143,7 +1209,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1199,7 +1268,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1255,7 +1327,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1311,7 +1386,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1362,7 +1440,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1418,7 +1499,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1474,7 +1558,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1526,7 +1613,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1578,7 +1668,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1634,7 +1727,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1690,7 +1786,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1746,7 +1845,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1802,7 +1904,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1856,7 +1961,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1955,7 +2063,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2013,7 +2124,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2168,7 +2282,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2213,7 +2330,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2258,7 +2378,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2314,7 +2437,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2370,7 +2496,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2423,7 +2552,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2468,7 +2600,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2530,7 +2665,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2576,7 +2714,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2624,7 +2765,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -222,7 +222,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -322,7 +322,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -526,7 +526,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -671,7 +671,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -160,7 +160,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2026.04.26"
                 }
               },
               "status": {
@@ -269,7 +269,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -370,7 +370,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -418,7 +418,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -466,7 +466,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -573,7 +573,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -620,7 +620,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/ArrayBuffer.json
+++ b/javascript/builtins/ArrayBuffer.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -152,7 +158,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -211,7 +220,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -255,7 +267,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -305,7 +320,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -350,7 +368,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -395,7 +416,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -440,7 +464,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -497,7 +524,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -541,7 +571,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -585,7 +618,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -633,7 +669,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncDisposableStack.json
+++ b/javascript/builtins/AsyncDisposableStack.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -79,7 +82,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -123,7 +129,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -167,7 +176,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -211,7 +223,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -255,7 +270,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -299,7 +317,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -343,7 +364,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -387,7 +411,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncDisposableStack.json
+++ b/javascript/builtins/AsyncDisposableStack.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -84,7 +84,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -131,7 +131,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -178,7 +178,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -225,7 +225,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -272,7 +272,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -319,7 +319,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -366,7 +366,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -413,7 +413,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -86,7 +89,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncFunction.json
+++ b/javascript/builtins/AsyncFunction.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -91,7 +91,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/AsyncGenerator.json
+++ b/javascript/builtins/AsyncGenerator.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -86,7 +86,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -134,7 +134,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -182,7 +182,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/AsyncGenerator.json
+++ b/javascript/builtins/AsyncGenerator.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -81,7 +84,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -126,7 +132,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -171,7 +180,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/AsyncGeneratorFunction.json
+++ b/javascript/builtins/AsyncGeneratorFunction.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -82,7 +85,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -80,7 +83,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -126,7 +132,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -85,7 +85,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/AsyncIterator.json
+++ b/javascript/builtins/AsyncIterator.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -134,7 +134,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -42,7 +42,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -135,7 +135,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -185,7 +185,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -235,7 +235,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -285,7 +285,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -335,7 +335,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -385,7 +385,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -435,7 +435,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -485,7 +485,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -582,7 +582,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -632,7 +632,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -682,7 +682,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -750,7 +750,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -800,7 +800,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -532,7 +532,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Atomics.json
+++ b/javascript/builtins/Atomics.json
@@ -40,7 +40,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -130,7 +133,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -177,7 +183,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -224,7 +233,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -271,7 +283,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -318,7 +333,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -365,7 +383,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -412,7 +433,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -459,7 +483,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -503,7 +530,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -550,7 +580,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -597,7 +630,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -644,7 +680,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -709,7 +748,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -756,7 +798,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -132,7 +132,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -180,7 +180,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -227,7 +227,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -373,7 +373,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -421,7 +421,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/BigInt.json
+++ b/javascript/builtins/BigInt.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -127,7 +130,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -172,7 +178,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -216,7 +225,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -359,7 +371,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -404,7 +419,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/BigInt64Array.json
+++ b/javascript/builtins/BigInt64Array.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -82,7 +85,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -39,7 +39,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -87,7 +87,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/BigUint64Array.json
+++ b/javascript/builtins/BigUint64Array.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -82,7 +85,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -162,7 +162,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -219,7 +219,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Boolean.json
+++ b/javascript/builtins/Boolean.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -154,7 +160,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -208,7 +217,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -48,7 +48,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -104,7 +107,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -149,7 +155,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -262,7 +274,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -318,7 +333,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -363,7 +381,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -408,7 +429,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -452,7 +476,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -508,7 +535,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -564,7 +594,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -620,7 +653,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -676,7 +712,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -732,7 +771,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -788,7 +830,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -844,7 +889,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -900,7 +948,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -945,7 +996,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -990,7 +1044,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1034,7 +1091,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1090,7 +1150,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1146,7 +1209,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1202,7 +1268,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1258,7 +1327,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1314,7 +1386,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1370,7 +1445,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1426,7 +1504,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1482,7 +1563,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -478,7 +478,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -1093,7 +1093,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/DataView.json
+++ b/javascript/builtins/DataView.json
@@ -50,7 +50,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -109,7 +109,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -157,7 +157,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -276,7 +276,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -335,7 +335,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -383,7 +383,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -431,7 +431,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -537,7 +537,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -596,7 +596,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -655,7 +655,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -714,7 +714,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -773,7 +773,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -832,7 +832,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -891,7 +891,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -950,7 +950,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -998,7 +998,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1046,7 +1046,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1152,7 +1152,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1211,7 +1211,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1270,7 +1270,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1329,7 +1329,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1388,7 +1388,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1447,7 +1447,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1506,7 +1506,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1565,7 +1565,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -49,7 +49,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -106,7 +106,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -163,7 +163,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -211,7 +211,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -269,7 +269,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -326,7 +326,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -383,7 +383,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -440,7 +440,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -497,7 +497,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -554,7 +554,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -611,7 +611,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -668,7 +668,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -725,7 +725,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -782,7 +782,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -839,7 +839,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -896,7 +896,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -953,7 +953,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1010,7 +1010,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1067,7 +1067,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1124,7 +1124,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1181,7 +1181,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1238,7 +1238,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1295,7 +1295,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1352,7 +1352,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1409,7 +1409,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1519,7 +1519,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1576,7 +1576,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1633,7 +1633,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1690,7 +1690,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1747,7 +1747,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1804,7 +1804,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1861,7 +1861,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1918,7 +1918,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1975,7 +1975,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2032,7 +2032,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2089,7 +2089,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2146,7 +2146,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2203,7 +2203,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2260,7 +2260,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2317,7 +2317,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2374,7 +2374,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2431,7 +2431,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2488,7 +2488,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2545,7 +2545,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2602,7 +2602,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2662,7 +2662,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2885,7 +2885,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3108,7 +3108,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3328,7 +3328,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3427,7 +3427,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3484,7 +3484,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3541,7 +3541,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3592,7 +3592,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -47,7 +47,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -101,7 +104,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -155,7 +161,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -200,7 +209,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -255,7 +267,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -309,7 +324,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -363,7 +381,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -417,7 +438,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -471,7 +495,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -525,7 +552,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -579,7 +609,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -633,7 +666,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -687,7 +723,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -741,7 +780,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -795,7 +837,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -849,7 +894,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -903,7 +951,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -957,7 +1008,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1011,7 +1065,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1065,7 +1122,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1119,7 +1179,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1173,7 +1236,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1227,7 +1293,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1281,7 +1350,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1335,7 +1407,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1442,7 +1517,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1496,7 +1574,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1550,7 +1631,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1604,7 +1688,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1658,7 +1745,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1712,7 +1802,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1766,7 +1859,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1820,7 +1916,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1874,7 +1973,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1928,7 +2030,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1982,7 +2087,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2036,7 +2144,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2090,7 +2201,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2144,7 +2258,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2198,7 +2315,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2252,7 +2372,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2306,7 +2429,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2360,7 +2486,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2414,7 +2543,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2468,7 +2600,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2525,7 +2660,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2745,7 +2883,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2965,7 +3106,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3182,7 +3326,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3278,7 +3425,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3332,7 +3482,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3386,7 +3539,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3434,7 +3590,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/DisposableStack.json
+++ b/javascript/builtins/DisposableStack.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -79,7 +82,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -123,7 +129,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -167,7 +176,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -211,7 +223,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -255,7 +270,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -299,7 +317,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -343,7 +364,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -387,7 +411,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/DisposableStack.json
+++ b/javascript/builtins/DisposableStack.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -84,7 +84,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -131,7 +131,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -178,7 +178,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -225,7 +225,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -272,7 +272,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -319,7 +319,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -366,7 +366,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -413,7 +413,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -218,7 +224,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -260,7 +269,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -307,7 +319,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -435,7 +450,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -526,7 +544,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -580,7 +601,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -676,7 +700,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -716,7 +743,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -770,7 +800,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -226,7 +226,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -271,7 +271,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -321,7 +321,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -546,7 +546,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -603,7 +603,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -702,7 +702,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -745,7 +745,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -802,7 +802,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -452,7 +452,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/EvalError.json
+++ b/javascript/builtins/EvalError.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/FinalizationRegistry.json
+++ b/javascript/builtins/FinalizationRegistry.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.05.05"
+            }
           },
           "status": {
             "experimental": false,
@@ -82,7 +85,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2025.05.05"
+              }
             },
             "status": {
               "experimental": false,
@@ -127,7 +133,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2025.05.05"
+              }
             },
             "status": {
               "experimental": false,
@@ -216,7 +225,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2025.05.05"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -80,7 +83,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Float16Array.json
+++ b/javascript/builtins/Float16Array.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -85,7 +85,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Float32Array.json
+++ b/javascript/builtins/Float32Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Float64Array.json
+++ b/javascript/builtins/Float64Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -194,7 +194,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -302,7 +302,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -361,7 +361,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -419,7 +419,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -476,7 +476,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -570,7 +570,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -670,7 +670,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -827,7 +827,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -922,7 +922,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Function.json
+++ b/javascript/builtins/Function.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -186,7 +192,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -291,7 +300,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -347,7 +359,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -402,7 +417,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -456,7 +474,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -547,7 +568,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -644,7 +668,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -798,7 +825,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -890,7 +920,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -85,7 +88,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -132,7 +138,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -179,7 +188,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Generator.json
+++ b/javascript/builtins/Generator.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -90,7 +90,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -140,7 +140,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -190,7 +190,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -86,7 +89,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/GeneratorFunction.json
+++ b/javascript/builtins/GeneratorFunction.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -91,7 +91,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Int16Array.json
+++ b/javascript/builtins/Int16Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Int32Array.json
+++ b/javascript/builtins/Int32Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Int8Array.json
+++ b/javascript/builtins/Int8Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -45,7 +45,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -95,7 +95,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -143,7 +143,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Intl.json
+++ b/javascript/builtins/Intl.json
@@ -43,7 +43,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -90,7 +93,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -135,7 +141,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -969,7 +969,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -177,7 +180,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -227,7 +233,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -277,7 +286,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -327,7 +339,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -377,7 +392,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -427,7 +445,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -477,7 +498,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -527,7 +551,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -577,7 +604,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -627,7 +657,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -677,7 +710,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -727,7 +763,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -863,7 +902,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -925,7 +967,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -182,7 +182,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -235,7 +235,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -288,7 +288,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -341,7 +341,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -394,7 +394,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -447,7 +447,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -500,7 +500,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -553,7 +553,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -606,7 +606,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -659,7 +659,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -712,7 +712,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -765,7 +765,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -904,7 +904,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -48,7 +48,10 @@
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -192,7 +195,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -337,7 +343,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/JSON.json
+++ b/javascript/builtins/JSON.json
@@ -50,7 +50,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -197,7 +197,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -345,7 +345,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -44,7 +44,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -97,7 +97,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -145,7 +145,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -197,7 +197,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -251,7 +251,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -304,7 +304,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -354,7 +354,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -407,7 +407,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -460,7 +460,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -643,7 +643,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -739,7 +739,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -794,7 +794,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -848,7 +848,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -898,7 +898,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -963,7 +963,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1014,7 +1014,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -590,7 +590,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -42,7 +42,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -92,7 +95,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -137,7 +143,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -186,7 +195,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -237,7 +249,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -287,7 +302,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -334,7 +352,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -384,7 +405,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -434,7 +458,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -561,7 +588,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -611,7 +641,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -704,7 +737,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -756,7 +792,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -807,7 +846,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -854,7 +896,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -916,7 +961,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -964,7 +1012,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -1356,7 +1356,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -99,7 +102,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -153,7 +159,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -207,7 +216,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -261,7 +273,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -315,7 +330,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -369,7 +387,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -423,7 +444,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -477,7 +501,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -531,7 +558,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -585,7 +615,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -632,7 +665,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -686,7 +722,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -733,7 +772,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -787,7 +829,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -841,7 +886,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -888,7 +936,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -935,7 +986,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -989,7 +1043,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1036,7 +1093,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1090,7 +1150,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1137,7 +1200,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1191,7 +1257,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1238,7 +1307,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1282,7 +1354,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1336,7 +1411,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1383,7 +1461,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1430,7 +1511,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1479,7 +1563,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1533,7 +1620,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1580,7 +1670,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1627,7 +1720,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1674,7 +1770,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1728,7 +1827,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1782,7 +1884,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1836,7 +1941,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1890,7 +1998,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1944,7 +2055,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1991,7 +2105,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2045,7 +2162,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2092,7 +2212,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2146,7 +2269,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2244,7 +2370,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2291,7 +2420,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2338,7 +2470,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Math.json
+++ b/javascript/builtins/Math.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -104,7 +104,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -161,7 +161,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -218,7 +218,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -275,7 +275,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -332,7 +332,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -389,7 +389,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -446,7 +446,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -503,7 +503,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -560,7 +560,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -617,7 +617,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -667,7 +667,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -724,7 +724,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -774,7 +774,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -831,7 +831,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -888,7 +888,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -938,7 +938,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -988,7 +988,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1045,7 +1045,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1095,7 +1095,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1152,7 +1152,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1202,7 +1202,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1259,7 +1259,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1309,7 +1309,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1413,7 +1413,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1463,7 +1463,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1513,7 +1513,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1565,7 +1565,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1622,7 +1622,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1672,7 +1672,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1722,7 +1722,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1772,7 +1772,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1829,7 +1829,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1886,7 +1886,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1943,7 +1943,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2000,7 +2000,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2057,7 +2057,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2107,7 +2107,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2164,7 +2164,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2214,7 +2214,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2271,7 +2271,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2372,7 +2372,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2422,7 +2422,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2472,7 +2472,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -97,7 +97,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -147,7 +147,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -204,7 +204,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -254,7 +254,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -311,7 +311,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -368,7 +368,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -425,7 +425,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -483,7 +483,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -540,7 +540,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -590,7 +590,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -640,7 +640,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -690,7 +690,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -740,7 +740,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -790,7 +790,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -840,7 +840,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -897,7 +897,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -954,7 +954,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1016,7 +1016,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1193,7 +1193,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1250,7 +1250,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1307,7 +1307,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Number.json
+++ b/javascript/builtins/Number.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -92,7 +95,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -139,7 +145,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -193,7 +202,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -240,7 +252,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -294,7 +309,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -348,7 +366,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -402,7 +423,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -457,7 +481,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -511,7 +538,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -558,7 +588,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -605,7 +638,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -652,7 +688,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -699,7 +738,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -746,7 +788,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -793,7 +838,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -847,7 +895,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -901,7 +952,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -960,7 +1014,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1134,7 +1191,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1188,7 +1248,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1242,7 +1305,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -50,7 +50,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -109,7 +109,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -159,7 +159,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -215,7 +215,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -274,7 +274,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -336,7 +336,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -395,7 +395,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -464,7 +464,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -526,7 +526,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -576,7 +576,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -633,7 +633,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -681,7 +681,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -748,7 +748,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -798,7 +798,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -857,7 +857,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -907,7 +907,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -966,7 +966,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1068,7 +1068,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1129,7 +1129,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1179,7 +1179,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1236,7 +1236,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1293,7 +1293,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1354,7 +1354,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1411,7 +1411,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1470,7 +1470,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1529,7 +1529,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1588,7 +1588,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1645,7 +1645,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1755,7 +1755,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1815,7 +1815,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1872,7 +1872,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1925,7 +1925,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1984,7 +1984,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2044,7 +2044,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2103,7 +2103,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2153,7 +2153,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1020,7 +1020,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -48,7 +48,10 @@
             "webview_android": {
               "version_added": "1"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -104,7 +107,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -151,7 +157,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -204,7 +213,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -260,7 +272,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -319,7 +334,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -375,7 +393,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -441,7 +462,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -500,7 +524,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -547,7 +574,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -601,7 +631,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -646,7 +679,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -710,7 +746,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -757,7 +796,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -813,7 +855,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -860,7 +905,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -916,7 +964,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -967,7 +1018,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1012,7 +1066,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1070,7 +1127,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1117,7 +1177,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1171,7 +1234,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1225,7 +1291,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1283,7 +1352,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1337,7 +1409,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1393,7 +1468,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1449,7 +1527,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1505,7 +1586,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1559,7 +1643,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1666,7 +1753,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1723,7 +1813,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1777,7 +1870,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1827,7 +1923,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1883,7 +1982,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1940,7 +2042,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1996,7 +2101,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2043,7 +2151,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -94,7 +94,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -145,7 +145,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -194,7 +194,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -242,7 +242,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -293,7 +293,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -344,7 +344,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -437,7 +437,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -488,7 +488,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -539,7 +539,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -590,7 +590,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -733,7 +733,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -637,7 +637,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -684,7 +684,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -89,7 +92,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -137,7 +143,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -183,7 +192,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -228,7 +240,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -276,7 +291,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -324,7 +342,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -414,7 +435,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -462,7 +486,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -510,7 +537,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -558,7 +588,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -602,7 +635,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -646,7 +682,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -692,7 +731,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -86,7 +89,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -745,7 +751,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Proxy.json
+++ b/javascript/builtins/Proxy.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -91,7 +91,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -753,7 +753,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/RangeError.json
+++ b/javascript/builtins/RangeError.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/ReferenceError.json
+++ b/javascript/builtins/ReferenceError.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -90,7 +90,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -140,7 +140,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -190,7 +190,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -240,7 +240,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -290,7 +290,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -340,7 +340,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -390,7 +390,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -440,7 +440,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -490,7 +490,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -540,7 +540,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -590,7 +590,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -640,7 +640,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -690,7 +690,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Reflect.json
+++ b/javascript/builtins/Reflect.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -85,7 +88,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -132,7 +138,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -179,7 +188,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -226,7 +238,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -273,7 +288,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -320,7 +338,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -367,7 +388,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -414,7 +438,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -461,7 +488,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -508,7 +538,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -555,7 +588,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -602,7 +638,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -649,7 +688,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -297,7 +297,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -1771,7 +1771,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -154,7 +160,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -239,7 +248,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -283,7 +295,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -337,7 +352,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -386,7 +404,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -440,7 +461,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -533,7 +557,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -587,7 +614,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -687,7 +717,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -741,7 +774,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -797,7 +833,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -853,7 +892,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -909,7 +951,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -963,7 +1008,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1065,7 +1113,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1121,7 +1172,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1175,7 +1229,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1362,7 +1419,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1506,7 +1566,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1560,7 +1623,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1656,7 +1722,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1700,7 +1769,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1748,7 +1820,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1795,7 +1870,10 @@
                 "version_added": "5.0"
               },
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1841,7 +1919,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1889,7 +1970,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1937,7 +2021,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1983,7 +2070,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/RegExp.json
+++ b/javascript/builtins/RegExp.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -162,7 +162,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -250,7 +250,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -354,7 +354,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -406,7 +406,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -463,7 +463,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -559,7 +559,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -616,7 +616,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -719,7 +719,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -776,7 +776,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -835,7 +835,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -894,7 +894,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -953,7 +953,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1010,7 +1010,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1115,7 +1115,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1174,7 +1174,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1231,7 +1231,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1421,7 +1421,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1568,7 +1568,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1625,7 +1625,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1724,7 +1724,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1822,7 +1822,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1872,7 +1872,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1921,7 +1921,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1972,7 +1972,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2023,7 +2023,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2072,7 +2072,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -42,7 +42,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -92,7 +95,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -137,7 +143,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -186,7 +195,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -239,7 +251,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -289,7 +304,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -339,7 +357,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -383,7 +404,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -430,7 +454,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -480,7 +507,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -530,7 +560,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -574,7 +607,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -618,7 +654,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -662,7 +701,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -706,7 +748,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -799,7 +844,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -850,7 +898,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -894,7 +945,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -938,7 +992,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -985,7 +1042,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1047,7 +1107,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1095,7 +1158,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -44,7 +44,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -97,7 +97,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -145,7 +145,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -197,7 +197,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -253,7 +253,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -306,7 +306,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -359,7 +359,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -456,7 +456,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -509,7 +509,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -562,7 +562,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -846,7 +846,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -900,7 +900,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1044,7 +1044,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1109,7 +1109,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1160,7 +1160,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Set.json
+++ b/javascript/builtins/Set.json
@@ -406,7 +406,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -609,7 +609,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -656,7 +656,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -703,7 +703,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -750,7 +750,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -947,7 +947,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -994,7 +994,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -41,7 +41,10 @@
             "webview_android": {
               "version_added": false
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -90,7 +93,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -186,7 +192,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -233,7 +242,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -280,7 +292,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -327,7 +342,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -376,7 +394,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -426,7 +447,10 @@
               "webview_android": {
                 "version_added": false
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -43,7 +43,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -95,7 +95,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -194,7 +194,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -396,7 +396,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -449,7 +449,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/SharedArrayBuffer.json
+++ b/javascript/builtins/SharedArrayBuffer.json
@@ -244,7 +244,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -294,7 +294,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -344,7 +344,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -50,7 +50,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -109,7 +109,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -166,7 +166,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -214,7 +214,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -271,7 +271,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -328,7 +328,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -385,7 +385,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -442,7 +442,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -499,7 +499,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -549,7 +549,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -606,7 +606,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -658,7 +658,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -715,7 +715,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -772,7 +772,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -829,7 +829,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -886,7 +886,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -936,7 +936,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -993,7 +993,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1050,7 +1050,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1154,7 +1154,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1211,7 +1211,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1268,7 +1268,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1325,7 +1325,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1387,7 +1387,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1572,7 +1572,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1620,7 +1620,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1670,7 +1670,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1720,7 +1720,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1770,7 +1770,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1820,7 +1820,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1876,7 +1876,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1941,7 +1941,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1989,7 +1989,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2046,7 +2046,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2103,7 +2103,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2160,7 +2160,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2217,7 +2217,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2269,7 +2269,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2326,7 +2326,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2383,7 +2383,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2440,7 +2440,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2497,7 +2497,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2554,7 +2554,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2614,7 +2614,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2739,7 +2739,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2863,7 +2863,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2920,7 +2920,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2977,7 +2977,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3084,7 +3084,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3164,7 +3164,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3244,7 +3244,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3353,7 +3353,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -3418,7 +3418,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -1097,7 +1097,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -3025,7 +3025,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/String.json
+++ b/javascript/builtins/String.json
@@ -48,7 +48,10 @@
             "webview_android": {
               "version_added": "1"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -104,7 +107,10 @@
               "webview_android": {
                 "version_added": "1"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -158,7 +164,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -203,7 +212,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -257,7 +269,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -311,7 +326,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -365,7 +383,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -419,7 +440,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -473,7 +497,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -520,7 +547,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -574,7 +604,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -623,7 +656,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -677,7 +713,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -731,7 +770,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -785,7 +827,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -839,7 +884,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -886,7 +934,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -940,7 +991,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -994,7 +1048,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1038,7 +1095,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1092,7 +1152,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1146,7 +1209,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1200,7 +1266,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1254,7 +1323,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1313,7 +1385,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1495,7 +1570,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1540,7 +1618,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1587,7 +1668,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1634,7 +1718,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1681,7 +1768,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1728,7 +1818,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1781,7 +1874,10 @@
               "webview_android": {
                 "version_added": "41"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1843,7 +1939,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1888,7 +1987,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1942,7 +2044,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1996,7 +2101,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2050,7 +2158,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2104,7 +2215,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2153,7 +2267,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2207,7 +2324,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2261,7 +2381,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2315,7 +2438,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2369,7 +2495,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2423,7 +2552,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2480,7 +2612,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2602,7 +2737,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2723,7 +2861,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2777,7 +2918,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2831,7 +2975,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2876,7 +3023,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2932,7 +3082,10 @@
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3009,7 +3162,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3086,7 +3242,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3192,7 +3351,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -3254,7 +3416,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/SuppressedError.json
+++ b/javascript/builtins/SuppressedError.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2026.04.26"
             }
           },
           "status": {
@@ -84,7 +84,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -131,7 +131,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -178,7 +178,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/SuppressedError.json
+++ b/javascript/builtins/SuppressedError.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -79,7 +82,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -123,7 +129,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -167,7 +176,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -153,7 +153,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -318,7 +318,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -42,7 +42,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -92,7 +92,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -201,7 +201,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -257,7 +257,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -368,7 +368,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -418,7 +418,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -468,7 +468,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -518,7 +518,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -568,7 +568,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -616,7 +616,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -664,7 +664,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -712,7 +712,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -760,7 +760,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -810,7 +810,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -858,7 +858,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -908,7 +908,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -958,7 +958,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1008,7 +1008,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1100,7 +1100,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1150,7 +1150,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1201,7 +1201,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/Symbol.json
+++ b/javascript/builtins/Symbol.json
@@ -40,7 +40,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -87,7 +90,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -145,7 +151,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -190,7 +199,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -243,7 +255,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -301,7 +316,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -348,7 +366,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -395,7 +416,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -442,7 +466,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -489,7 +516,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -536,7 +566,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -581,7 +614,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -626,7 +662,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -671,7 +710,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -716,7 +758,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -763,7 +808,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -808,7 +856,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -855,7 +906,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -902,7 +956,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -949,7 +1006,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1038,7 +1098,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1085,7 +1148,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1133,7 +1199,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/SyntaxError.json
+++ b/javascript/builtins/SyntaxError.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/TypeError.json
+++ b/javascript/builtins/TypeError.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -2103,7 +2103,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -2151,7 +2151,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {
@@ -2306,7 +2306,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -157,7 +157,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -218,7 +218,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -279,7 +279,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -340,7 +340,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -396,7 +396,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -446,7 +446,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -496,7 +496,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -546,7 +546,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -596,7 +596,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -646,7 +646,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -696,7 +696,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -746,7 +746,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -794,7 +794,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -842,7 +842,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -892,7 +892,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -942,7 +942,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -992,7 +992,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1105,7 +1105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1154,7 +1154,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1204,7 +1204,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1254,7 +1254,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1305,7 +1305,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1366,7 +1366,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1416,7 +1416,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1577,7 +1577,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1627,7 +1627,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1677,7 +1677,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1727,7 +1727,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1788,7 +1788,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1838,7 +1838,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1888,7 +1888,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1938,7 +1938,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -1999,7 +1999,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2055,7 +2055,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2208,7 +2208,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2258,7 +2258,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2371,7 +2371,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -2422,7 +2422,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/TypedArray.json
+++ b/javascript/builtins/TypedArray.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -152,7 +155,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -210,7 +216,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -268,7 +277,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -326,7 +338,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -379,7 +394,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -426,7 +444,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -473,7 +494,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -520,7 +544,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -567,7 +594,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -614,7 +644,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -661,7 +694,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -708,7 +744,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -753,7 +792,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -798,7 +840,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -845,7 +890,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -892,7 +940,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -939,7 +990,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1049,7 +1103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1095,7 +1152,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1142,7 +1202,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1189,7 +1252,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1237,7 +1303,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1295,7 +1364,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1342,7 +1414,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1500,7 +1575,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1547,7 +1625,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1594,7 +1675,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1641,7 +1725,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1699,7 +1786,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1746,7 +1836,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1793,7 +1886,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1840,7 +1936,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1898,7 +1997,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1951,7 +2053,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -1996,7 +2101,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2041,7 +2149,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2095,7 +2206,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2142,7 +2256,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2187,7 +2304,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2249,7 +2369,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -2297,7 +2420,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -48,7 +48,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -105,7 +105,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/URIError.json
+++ b/javascript/builtins/URIError.json
@@ -46,7 +46,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -100,7 +103,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Uint16Array.json
+++ b/javascript/builtins/Uint16Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Uint32Array.json
+++ b/javascript/builtins/Uint32Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -52,7 +52,7 @@
             },
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -113,7 +113,7 @@
               },
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -168,7 +168,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -217,7 +217,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {

--- a/javascript/builtins/Uint8ClampedArray.json
+++ b/javascript/builtins/Uint8ClampedArray.json
@@ -50,7 +50,10 @@
             "webview_android": {
               "version_added": "4"
             },
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -108,7 +111,10 @@
               "webview_android": {
                 "version_added": "4"
               },
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -160,7 +166,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -206,7 +215,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -42,7 +42,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -92,7 +95,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -186,7 +192,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -238,7 +247,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -289,7 +301,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -416,7 +431,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -469,7 +487,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -513,7 +534,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -44,7 +44,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -97,7 +97,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -194,7 +194,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -249,7 +249,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -303,7 +303,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -433,7 +433,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -489,7 +489,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -536,7 +536,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/WeakRef.json
+++ b/javascript/builtins/WeakRef.json
@@ -37,7 +37,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2025.05.05"
+            }
           },
           "status": {
             "experimental": false,
@@ -82,7 +85,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2025.05.05"
+              }
             },
             "status": {
               "experimental": false,
@@ -171,7 +177,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2025.05.05"
+              }
             },
             "status": {
               "experimental": false,

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -383,7 +383,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2026.04.26"
               }
             },
             "status": {

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -41,7 +41,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -91,7 +91,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -185,7 +185,7 @@
                 "webview_android": "mirror",
                 "webview_ios": "mirror",
                 "workerd": {
-                  "version_added": "2026.05.03"
+                  "version_added": "2022.09.27"
                 }
               },
               "status": {
@@ -236,7 +236,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -286,7 +286,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -336,7 +336,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/javascript/builtins/WeakSet.json
+++ b/javascript/builtins/WeakSet.json
@@ -39,7 +39,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -86,7 +89,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -177,7 +183,10 @@
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
                 "webview_android": "mirror",
-                "webview_ios": "mirror"
+                "webview_ios": "mirror",
+                "workerd": {
+                  "version_added": "2026.05.03"
+                }
               },
               "status": {
                 "experimental": false,
@@ -225,7 +234,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -272,7 +284,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -319,7 +334,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -363,7 +381,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "show-errors": "npm test 1> /dev/null",
     "test": "npm run format && npm run lint && npm run unittest",
     "traverse": "node scripts/traverse.js",
+    "workerd-release-map": "node scripts/workerd-release-map.js",
     "update-browser-releases": "node scripts/update-browser-releases/index.js",
     "bcd": "node scripts/bulk-editor/index.js",
     "split": "node scripts/split.js",

--- a/schemas/browsers-schema.md
+++ b/schemas/browsers-schema.md
@@ -104,6 +104,7 @@ The following table indicates initial versions for browsers in BCD. These are th
 | iOS Safari       | 1               |                                                                                                                                                                          |
 | Samsung Internet | 1.0             |                                                                                                                                                                          |
 | WebView Android  | 1               |                                                                                                                                                                          |
+| workerd          | 2022.09.27      | Versions are compatibility-date checkpoints encoded as `YYYY.MM.DD`; `2022.09.27` maps to `compatibilityDate = "2022-09-27"`.                                            |
 
 ## Exports
 

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -214,6 +214,7 @@ The currently accepted browser identifiers should be declared in alphabetical or
 - `samsunginternet_android`, the Samsung Internet browser (Android version)
 - `webview_android`, WebView, the embedded browser for Android applications
 - `webview_ios`, WebKit WebView, the embedded browser for iOS applications, based on the iOS version
+- `workerd`, workerd JavaScript runtime built on Chrome's V8 JavaScript engine
 
 Desktop browser identifiers are mandatory, with the `version_added` property set to `null` if support is unknown.
 

--- a/schemas/compat-data.schema.json
+++ b/schemas/compat-data.schema.json
@@ -176,7 +176,8 @@
           "safari_ios",
           "samsunginternet_android",
           "webview_android",
-          "webview_ios"
+          "webview_ios",
+          "workerd"
         ]
       },
       "additionalProperties": {

--- a/scripts/update-browser-releases/index.js
+++ b/scripts/update-browser-releases/index.js
@@ -8,6 +8,7 @@ import { updateEdgeReleases } from './edge.js';
 import { updateFirefoxReleases } from './firefox.js';
 import { updateOperaReleases } from './opera.js';
 import { updateSafariReleases } from './safari.js';
+import { updateWorkerdReleases } from './workerd.js';
 
 const argv = yargs(process.argv.slice(2))
   .usage('Usage: npm run update-browser-releases -- (flags)')
@@ -43,6 +44,11 @@ const argv = yargs(process.argv.slice(2))
   })
   .option('bun', {
     describe: 'Update Bun',
+    type: 'boolean',
+    group: 'Engine selection:',
+  })
+  .option('workerd', {
+    describe: 'Update workerd',
     type: 'boolean',
     group: 'Engine selection:',
   })
@@ -83,7 +89,8 @@ const updateAllBrowsers =
     argv['edge'] ||
     argv['opera'] ||
     argv['safari'] ||
-    argv['bun']
+    argv['bun'] ||
+    argv['workerd']
   );
 const updateChrome = argv['chrome'] || updateAllBrowsers;
 const updateWebview = argv['webview'] || updateAllBrowsers;
@@ -92,6 +99,7 @@ const updateEdge = argv['edge'] || updateAllBrowsers;
 const updateOpera = argv['opera'] || updateAllBrowsers;
 const updateSafari = argv['safari'] || updateAllBrowsers;
 const updateBun = argv['bun'] || updateAllBrowsers;
+const updateWorkerd = argv['workerd'] || updateAllBrowsers;
 const updateAllDevices =
   argv['alldevices'] || !(argv['mobile'] || argv['desktop']);
 const updateMobile = argv['mobile'] || updateAllDevices;
@@ -236,6 +244,11 @@ const options = {
     bcdFile: './browsers/bun.json',
     bcdBrowserName: 'bun',
   }),
+  workerd: /** @type {const} */ ({
+    browserName: 'workerd',
+    bcdFile: './browsers/workerd.json',
+    bcdBrowserName: 'workerd',
+  }),
 };
 
 if (!debug) {
@@ -276,6 +289,7 @@ const results = await Promise.all([
       ]
     : []),
   updateBun && updateBunReleases(options.bun),
+  updateWorkerd && updateWorkerdReleases(options.workerd),
 ]);
 
 const result = results.filter(Boolean).join('\n\n');

--- a/scripts/update-browser-releases/workerd.js
+++ b/scripts/update-browser-releases/workerd.js
@@ -51,6 +51,14 @@ const dashedDatePattern = /^\d{4}-\d{2}-\d{2}$/;
 const dottedDatePattern = /^\d{4}\.\d{2}\.\d{2}$/;
 
 /**
+ * Returns the earlier of two ISO dates.
+ * @param {string} first The first date.
+ * @param {string} second The second date.
+ * @returns {string} The earlier date.
+ */
+const minDate = (first, second) => (first < second ? first : second);
+
+/**
  * Fetches text with a consistent release updater user agent.
  * @param {string} url The URL to fetch.
  * @returns {Promise<string>} The response text.
@@ -315,6 +323,7 @@ export const updateWorkerdReleases = async (options) => {
 
   let metadata;
   let maximumCompatibilityDate;
+  let releaseVersion;
   let compatibilityDateSource;
 
   try {
@@ -323,6 +332,12 @@ export const updateWorkerdReleases = async (options) => {
       await fetchLatestSourceFile(
         metadata,
         'src/workerd/io/maximum-compatibility-date.txt',
+      )
+    ).trim();
+    releaseVersion = (
+      await fetchLatestSourceFile(
+        metadata,
+        'src/workerd/io/release-version.txt',
       )
     ).trim();
     compatibilityDateSource = await fetchLatestSourceFile(
@@ -343,7 +358,20 @@ export const updateWorkerdReleases = async (options) => {
     );
   }
 
-  const latestVersion = toDottedDate(maximumCompatibilityDate);
+  if (!dashedDatePattern.test(releaseVersion)) {
+    return gfmNoteblock(
+      'WARNING',
+      `**${options.browserName ?? 'workerd'}**: Invalid release version date: ${releaseVersion}.`,
+    );
+  }
+
+  // The maximum compatibility date can point at a future checkpoint that the
+  // runtime refuses until that calendar date arrives. Use the published release
+  // date as the current BCD checkpoint so public data never advertises a future
+  // compatibility date as currently usable.
+  const latestVersion = toDottedDate(
+    minDate(releaseVersion, maximumCompatibilityDate),
+  );
   const dates = new Set([
     toDottedDate(WORKERD_INITIAL_COMPATIBILITY_DATE),
     latestVersion,

--- a/scripts/update-browser-releases/workerd.js
+++ b/scripts/update-browser-releases/workerd.js
@@ -1,0 +1,402 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+/** @import {CompatData} from '../../types/types.js' */
+
+/**
+ * @typedef {object} WorkerdLatestMetadata
+ * @property {string} version The published npm package version.
+ * @property {string} [gitHead] The source commit published to npm.
+ */
+
+/**
+ * @typedef {null | boolean | number | string | object | object[]} JSONValue
+ */
+
+/**
+ * @typedef {object} WorkerdSupportFlag
+ * @property {string} [name] The runtime flag name.
+ */
+
+/**
+ * @typedef {object} WorkerdSupportData
+ * @property {string | boolean | null} [version_added] The added version.
+ * @property {string | boolean | null} [version_removed] The removed version.
+ * @property {WorkerdSupportFlag[]} [flags] The support flags.
+ */
+
+import fs from 'node:fs/promises';
+
+import { compareVersions } from 'compare-versions';
+
+import stringify from '../lib/stringify-and-order-properties.js';
+
+import {
+  createOrUpdateBrowserEntry,
+  gfmNoteblock,
+  updateBrowserEntry,
+} from './utils.js';
+
+const WORKERD_NPM_LATEST_API = 'https://registry.npmjs.org/workerd/latest';
+const WORKERD_RAW_BASE = 'https://raw.githubusercontent.com/cloudflare/workerd';
+const WORKERD_INITIAL_COMPATIBILITY_DATE = '2022-09-27';
+const WORKERD_LAUNCH_BLOG =
+  'https://blog.cloudflare.com/workerd-open-source-workers-runtime/';
+const WORKERD_COMPATIBILITY_FLAGS_DOC =
+  'https://developers.cloudflare.com/workers/configuration/compatibility-flags/';
+const USER_AGENT =
+  'MDN-Browser-Release-Update-Bot/1.0 (+https://developer.mozilla.org/)';
+
+const dashedDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+const dottedDatePattern = /^\d{4}\.\d{2}\.\d{2}$/;
+
+/**
+ * Fetches text with a consistent release updater user agent.
+ * @param {string} url The URL to fetch.
+ * @returns {Promise<string>} The response text.
+ */
+const fetchText = async (url) => {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'text/plain',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Fetch failed for ${url}: HTTP ${res.status}`);
+  }
+
+  return await res.text();
+};
+
+/**
+ * Fetches latest workerd package metadata from npm.
+ * @returns {Promise<WorkerdLatestMetadata>} The latest package metadata.
+ */
+const fetchLatestMetadata = async () => {
+  const res = await fetch(WORKERD_NPM_LATEST_API, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(
+      `Fetch failed for ${WORKERD_NPM_LATEST_API}: HTTP ${res.status}`,
+    );
+  }
+
+  const metadata = /** @type {Partial<WorkerdLatestMetadata>} */ (
+    await res.json()
+  );
+
+  if (!metadata.version) {
+    throw new Error('workerd npm metadata did not include a version');
+  }
+
+  return {
+    version: metadata.version,
+    gitHead: metadata.gitHead,
+  };
+};
+
+/**
+ * Fetches a source file from the latest published workerd package tag or commit.
+ * @param {WorkerdLatestMetadata} metadata The latest package metadata.
+ * @param {string} sourcePath The path within the workerd repository.
+ * @returns {Promise<string>} The source file contents.
+ */
+const fetchLatestSourceFile = async (metadata, sourcePath) => {
+  const refs = [`v${metadata.version}`];
+
+  if (metadata.gitHead) {
+    refs.push(metadata.gitHead);
+  }
+
+  let lastErrorMessage = '';
+  for (const ref of refs) {
+    try {
+      return await fetchText(`${WORKERD_RAW_BASE}/${ref}/${sourcePath}`);
+    } catch (error) {
+      lastErrorMessage = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  throw new Error(
+    `Failed to fetch ${sourcePath} for workerd@${metadata.version}: ${lastErrorMessage}`,
+  );
+};
+
+/**
+ * Converts a workerd compatibility date to a BCD version key.
+ * @param {string} date A `YYYY-MM-DD` date.
+ * @returns {string} The BCD dotted date key.
+ */
+const toDottedDate = (date) => date.replaceAll('-', '.');
+
+/**
+ * Converts a BCD workerd version key to a compatibility date.
+ * @param {string} version A `YYYY.MM.DD` version key.
+ * @returns {string} The workerd compatibility date.
+ */
+const toDashedDate = (version) => version.replaceAll('.', '-');
+
+/**
+ * Adds a value to a map of sets.
+ * @param {Map<string, Set<string>>} map The map to update.
+ * @param {string} key The key to update.
+ * @param {string} value The value to add.
+ * @returns {void}
+ */
+const addMapSetValue = (map, key, value) => {
+  const values = map.get(key);
+
+  if (values) {
+    values.add(value);
+  } else {
+    map.set(key, new Set([value]));
+  }
+};
+
+/**
+ * Parses workerd compatibility flag metadata into flag-to-date mappings.
+ * @param {string} source The compatibility-date.capnp source.
+ * @returns {Map<string, Set<string>>} Compatibility dates keyed by runtime flag name.
+ */
+const parseCompatibilityFlagDates = (source) => {
+  /** @type {Map<string, Set<string>>} */
+  const datesByFlag = new Map();
+
+  for (const block of source.split(';')) {
+    const flagName = block.match(/\$compatEnableFlag\("([^"]+)"\)/)?.[1];
+
+    if (!flagName) {
+      continue;
+    }
+
+    const enableDate = block.match(
+      /\$compatEnableDate\("(\d{4}-\d{2}-\d{2})"\)/,
+    )?.[1];
+
+    if (enableDate) {
+      addMapSetValue(datesByFlag, flagName, enableDate);
+    }
+
+    const impliedDateMatches = block.matchAll(
+      /\$impliedByAfterDate\([^)]*date\s*=\s*"(\d{4}-\d{2}-\d{2})"[^)]*\)/g,
+    );
+
+    for (const match of impliedDateMatches) {
+      addMapSetValue(datesByFlag, flagName, match[1]);
+    }
+  }
+
+  return datesByFlag;
+};
+
+/**
+ * Collects workerd versions and runtime flags from support data.
+ * @param {WorkerdSupportData | WorkerdSupportData[] | string} support The workerd support statement or statements.
+ * @param {Set<string>} dates The dates to update.
+ * @param {Set<string>} flags The flags to update.
+ * @returns {void}
+ */
+const collectSupportStatementData = (support, dates, flags) => {
+  const statements = Array.isArray(support) ? support : [support];
+
+  for (const statement of statements) {
+    if (!statement || typeof statement !== 'object') {
+      continue;
+    }
+
+    const simple = /** @type {WorkerdSupportData} */ (statement);
+
+    for (const version of [simple.version_added, simple.version_removed]) {
+      if (typeof version === 'string' && dottedDatePattern.test(version)) {
+        dates.add(version);
+      }
+    }
+
+    if (!Array.isArray(simple.flags)) {
+      continue;
+    }
+
+    for (const flag of simple.flags) {
+      if (!flag || typeof flag !== 'object') {
+        continue;
+      }
+
+      if (flag.name) {
+        flags.add(flag.name);
+      }
+    }
+  }
+};
+
+/**
+ * Recursively collects all workerd support versions and runtime flags in BCD.
+ * @param {JSONValue} node The current data node.
+ * @param {Set<string>} dates The dates to update.
+ * @param {Set<string>} flags The flags to update.
+ * @returns {void}
+ */
+const collectWorkerdSupportData = (node, dates, flags) => {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectWorkerdSupportData(item, dates, flags);
+    }
+    return;
+  }
+
+  const record =
+    /** @type {{ [key: string]: JSONValue } & { __compat?: { support?: { workerd?: WorkerdSupportData | WorkerdSupportData[] | string } } }} */ (
+      node
+    );
+
+  if (record.__compat && typeof record.__compat === 'object') {
+    const compat = record.__compat;
+    if (compat.support?.workerd) {
+      collectSupportStatementData(compat.support.workerd, dates, flags);
+    }
+  }
+
+  for (const value of Object.values(record)) {
+    collectWorkerdSupportData(value, dates, flags);
+  }
+};
+
+/**
+ * Returns the release notes URL for a workerd date checkpoint.
+ * @param {string} version The BCD workerd version key.
+ * @returns {string} The release notes URL.
+ */
+const releaseNotesForVersion = (version) =>
+  version === toDottedDate(WORKERD_INITIAL_COMPATIBILITY_DATE)
+    ? WORKERD_LAUNCH_BLOG
+    : WORKERD_COMPATIBILITY_FLAGS_DOC;
+
+/**
+ * Updates the workerd releases.
+ * @param {object} options - The options.
+ * @param {'workerd'} options.bcdBrowserName - The name of the browser in the BCD file.
+ * @param {string} options.bcdFile - The path to the BCD file.
+ * @param {string} options.browserName - The name of the browser.
+ * @returns {Promise<string>} The result.
+ */
+export const updateWorkerdReleases = async (options) => {
+  const browser = options.bcdBrowserName;
+
+  /** @type {string} */
+  let fileText;
+  try {
+    fileText = await fs.readFile(options.bcdFile, 'utf-8');
+  } catch {
+    return gfmNoteblock(
+      'NOTE',
+      `**${options.browserName ?? 'workerd'}**: No browser data file found at ${options.bcdFile}. Add a seed file (e.g., browsers/workerd.json) before running updates.`,
+    );
+  }
+
+  /** @type {CompatData} */
+  const data = JSON.parse(fileText);
+
+  if (!data.browsers[browser]) {
+    return gfmNoteblock(
+      'WARNING',
+      `**${options.browserName ?? 'workerd'}**: No browser entry found for ${browser}.`,
+    );
+  }
+
+  let metadata;
+  let maximumCompatibilityDate;
+  let compatibilityDateSource;
+
+  try {
+    metadata = await fetchLatestMetadata();
+    maximumCompatibilityDate = (
+      await fetchLatestSourceFile(
+        metadata,
+        'src/workerd/io/maximum-compatibility-date.txt',
+      )
+    ).trim();
+    compatibilityDateSource = await fetchLatestSourceFile(
+      metadata,
+      'src/workerd/io/compatibility-date.capnp',
+    );
+  } catch (e) {
+    return gfmNoteblock(
+      'WARNING',
+      `**${options.browserName ?? 'workerd'}**: Failed to fetch release data (${e}).`,
+    );
+  }
+
+  if (!dashedDatePattern.test(maximumCompatibilityDate)) {
+    return gfmNoteblock(
+      'WARNING',
+      `**${options.browserName ?? 'workerd'}**: Invalid maximum compatibility date: ${maximumCompatibilityDate}.`,
+    );
+  }
+
+  const latestVersion = toDottedDate(maximumCompatibilityDate);
+  const dates = new Set([
+    toDottedDate(WORKERD_INITIAL_COMPATIBILITY_DATE),
+    latestVersion,
+  ]);
+  const flags = new Set();
+
+  const { default: bcd } = await import('../../index.js');
+  collectWorkerdSupportData(/** @type {JSONValue} */ (bcd), dates, flags);
+
+  const datesByFlag = parseCompatibilityFlagDates(compatibilityDateSource);
+  for (const flag of flags) {
+    for (const date of datesByFlag.get(flag) ?? []) {
+      dates.add(toDottedDate(date));
+    }
+  }
+
+  let result = '';
+  const sortedDates = [...dates].sort(compareVersions);
+
+  for (const version of sortedDates) {
+    const status = version === latestVersion ? 'current' : 'retired';
+    result += createOrUpdateBrowserEntry(
+      data,
+      browser,
+      version,
+      status,
+      undefined,
+      undefined,
+      toDashedDate(version),
+      releaseNotesForVersion(version),
+    );
+  }
+
+  const existing = Object.keys(data.browsers[browser].releases ?? {});
+  for (const version of existing) {
+    if (version !== latestVersion) {
+      result += updateBrowserEntry(
+        data,
+        browser,
+        version,
+        undefined,
+        'retired',
+        undefined,
+        undefined,
+      );
+    }
+  }
+
+  await fs.writeFile(`./${options.bcdFile}`, stringify(data) + '\n');
+
+  if (result) {
+    result = `### Updates for ${options.browserName ?? 'workerd'}\n${result}`;
+  }
+
+  return result;
+};

--- a/scripts/workerd-release-map.js
+++ b/scripts/workerd-release-map.js
@@ -1,0 +1,270 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+/**
+ * @typedef {object} WorkerdPackageMetadata
+ * @property {string} version The published npm package version.
+ * @property {string} [gitHead] The source commit published to npm.
+ * @property {string} [deprecated] The npm deprecation message, if any.
+ */
+
+/** @typedef {{ versions: Record<string, WorkerdPackageMetadata>, "dist-tags": { latest?: string } }} WorkerdRegistryMetadata */
+
+/**
+ * @typedef {object} WorkerdReleaseMapEntry
+ * @property {string} packageVersion The published npm package version.
+ * @property {string} [gitHead] The source commit published to npm.
+ * @property {string} releaseVersion The value from release-version.txt.
+ * @property {string} maximumCompatibilityDate The newest compatibility date supported by the binary.
+ * @property {string} bcdCheckpoint The BCD dotted-date checkpoint.
+ * @property {string} [v8Version] The pinned V8 version from build/deps/v8.MODULE.bazel.
+ * @property {string} [v8Tarball] The V8 source tarball URL, if parsed.
+ * @property {string[]} sourceRefs The source refs tried for this package.
+ */
+
+import fs from 'node:fs/promises';
+import { styleText } from 'node:util';
+
+import { compareVersions } from 'compare-versions';
+
+const WORKERD_NPM_API = 'https://registry.npmjs.org/workerd';
+const WORKERD_RAW_BASE = 'https://raw.githubusercontent.com/cloudflare/workerd';
+const USER_AGENT =
+  'MDN-Browser-Release-Update-Bot/1.0 (+https://developer.mozilla.org/)';
+
+const dashedDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Converts a workerd compatibility date to a BCD version key.
+ * @param {string} date A `YYYY-MM-DD` date.
+ * @returns {string} The BCD dotted date key.
+ */
+const toDottedDate = (date) => date.replaceAll('-', '.');
+
+/**
+ * Fetches JSON with a consistent release updater user agent.
+ * @param {string} url The URL to fetch.
+ * @returns {Promise<WorkerdRegistryMetadata>} The parsed registry metadata.
+ */
+const fetchRegistryMetadata = async (url) => {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Fetch failed for ${url}: HTTP ${res.status}`);
+  }
+
+  return /** @type {WorkerdRegistryMetadata} */ (await res.json());
+};
+
+/**
+ * Fetches text with a consistent release updater user agent.
+ * @param {string} url The URL to fetch.
+ * @returns {Promise<string>} The response text.
+ */
+const fetchText = async (url) => {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': USER_AGENT,
+      Accept: 'text/plain',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Fetch failed for ${url}: HTTP ${res.status}`);
+  }
+
+  return await res.text();
+};
+
+/**
+ * Fetches a source file from the package tag or npm source commit.
+ * @param {WorkerdPackageMetadata} metadata The package metadata.
+ * @param {string} sourcePath The path within the workerd repository.
+ * @returns {Promise<{ contents: string; sourceRefs: string[] }>} The source file contents and refs.
+ */
+const fetchSourceFile = async (metadata, sourcePath) => {
+  const sourceRefs = [`v${metadata.version}`];
+
+  if (metadata.gitHead) {
+    sourceRefs.push(metadata.gitHead);
+  }
+
+  let lastErrorMessage = '';
+  for (const ref of sourceRefs) {
+    try {
+      const contents = await fetchText(
+        `${WORKERD_RAW_BASE}/${ref}/${sourcePath}`,
+      );
+      return { contents, sourceRefs };
+    } catch (error) {
+      lastErrorMessage = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  throw new Error(
+    `Failed to fetch ${sourcePath} for workerd@${metadata.version}: ${lastErrorMessage}`,
+  );
+};
+
+/**
+ * Parses V8 metadata from workerd's Bazel module file.
+ * @param {string} source The build/deps/v8.MODULE.bazel source.
+ * @returns {{ v8Version?: string; v8Tarball?: string }} Parsed V8 metadata.
+ */
+const parseV8Metadata = (source) => {
+  const v8Version = source.match(/VERSION\s*=\s*"([^"]+)"/)?.[1];
+  const v8Tarball = v8Version
+    ? `https://github.com/v8/v8/archive/refs/tags/${v8Version}.tar.gz`
+    : undefined;
+
+  return { v8Version, v8Tarball };
+};
+
+/**
+ * Builds one release-map entry.
+ * @param {WorkerdPackageMetadata} metadata The package metadata.
+ * @returns {Promise<WorkerdReleaseMapEntry>} The release-map entry.
+ */
+const buildReleaseEntry = async (metadata) => {
+  const maximumCompatibilityDateSource = await fetchSourceFile(
+    metadata,
+    'src/workerd/io/maximum-compatibility-date.txt',
+  );
+  const releaseVersionSource = await fetchSourceFile(
+    metadata,
+    'src/workerd/io/release-version.txt',
+  );
+  const v8Source = await fetchSourceFile(
+    metadata,
+    'build/deps/v8.MODULE.bazel',
+  );
+
+  const maximumCompatibilityDate =
+    maximumCompatibilityDateSource.contents.trim();
+  const releaseVersion = releaseVersionSource.contents.trim();
+
+  if (!dashedDatePattern.test(maximumCompatibilityDate)) {
+    throw new Error(
+      `Invalid maximum compatibility date for workerd@${metadata.version}: ${maximumCompatibilityDate}`,
+    );
+  }
+
+  const { v8Version, v8Tarball } = parseV8Metadata(v8Source.contents);
+
+  return {
+    packageVersion: metadata.version,
+    gitHead: metadata.gitHead,
+    releaseVersion,
+    maximumCompatibilityDate,
+    bcdCheckpoint: toDottedDate(maximumCompatibilityDate),
+    v8Version,
+    v8Tarball,
+    sourceRefs: maximumCompatibilityDateSource.sourceRefs,
+  };
+};
+
+/**
+ * Parses CLI arguments.
+ * @returns {{ all: boolean; limit: number; output?: string; versions: string[] }} Parsed options.
+ */
+const parseArgs = () => {
+  const args = process.argv.slice(2);
+  /** @type {string[]} */
+  const versions = [];
+  /** @type {string | undefined} */
+  let output;
+  let all = false;
+  let limit = 1;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (arg === '--all') {
+      all = true;
+    } else if (arg === '--limit') {
+      limit = Number(args[++i]);
+    } else if (arg === '--output') {
+      output = args[++i];
+    } else if (arg === '--version') {
+      versions.push(args[++i]);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error('--limit must be a positive integer');
+  }
+
+  return { all, limit, output, versions };
+};
+
+/**
+ * Selects package versions to map.
+ * @param {WorkerdRegistryMetadata} registry The npm registry metadata.
+ * @param {{ all: boolean; limit: number; versions: string[] }} options The selection options.
+ * @returns {WorkerdPackageMetadata[]} The selected package metadata.
+ */
+const selectVersions = (registry, options) => {
+  if (options.versions.length > 0) {
+    return options.versions.map((version) => {
+      const metadata = registry.versions[version];
+      if (!metadata) {
+        throw new Error(`workerd@${version} was not found in the npm registry`);
+      }
+      return metadata;
+    });
+  }
+
+  if (!options.all) {
+    const latest = registry['dist-tags'].latest;
+    if (!latest || !registry.versions[latest]) {
+      throw new Error(
+        'The npm registry response did not include a latest workerd version',
+      );
+    }
+    return [registry.versions[latest]];
+  }
+
+  return Object.values(registry.versions)
+    .filter((metadata) => !metadata.deprecated)
+    .sort((a, b) => compareVersions(b.version, a.version))
+    .slice(0, options.limit);
+};
+
+/**
+ * Generates the release map.
+ * @returns {Promise<void>}
+ */
+const main = async () => {
+  const options = parseArgs();
+  const registry = await fetchRegistryMetadata(WORKERD_NPM_API);
+  const selectedVersions = selectVersions(registry, options);
+  /** @type {WorkerdReleaseMapEntry[]} */
+  const entries = [];
+
+  for (const metadata of selectedVersions) {
+    entries.push(await buildReleaseEntry(metadata));
+  }
+
+  const output = `${JSON.stringify(entries, null, 2)}\n`;
+
+  if (options.output) {
+    await fs.writeFile(options.output, output);
+    console.log(
+      `Wrote ${entries.length} workerd release-map entr${entries.length === 1 ? 'y' : 'ies'} to ${options.output}`,
+    );
+  } else {
+    console.log(output);
+  }
+};
+
+main().catch((error) => {
+  console.error(styleText('red', String(error)));
+  process.exit(1);
+});

--- a/scripts/workerd-release-map.js
+++ b/scripts/workerd-release-map.js
@@ -16,7 +16,8 @@
  * @property {string} [gitHead] The source commit published to npm.
  * @property {string} releaseVersion The value from release-version.txt.
  * @property {string} maximumCompatibilityDate The newest compatibility date supported by the binary.
- * @property {string} bcdCheckpoint The BCD dotted-date checkpoint.
+ * @property {string} bcdCheckpoint The current usable BCD dotted-date checkpoint.
+ * @property {string} maximumBcdCheckpoint The maximum BCD dotted-date checkpoint supported by the binary.
  * @property {string} [v8Version] The pinned V8 version from build/deps/v8.MODULE.bazel.
  * @property {string} [v8Tarball] The V8 source tarball URL, if parsed.
  * @property {string[]} sourceRefs The source refs tried for this package.
@@ -33,6 +34,14 @@ const USER_AGENT =
   'MDN-Browser-Release-Update-Bot/1.0 (+https://developer.mozilla.org/)';
 
 const dashedDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Returns the earlier of two ISO dates.
+ * @param {string} first The first date.
+ * @param {string} second The second date.
+ * @returns {string} The earlier date.
+ */
+const minDate = (first, second) => (first < second ? first : second);
 
 /**
  * Converts a workerd compatibility date to a BCD version key.
@@ -154,6 +163,12 @@ const buildReleaseEntry = async (metadata) => {
     );
   }
 
+  if (!dashedDatePattern.test(releaseVersion)) {
+    throw new Error(
+      `Invalid release version date for workerd@${metadata.version}: ${releaseVersion}`,
+    );
+  }
+
   const { v8Version, v8Tarball } = parseV8Metadata(v8Source.contents);
 
   return {
@@ -161,7 +176,10 @@ const buildReleaseEntry = async (metadata) => {
     gitHead: metadata.gitHead,
     releaseVersion,
     maximumCompatibilityDate,
-    bcdCheckpoint: toDottedDate(maximumCompatibilityDate),
+    bcdCheckpoint: toDottedDate(
+      minDate(releaseVersion, maximumCompatibilityDate),
+    ),
+    maximumBcdCheckpoint: toDottedDate(maximumCompatibilityDate),
     v8Version,
     v8Tarball,
     sourceRefs: maximumCompatibilityDateSource.sourceRefs,

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -39,7 +39,7 @@
           "webview_android": "mirror",
           "webview_ios": "mirror",
           "workerd": {
-            "version_added": "2026.05.03"
+            "version_added": "2022.09.27"
           }
         },
         "status": {

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -37,7 +37,10 @@
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
-          "webview_ios": "mirror"
+          "webview_ios": "mirror",
+          "workerd": {
+            "version_added": "2026.05.03"
+          }
         },
         "status": {
           "experimental": false,

--- a/webassembly/api/Exception.json
+++ b/webassembly/api/Exception.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -85,7 +85,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -172,7 +172,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -219,7 +219,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -263,7 +263,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/webassembly/api/Exception.json
+++ b/webassembly/api/Exception.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -80,7 +83,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -164,7 +170,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -208,7 +217,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -249,7 +261,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Global.json
+++ b/webassembly/api/Global.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -88,7 +88,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -134,7 +134,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -180,7 +180,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/webassembly/api/Global.json
+++ b/webassembly/api/Global.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -83,7 +86,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -126,7 +132,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -169,7 +178,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Instance.json
+++ b/webassembly/api/Instance.json
@@ -38,7 +38,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -84,7 +87,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -130,7 +136,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Instance.json
+++ b/webassembly/api/Instance.json
@@ -40,7 +40,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -89,7 +89,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -138,7 +138,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/webassembly/api/Memory.json
+++ b/webassembly/api/Memory.json
@@ -40,7 +40,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -89,7 +89,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -184,7 +184,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -233,7 +233,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/webassembly/api/Memory.json
+++ b/webassembly/api/Memory.json
@@ -38,7 +38,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -84,7 +87,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -176,7 +182,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -222,7 +231,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -40,7 +40,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -89,7 +89,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -180,7 +180,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -230,7 +230,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -280,7 +280,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/webassembly/api/Module.json
+++ b/webassembly/api/Module.json
@@ -38,7 +38,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -84,7 +87,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -172,7 +178,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -219,7 +228,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -266,7 +278,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Table.json
+++ b/webassembly/api/Table.json
@@ -40,7 +40,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -89,7 +89,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -138,7 +138,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -187,7 +187,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -236,7 +236,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {
@@ -285,7 +285,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {

--- a/webassembly/api/Table.json
+++ b/webassembly/api/Table.json
@@ -38,7 +38,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -84,7 +87,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -130,7 +136,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -176,7 +185,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -222,7 +234,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,
@@ -268,7 +283,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Tag.json
+++ b/webassembly/api/Tag.json
@@ -36,7 +36,10 @@
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
-            "webview_ios": "mirror"
+            "webview_ios": "mirror",
+            "workerd": {
+              "version_added": "2026.05.03"
+            }
           },
           "status": {
             "experimental": false,
@@ -80,7 +83,10 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": "mirror"
+              "webview_ios": "mirror",
+              "workerd": {
+                "version_added": "2026.05.03"
+              }
             },
             "status": {
               "experimental": false,

--- a/webassembly/api/Tag.json
+++ b/webassembly/api/Tag.json
@@ -38,7 +38,7 @@
             "webview_android": "mirror",
             "webview_ios": "mirror",
             "workerd": {
-              "version_added": "2026.05.03"
+              "version_added": "2022.09.27"
             }
           },
           "status": {
@@ -85,7 +85,7 @@
               "webview_android": "mirror",
               "webview_ios": "mirror",
               "workerd": {
-                "version_added": "2026.05.03"
+                "version_added": "2022.09.27"
               }
             },
             "status": {


### PR DESCRIPTION
## Summary

This PR adds `workerd` as a server runtime browser identifier in BCD, establishes the release/version model needed for future `workerd` data, and adds an initial positive support-data set for Web APIs, WebAssembly APIs, JavaScript built-ins, and relevant globals.

It includes:

- `browsers/workerd.json` with the initial open-source checkpoint and current usable compatibility-date checkpoint.
- Schema support for `workerd` support blocks.
- Documentation for the `workerd` versioning model.
- A `--workerd` release updater that keeps release checkpoints aligned with published `workerd` source metadata.
- A `workerd-release-map` evidence script that maps published packages to source metadata and the pinned V8 version.
- Initial positive support data for `workerd` across APIs, WebAssembly, JavaScript built-ins, and globals.

## Rationale

`workerd` is Cloudflare's open-source JavaScript/Wasm runtime and the runtime that powers Cloudflare Workers. It fits BCD's server-runtime model alongside Bun, Deno, and Node.js, but its compatibility contract is different from package-versioned runtimes.

For `workerd`, the developer-facing compatibility axis is not the npm package version such as `1.20260426.1`. Developers configure runtime behavior with `compatibilityDate` and optional `compatibilityFlags`. Package versions are still useful as release evidence and automation inputs, but they are not the support values developers normally reason about.

This PR therefore models `workerd` versions as compatibility-date checkpoints encoded as dotted numeric versions. For example:

```json
{
  "workerd": {
    "version_added": "2026.04.26"
  }
}
```

This maps to:

```capnp
compatibilityDate = "2026-04-26"
```

BCD already accepts dotted numeric versions, while hyphenated date strings are not valid `version_added` values.

## Version Semantics

`workerd.version_added` means that a feature is available by default at the specified compatibility-date checkpoint, without explicit opt-in compatibility flags.

Features available only behind explicit compatibility flags should use BCD `flags` data. Features that require `nodejs_compat` should also be represented as flagged support, because `nodejs_compat` is an opt-in compatibility mode rather than baseline `workerd` behavior.

Older `workerd` compatibility dates continue to be supported by newer `workerd` binaries. In this PR, older BCD release entries are marked `retired` only to satisfy BCD release-status conventions; for `workerd`, `retired` means “not the latest current compatibility-date checkpoint,” not “the runtime stopped accepting this compatibility date.”

## Support Data Scope

This PR adds an initial positive support-data set only. It intentionally does not bulk-add `version_added: false` statements for unsupported features.

The initial support-data scope is:

- Web platform APIs relevant to a server runtime and reported as supported by collector-derived `workerd` results.
- Relevant globals verified by a local `workerd@1.20260426.1` probe: `fetch`, `crypto`, `performance`, timers, `queueMicrotask`, `structuredClone`, `atob`, `btoa`, `console`, `caches`, `origin`, `reportError`, and `scheduler`.
- WebAssembly core APIs reported as supported.
- JavaScript built-ins reported as supported by collector-derived `workerd` results.

This adds:

- 1,114 positive `workerd` support statements.
- 128 data files touched.
- 424 API support statements.
- 30 WebAssembly support statements.
- 660 JavaScript built-in support statements.
- 0 explicit unsupported `version_added: false` statements.

## Support Date Strategy

The support dates are intentionally split:

- 997 entries use `version_added: "2022.09.27"`, the public open-source `workerd` launch checkpoint.
- 3 stream constructor entries use `2022.11.30`, from the `streams_enable_constructors` / `transformstream_enable_standard_constructor` default date.
- 1 `Headers.getSetCookie` entry uses `2023.03.01`, from `http_headers_getsetcookie`.
- 2 `URLSearchParams` value-parameter entries use `2023.07.01`, from `urlsearchparams_delete_has_value_arg`.
- 1 `URLPattern` option entry uses `2025.05.01`, from `urlpattern_standard`.
- 7 `WeakRef` / `FinalizationRegistry` entries use `2025.05.05`, from `enable_weak_ref`.
- 1 `Navigator.language` entry uses `2025.05.19`, from `enable_navigator_language`.
- 11 `MessageChannel` / `MessagePort` entries use `2025.08.15`, from `expose_global_message_channel`.
- 91 entries use `2026.04.26`, the current usable compatibility-date checkpoint for the latest published package. These are newer or less safely backfilled features where assigning an earlier workerd checkpoint should wait for historical `workerd` test evidence, source mapping, or flag-specific evidence.

This avoids presenting long-standing APIs like `Array`, `Request`, `URL`, `fetch`, or core WebAssembly APIs as if they were only added in 2026, while also avoiding unsupported historical guesses for newer features.

## Current Checkpoint vs Maximum Checkpoint

The latest package, `workerd@1.20260426.1`, contains:

- `release-version.txt`: `2026-04-26`
- `maximum-compatibility-date.txt`: `2026-05-03`

A local `workerd` run rejects `compatibilityDate = "2026-05-03"` before that calendar date arrives. For BCD, this PR therefore uses `2026.04.26` as the current usable checkpoint and records `2026.05.03` only as the maximum supported future checkpoint in `npm run workerd-release-map` output.

## JavaScript Built-in Evidence

JavaScript built-in support can be driven by V8 rolls rather than `workerd` compatibility flags. To make that relationship explicit and keep future updates reproducible, this PR adds:

```sh
npm run workerd-release-map
```

For the current latest package, it reports:

```json
[
  {
    "packageVersion": "1.20260426.1",
    "releaseVersion": "2026-04-26",
    "maximumCompatibilityDate": "2026-05-03",
    "bcdCheckpoint": "2026.04.26",
    "maximumBcdCheckpoint": "2026.05.03",
    "v8Version": "14.7.173.16",
    "v8Tarball": "https://github.com/v8/v8/archive/refs/tags/14.7.173.16.tar.gz"
  }
]
```

That gives reviewers and future maintainers an evidence trail from BCD checkpoint → published workerd package → source tag/commit → V8 version. Future PRs can use the same script with `--all`, `--limit`, or `--version` to build a historical release map and refine `version_added` values where evidence supports it.

## Implementation

The new browser metadata uses:

```json
{
  "name": "workerd",
  "type": "server",
  "pref_url": "https://developers.cloudflare.com/workers/configuration/compatibility-flags/",
  "accepts_flags": true,
  "accepts_webextensions": false
}
```

The release updater is wired into `npm run update-browser-releases -- --workerd`. It:

- Fetches `https://registry.npmjs.org/workerd/latest`.
- Resolves the corresponding GitHub tag, with `gitHead` as a fallback.
- Reads `src/workerd/io/release-version.txt` and `src/workerd/io/maximum-compatibility-date.txt`.
- Uses the earlier of those two dates as the current usable BCD checkpoint, so BCD does not publish a future compatibility date as currently usable.
- Reads `src/workerd/io/compatibility-date.capnp` to map referenced runtime flags to their default dates.
- Preserves date checkpoints already referenced by existing `workerd` support data.
- Adds default dates for runtime flags referenced by existing `workerd` support data.

## Validation

Commands run:

```sh
npm run gentypes
npm run update-browser-releases -- --workerd
npm run workerd-release-map
npm run build
npm run format
npm run lint
npm run unittest
```

Additional validation:

- Confirmed `workerd@latest` is `1.20260426.1`.
- Confirmed `v1.20260426.1/src/workerd/io/release-version.txt` is `2026-04-26`.
- Confirmed `v1.20260426.1/src/workerd/io/maximum-compatibility-date.txt` is `2026-05-03`.
- Confirmed `workerd@1.20260426.1` rejects `compatibilityDate = "2026-05-03"` before that date, so `2026.04.26` is the current usable checkpoint.
- Confirmed `v1.20260426.1/build/deps/v8.MODULE.bazel` pins V8 `14.7.173.16`.
- Confirmed the launch blog date is `2022-09-27`, matching the initial `2022.09.27` checkpoint.
- Confirmed the current positive support set exactly matches the collector-derived positive set for API, JavaScript, and WebAssembly entries before adding separately probed globals and explicitly flag-documented entries.
- Confirmed there are no obvious browser-only positives for DOM, Canvas, WebGL, WebGPU, WebAudio, WebRTC, device APIs, IndexedDB, Trusted Types, or image bitmap globals.
- Confirmed representative compatibility-flag-derived dates export correctly, including `Headers.getSetCookie`, `URLSearchParams.delete(value)`, `URLPattern({ ignoreCase })`, `Navigator.language`, `MessageChannel`, `WeakRef`, and `FinalizationRegistry`.
- Confirmed the updater is idempotent for the current data.

`npm run format` passes, while still printing the repository's existing JSDoc warnings.

## Reviewer Notes

The main policy decision here is whether BCD is comfortable accepting dotted compatibility-date checkpoints as the version axis for `workerd`. If that model is accepted, future support data can remain readable and developer-aligned. If it is rejected, the fallback would be to use npm package versions such as `1.20260426.1`, but that would be less useful for developers because `workerd` feature availability is controlled by `compatibilityDate` and `compatibilityFlags`.

Follow-up PRs can add:

- More precise historical `version_added` dates where historical `workerd` compatibility-date evidence exists.
- Flagged support ranges for compatibility flags where BCD has matching subfeatures.
- Additional JavaScript built-in and syntax data as historical V8-to-`workerd` mapping is expanded.