### PR TITLE
Chrome 146 WebGPU compatibility mode featureLevel option

### DIFF
--- a/api/GPU.json
+++ b/api/GPU.json
@@ -227,6 +227,43 @@
               "deprecated": false
             }
           }
+        },
+        "options_featureLevel": {
+          "__compat": {
+            "description": "`featureLevel` option",
+            "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpurequestadapteroptions-featurelevel",
+            "tags": [
+              "web-features:webgpu"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "146",
+                "partial_implementation": true,
+                "notes": "Compatibility mode supported only on Android 5.0 and above (running OpenGL ES 3.1 and above)."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "wgslLanguageFeatures": {

--- a/api/GPU.json
+++ b/api/GPU.json
@@ -239,7 +239,7 @@
               "chrome": {
                 "version_added": "146",
                 "partial_implementation": true,
-                "notes": "Compatibility mode supported only on Android 5.0 and above (running OpenGL ES 3.1 and above)."
+                "notes": "Compatibility mode supported only on Android 10.0 and above (running OpenGL ES 3.1 and above)."
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 146 adds support for WebGPU compatibility mode: see https://chromestatus.com/feature/6436406437871616, and also see https://developer.chrome.com/blog/new-in-webgpu-146#support_webgpu_compatibility_mode_on_opengl_es_31 for more info and context.

This PR adds a data point for the `featureLevel` option of the `GPU.requestAdapter()` method, which is used to opt in to compatibility mode. Note that:

- `featureLevel`is recognized and can be used on any Chrome 146+ browser; however, at the moment, only old Android devices running OpenGL ES 3.1 and above will support compatibility mode. Support will be added later for other older device/API combinations. Hence, the partial implementation and the note, which still describes support on Chrome desktop as well as Android.
- OpenGL ES 3.1 is available on Android 5.0: I got this information from https://developer.android.com/develop/ui/views/graphics/opengl/about-opengl.
- There is no GPUAdapter property to describe whether the adapter was successfully requested with `featureLevel: "compatibility"` set. Instead, you have to use `adapter.features.has("core-features-and-limits")` to test. If it returns `false`, your adapter is in compatibility mode.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
