### PR TITLE
Chrome 148 ships `SharedWorker` `extendedLifetime` option

### DIFF
--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -235,7 +235,7 @@
             }
           }
         },
-        "options_extendedlifetime_parameter": {
+        "options_extendedLifetime_parameter": {
           "__compat": {
             "description": "`options.extendedLifetime` parameter",
             "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworkeroptions-extendedlifetime",

--- a/api/SharedWorker.json
+++ b/api/SharedWorker.json
@@ -235,6 +235,41 @@
             }
           }
         },
+        "options_extendedlifetime_parameter": {
+          "__compat": {
+            "description": "`options.extendedLifetime` parameter",
+            "spec_url": "https://html.spec.whatwg.org/multipage/workers.html#dom-sharedworkeroptions-extendedlifetime",
+            "tags": [
+              "web-features:shared-workers"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "148"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_name_parameter": {
           "__compat": {
             "description": "`options.name` parameter",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Added `extendedLifetime` parameter to Shared Worker which is coming unflagged to Chrome 148

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://wpt.fyi/results/workers?label=master&label=experimental&aligned&q=extendedLife

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromestatus.com/feature/5138641357373440

Old doc for when this was in OT: https://developer.chrome.com/blog/extended-lifetime-shared-workers-origin-trial

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Makes progress on https://github.com/mdn/mdn/issues/812

Content PR: https://github.com/mdn/content/pull/43955

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
