### PR TITLE
Add `DateTimeFormat` `timeZone` option accepting UTC offset

### DIFF
--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -680,7 +680,7 @@
                     }
                   }
                 },
-                "utc_offset": {
+                "accepts_utc_offset": {
                   "__compat": {
                     "description": "UTC offset in `options.timeZone` option",
                     "tags": [

--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -680,9 +680,10 @@
                     }
                   }
                 },
-                "accepts_utc_offset": {
+                "utc_offset": {
                   "__compat": {
                     "description": "UTC offset in `options.timeZone` option",
+                    "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat",
                     "tags": [
                       "web-features:intl"
                     ],
@@ -697,9 +698,7 @@
                       "deno": {
                         "version_added": "1.38"
                       },
-                      "edge": {
-                        "version_added": "120"
-                      },
+                      "edge": "mirror",
                       "firefox": {
                         "version_added": "121"
                       },
@@ -708,9 +707,7 @@
                         "version_added": "22.0.0"
                       },
                       "oculus": "mirror",
-                      "opera": {
-                        "version_added": "106"
-                      },
+                      "opera": "mirror",
                       "opera_android": "mirror",
                       "safari": {
                         "version_added": "17.4"

--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -683,7 +683,7 @@
                 "utc_offset": {
                   "__compat": {
                     "description": "UTC offset in `options.timeZone` option",
-                    "spec_url": "https://tc39.es/ecma402/#sec-Intl.DateTimeFormat",
+                    "spec_url": "https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-time-zone-offset-strings",
                     "tags": [
                       "web-features:intl"
                     ],

--- a/javascript/builtins/Intl/DateTimeFormat.json
+++ b/javascript/builtins/Intl/DateTimeFormat.json
@@ -679,6 +679,53 @@
                       "deprecated": false
                     }
                   }
+                },
+                "utc_offset": {
+                  "__compat": {
+                    "description": "UTC offset in `options.timeZone` option",
+                    "tags": [
+                      "web-features:intl"
+                    ],
+                    "support": {
+                      "bun": {
+                        "version_added": "1.0.19"
+                      },
+                      "chrome": {
+                        "version_added": "120"
+                      },
+                      "chrome_android": "mirror",
+                      "deno": {
+                        "version_added": "1.38"
+                      },
+                      "edge": {
+                        "version_added": "120"
+                      },
+                      "firefox": {
+                        "version_added": "121"
+                      },
+                      "firefox_android": "mirror",
+                      "nodejs": {
+                        "version_added": "22.0.0"
+                      },
+                      "oculus": "mirror",
+                      "opera": {
+                        "version_added": "106"
+                      },
+                      "opera_android": "mirror",
+                      "safari": {
+                        "version_added": "17.4"
+                      },
+                      "safari_ios": "mirror",
+                      "samsunginternet_android": "mirror",
+                      "webview_android": "mirror",
+                      "webview_ios": "mirror"
+                    },
+                    "status": {
+                      "experimental": false,
+                      "standard_track": true,
+                      "deprecated": false
+                    }
+                  }
                 }
               },
               "options_timeZoneName_parameter": {


### PR DESCRIPTION
#### Summary

Add missing compatibility information for using a UTC offset string (for example, `"+01:00"`) as the `timeZone` option of `Intl.DateTimeFormat`.

Example:
```js
new Intl.DateTimeFormat("en", {
  timeZone: "+01:00"
});
```

This behavior was standardized in **ECMA-402 11th Edition** (June 2024).

#### Supporting details

This feature is not consistently documented in browser or runtime release notes, so version history was determined using a combination of public sources and manual verification.

Confirmed implementation references:

- Firefox 121
  https://bugzilla.mozilla.org/show_bug.cgi?id=1856291
- Safari 17.4
   https://developer.apple.com/documentation/safari-release-notes/safari-17_4-release-notes
- Chromium / Chrome 120
   https://chromium.googlesource.com/chromium/src/+/052b9f3d67f02c7f5127d2b3257b9764363784c5

#### Verification performed
Browser versions (desktop browsers) were manually tested using BrowserStack. JavaScript runtimes were verified locally.

#### Browser verification

| Browser | Support added |
|---|---|
| Chrome  | 120 |
| Edge | 120 |
| Firefox | 121 |
| Opera | 106 |
| Safari | 17.4 |

**Chrome 119 (suppor missing)**
<img width="550" height="133" alt="chrome_119_utc_offset_not_working" src="https://github.com/user-attachments/assets/fd0ee0ba-9efd-4dad-a2ee-2027f2c41a62" />

 **Chrome 120 (support added)**
<img width="550" height="133" alt="chrome_120_utc_offset_working" src="https://github.com/user-attachments/assets/2646e0c7-e2bb-468c-a95a-48519e10c586" />

**Edge 119 (support missing)**
<img width="553" height="137" alt="edge_119_utc_offset_not_working" src="https://github.com/user-attachments/assets/7d3905a6-5fe8-48e4-a252-9468b21e6ba8" />

**Edge 120 (support added)**
<img width="553" height="108" alt="edge_120_utc_offset_working" src="https://github.com/user-attachments/assets/ef0c2922-06ea-4e91-9cea-a90b7ac85655" />

**Firefox 120 (support missing)**
<img width="502" height="124" alt="firefox_120_utc_offset_not_working" src="https://github.com/user-attachments/assets/c6d8eda8-0e2a-4edc-bf5a-855b99667735" />

**Firefox 121 (support added)**
<img width="502" height="98" alt="firefox_121_utc_offset_working" src="https://github.com/user-attachments/assets/2e62bd4c-f6a9-4a35-96d8-58e75008dcc7" />

**Opera 105 (support missing)**
<img width="553" height="134" alt="opera_105_utc_offset_not_working" src="https://github.com/user-attachments/assets/428b66a8-49e7-4b67-b9d5-e6b0fcfe3456" />

**Opera 106 (support added)**
<img width="553" height="134" alt="opera_106_utc_offset_working" src="https://github.com/user-attachments/assets/a7ad2b86-76f5-4491-8f71-bbed2af70fdf" />

**Safari 17.3 (support missing)**
<img width="879" height="108" alt="safari_17_3_utc_offset_not_working" src="https://github.com/user-attachments/assets/dc6a47a4-79a9-4ca4-a797-72069523818b" />

**Safari 18.4 (support added)** 
**Note**: There is no 17.4 version available in BrowserStack so I used next one available, but release notes from Safari 17.4 are enough.
<img width="879" height="108" alt="safari_18_4_utc_offset_working" src="https://github.com/user-attachments/assets/62533454-9b96-48e9-8059-21d35068b776" />

#### Runtime verification

| Runtime | Support added |
|---|---|
| Bun  | 1.0.19 |
| Deno | 1.38 |
| Node.js | 22.0.0 |

**Bun 1.0.18 (support missing) / Bun 1.0.19 (support added)**
<img width="520" height="191" alt="bun_1_0_19_utc_offset_working" src="https://github.com/user-attachments/assets/bbf18caf-3a12-44f5-8e06-a513be8d8e4d" />

**Deno 1.37 (support missing) / Deno 1.38 (support added)**
<img width="565" height="275" alt="deno_1_38_utc_offset_working" src="https://github.com/user-attachments/assets/74609644-74c6-49e1-857e-709526c9c4be" />

**Node.js 21.7.3 (support missing) / Node.js 22.0.0 (support added)**
<img width="645" height="329" alt="node_22_0_0_utc_offset_working" src="https://github.com/user-attachments/assets/a0f2966b-0c81-4c38-aff4-0e5fda33f264" />
