### PR TITLE
Add missing `autoplay` attribute to `<audio>`

### DIFF
--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -49,6 +49,49 @@
             "deprecated": false
           }
         },
+        "autoplay": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay",
+            "tags": [
+              "web-features:audio"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "3"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "3.5"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "10.5"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "3.1"
+              },
+              "safari_ios": {
+                "version_added": "10"
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "controls": {
           "__compat": {
             "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-controls",

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -51,6 +51,7 @@
         },
         "autoplay": {
           "__compat": {
+            "description": "`autoplay` attribute",
             "spec_url": "https://html.spec.whatwg.org/multipage/media.html#attr-media-autoplay",
             "tags": [
               "web-features:audio"


### PR DESCRIPTION
#### Summary

The audio element data is missing an entry for the autoplay attribute.

#### Test results and supporting details

Found by the collector.
Data is the same as for the video element.

#### Related issues

None.