### PR TITLE
Add `attr()` fallback values subfeature

### DIFF
--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -128,6 +128,7 @@
         "fallback": {
           "__compat": {
             "description": "fallback values",
+            "spec_url": "https://drafts.csswg.org/css-values-5/#ref-for-typedef-declaration-value②⑥",
             "support": {
               "chrome": {
                 "version_added": "133"

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -125,6 +125,37 @@
             }
           }
         },
+        "fallback": {
+          "__compat": {
+            "description": "fallback values",
+            "support": {
+              "chrome": {
+                "version_added": "133"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "type_function": {
           "__compat": {
             "description": "`type(<syntax>)` function",


### PR DESCRIPTION
#### Summary

The `attr()` function supports fallback values. Add a subfeature for that.

#### Test results and supporting details

- https://developer.apple.com/documentation/safari-release-notes/safari-18_4-release-notes
- https://bugzilla.mozilla.org/show_bug.cgi?id=1448248
- https://chromestatus.com/feature/4680129030651904

#### Related issues

- I should file a content issue so that https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/attr gets updated. (experimental banner should be removed).
- https://github.com/mdn/browser-compat-data/pull/28661 did more Chrome 133 `attr()` updates.