### PR TITLE
Update version_added for chrome support in color.json

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -284,7 +284,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "147",
                 "impl_url": "https://crbug.com/40142548"
               },
               "chrome_android": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -284,8 +284,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "147",
-                "impl_url": "https://crbug.com/40142548"
+                "version_added": "147"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

Mark `contrast-color` as supported in Chromium.

#### Test results and supporting details

https://issues.chromium.org/issues/40142548
https://chromestatus.com/feature/4841046007742464

#### Related issues

Fixes #29564.
Fixes #29258.