### PR TITLE
Chrome 144 `XRSession` `visibilitymaskchange` event

### DIFF
--- a/api/XRSession.json
+++ b/api/XRSession.json
@@ -1542,6 +1542,43 @@
           }
         }
       },
+      "visibilitymaskchange_event": {
+        "__compat": {
+          "description": "`visibilitymaskchange` event",
+          "spec_url": "https://immersive-web.github.io/webxr/#eventdef-xrsession-visibilitymaskchange",
+          "tags": [
+            "web-features:webxr-device"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "144"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "visibilityState": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XRSession/visibilityState",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 144 adds support for the `visibilitymaskchange` event/`XRVisibilityMaskChange` event object; see https://chromestatus.com/feature/5073760055066624.

Data for the `XRVisibilityMaskChange` event object was already added, but data for the event itself was missing.

This PR adds a data point for the event.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
