### PR TITLE
Firefox Nightly supports `animation-range` properties

### DIFF
--- a/css/properties/animation-range-end.json
+++ b/css/properties/animation-range-end.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1676779"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1676779"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range-end.json
+++ b/css/properties/animation-range-end.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "150"
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,7 +49,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "150"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range-start.json
+++ b/css/properties/animation-range-start.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1676779"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1676779"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range-start.json
+++ b/css/properties/animation-range-start.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "150"
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,7 +49,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "150"
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range.json
+++ b/css/properties/animation-range.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1676779"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/animation-range.json
+++ b/css/properties/animation-range.json
@@ -15,7 +15,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "150"
+              "version_added": false,
+              "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,7 +49,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "150"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

Reverts Firefox 150 support for the animation-range group of properties.

It turned out they’re not supported.

#### Test results and supporting details

- https://bugzilla.mozilla.org/show_bug.cgi?id=1825427
- https://bugzilla.mozilla.org/show_bug.cgi?id=1676779

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/29494