### PR TITLE
Firefox 151 / Safari 26.4 support Fullscreen Keyboard Lock API

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -8765,13 +8765,10 @@
             "deprecated": false
           }
         },
-        "options_navigationUI_parameter": {
+        "options_parameter": {
           "__compat": {
-            "description": "`options.navigationUI` parameter",
-            "spec_url": "https://fullscreen.spec.whatwg.org/#dom-fullscreenoptions-navigationui",
-            "tags": [
-              "web-features:fullscreen"
-            ],
+            "description": "`options` parameter",
+            "spec_url": "https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen-options-options",
             "support": {
               "chrome": {
                 "version_added": "71"
@@ -8779,7 +8776,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "151"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8800,42 +8797,112 @@
               "standard_track": true,
               "deprecated": false
             }
-          }
-        },
-        "options_screen_parameter": {
-          "__compat": {
-            "description": "`options.screen` parameter",
-            "spec_url": "https://w3c.github.io/window-management/#ref-for-dom-fullscreenoptions-screen",
-            "tags": [
-              "web-features:window-management"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "100"
+          },
+          "keyboardLock_option": {
+            "__compat": {
+              "description": "`keyboardLock` option",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "151"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "26.4"
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
               },
-              "chrome_android": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
+          },
+          "navigationUI_option": {
+            "__compat": {
+              "description": "`navigationUI` option",
+              "spec_url": "https://fullscreen.spec.whatwg.org/#dom-fullscreenoptions-navigationui",
+              "tags": [
+                "web-features:fullscreen"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "71"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "16.4"
+                },
+                "safari_ios": {
+                  "version_added": false
+                },
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
               },
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "screen_option": {
+            "__compat": {
+              "description": "`screen` option",
+              "spec_url": "https://w3c.github.io/window-management/#ref-for-dom-fullscreenoptions-screen",
+              "tags": [
+                "web-features:window-management"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "100"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
               },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },

--- a/api/Element.json
+++ b/api/Element.json
@@ -8803,7 +8803,8 @@
               "description": "`keyboardLock` option",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": false,
+                  "impl_url": "https://crbug.com/505427218"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
FF151 supports the Fullscreen Keyboard Lock API in https://bugzilla.mozilla.org/show_bug.cgi?id=2032302 (implementation in https://bugzilla.mozilla.org/show_bug.cgi?id=700123). 

This is the addition of a `keyboardLock` option (to the `options` parameter) that can take the values `none` or `browser` to the `Element.requestFullScreen()`. This is also supported by [Safari 26.4](https://developer.apple.com/documentation/safari-release-notes/safari-26_4-release-notes) (search keyboard lock) but not yet by Chrome (https://issues.chromium.org/issues/505427218).

Safari has an extra option `system` that means the same as `none` (does nothing). I have not captured that because it isn't in the prospective spec.

The spec for this has not landed, but seems to be heading towards some kind of agreement as we speak. https://github.com/whatwg/fullscreen/pull/232

Given that I gave marked this non-standard - and the fact is I am not sure yet exactly what it will end up doing. I.e whether anything that counts as "compatibility" will change.

- For example, keyboard lock can be disabled on supporting browsers by long-pressing Esc, but this is not mandated by the spec, and might end up being something that is.
- The keys that are passed to the handlers in lock mode depends on the implementation. Not sure if we need to document then.
- On FF the normal Esc key mechanism of leaving fullscreen is replaced by long press. One Safari either works - you're expected to disable the Esc key if you don't want it to close the fullscreen mode.

Related docs work can be tracked in https://github.com/mdn/content/issues/43868
