### PR TITLE
Add `shape-outside: rect()`

### DIFF
--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -406,6 +406,42 @@
             }
           }
         },
+        "rect": {
+          "__compat": {
+            "description": "`rect()`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/basic-shape/rect",
+            "spec_url": "https://drafts.csswg.org/css-shapes/#funcdef-basic-shape-rect",
+            "tags": [
+              "web-features:shape-outside"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "17.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "xywh": {
           "__compat": {
             "description": "`xywh()`",


### PR DESCRIPTION
#### Summary

Add shape-outside: rect()

#### Test results and supporting details

Collector results

#### Related issues

Follow-up to https://github.com/mdn/browser-compat-data/pull/29284
See also https://github.com/openwebdocs/mdn-bcd-collector/pull/3115
