### PR TITLE
Mark `NetworkInformation.{downlinkMax,type}` partial in Chrome

### DIFF
--- a/api/NetworkInformation.json
+++ b/api/NetworkInformation.json
@@ -184,6 +184,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
+              "partial_implementation": true,
               "notes": "Only supported on ChromeOS"
             },
             "chrome_android": {
@@ -348,6 +349,7 @@
           "support": {
             "chrome": {
               "version_added": "61",
+              "partial_implementation": true,
               "notes": "Only supported on ChromeOS"
             },
             "chrome_android": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Marks Chrome support for `NetworkInformation.{downlinkMax,type}` as partial.

#### Test results and supporting details

It is only supported on ChromeOS, i.e. the collector tests are failing:

- https://collector.openwebdocs.org/tests/api/NetworkInformation/downlinkMax
- https://collector.openwebdocs.org/tests/api/NetworkInformation/type

#### Related issues

Related to https://github.com/mdn/browser-compat-data/issues/17913.