### PR TITLE
Document spec_url guidelines

### DIFF
--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -78,7 +78,7 @@ When a specification extends the definition of another specification, it makes s
 
 When the interface has "entries", "forEach", "get", "has", "keys", "values", "@@iterator" methods and a "size" getter via "maplike", "setlike", or "iterable" IDL constructs, link to the interface containing the definition and not to the IDL standard.
 
-```json
+```text
 👍  "spec_url": "https://webaudio.github.io/web-audio-api/#audioparammap",
 
 👍  "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssnumericarray",

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -2,6 +2,8 @@
 
 The browser-compat-data project (BCD) uses the `spec_url` property to map compatibility data to features described in specifications.
 
+The following `spec_url` guidelines give advice on how to provide good links to specifications. They are based on a discussion in [#29582](https://github.com/mdn/browser-compat-data/pull/29582/).
+
 ## Benefits
 
 Maintaining pointers to specifications from BCD features provides several benefits:
@@ -113,6 +115,6 @@ If the `[SecureContext]` flag appears in front of an WebIDL method definition, u
       "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatorua-useragentdata",
 ```
 
-## Avoid text fragment links
+### Avoid text fragment links
 
 Specification URLs are validated against [webref](https://github.com/w3c/webref) IDs to make sure BCD only records features which are actually defined in the provided specification. Linking to text using `#:~:text=` fragment identifiers opts out of this validation. Use this opt-out rarely.

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -35,7 +35,11 @@ In addition to the validated rules above, the following best practices have emer
 
 ### Aim to provide just one URL
 
-The `spec_url` property allows to take an array of multiple URLs, but most of the time it is best to provide just the most meaningful URL. For example, don't add multiple (historical) versions of specifications.
+The `spec_url` property allows to take an array of multiple URLs, however, as a general guiding principle, provide just the single most meaningful URL. For example, don't add multiple (historical) versions of specifications.
+
+If you find yourself in a situation where your BCD (behavioral) feature points to several URLs of a specification, this could actually be a strong hint that you should split up the feature into multiple BCD feature keys.
+
+See below for cases where we actually recommend multiple URLs (events and specifications extending other specifications).
 
 ### Events
 
@@ -47,6 +51,19 @@ For events, provide two URLs: one for the `.onevent` property definition, and on
   "https://drafts.csswg.org/web-animations-1/#cancel-event"
 ],
 ```
+
+### Specifications extending other specifications
+
+When a specification extends the definition of another specification, it makes sense to list both as `spec_urls`. For example:
+
+- ECMA 262 is extended by ECMA 402
+  - https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-date.prototype.tolocaledatestring
+  - https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring
+- SVG and CSS both define a property
+  - https://drafts.csswg.org/css-inline/#baseline-shift-property
+  - https://w3c.github.io/svgwg/svg2-draft/text.html#BaselineShiftProperty
+- API interfaces which have a core definition and and extended in other specifications.
+- CSS properties which an initial definition in one level of a spec, and are completed in a subsequent diff spec.
 
 ### Maplikes, Setlikes, Iterables
 

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -25,7 +25,8 @@ If a specification is listed in browser-specs and has a [standing](https://githu
 If BCD's linter complains about the provided URL, you will need to check its state within browser-specs. Common scenarios include:
 
 - The specification is not yet part of browser-specs. Check whether an issue already exists; if not, open one and ask whether the W3C would consider adding the specification.
-- The specification no longer has a "good" standing. Check if there is a new version of the specification (at a different URL), or if the specification development has been discontinued (and the features in BCD should be considered "non-standard" from this point on). If the specification cannot be added to browser-specs, but there is a reason it should be in BCD, you can add it to BCD's [specification host exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/linter/test-spec-urls.js). Only do this as a last resort.
+- The specification no longer has a "good" standing. Check if there is a new version of the specification (at a different URL), or if the specification development has been discontinued (and the features in BCD should be considered "non-standard" from this point on).
+- If the specification cannot be added to browser-specs, but there is a reason it should be in BCD, you can add it to BCD's [specification host exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/common/spec-urls-exceptions.txt). Only do this as a last resort. The specifications hosted at https://github.com/WebAssembly and https://registry.khronos.org/webgl/extensions/ are part of the exception list by default.
 - The specification URL doesn't contain a fragment identifier. You will have to add one. It looks like this: `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`.
 
 ## Best practices

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -1,0 +1,62 @@
+# Data guidelines for the `spec_url` property
+
+The browser-compat-data project (BCD) uses the `spec_url` property to map compatibility data to features described in specifications.
+
+## Benefits
+
+Maintaining pointers to specifications from BCD features provides several benefits:
+
+- Specifications can show compatibility data inline next to feature definitions.
+- If a `spec_url` is provided, BCD itself or other data consumers, can treat the feature as standardized. In the absence of a `spec_url`, we could say that the feature is non-standard.
+- By using deep links (fragment identifiers), BCD can more precisely identify the feature. This can be helpful when trying to understand descriptions of BCD feature keys, for example.
+- It enables statistics and coverage analysis. Which BCD features are standardized? Which standards bodies standardize? And more.
+
+## Schema definition and validation
+
+The `spec_url` property is defined and validated by the BCD JSON schema: It may be either a single URL or an array of URLs, each pointing to a specific part of a specification where the feature is defined.
+
+The `spec_url` property is required if `standard_track` is set to `true`. However, currently, there is an [exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/common/standard-track-exceptions.txt) for this requirement. BCD maintainers are working through this backlog. It updates automatically when you add a URL to a feature that doesn't currently have a `spec_url` property.
+
+Each URL must link to a specification published by a standards body or a formal proposal that may lead to such publication.
+To determine whether a specification host is valid, BCD relies on data from the [w3c/browser-specs](https://github.com/w3c/browser-specs) project.
+
+If a specification is listed in browser-specs and has a [standing](https://github.com/w3c/browser-specs#standing) of "good", the URL will be accepted in BCD's `spec_url` field.
+
+If BCD's linter complains about the provided URL, you will need to check its state within browser-specs. Common scenarios include:
+
+- The specification is not yet part of browser-specs. Check whether an issue already exists; if not, open one one and ask whether the W3C would consider adding the specification.
+- The specification no longer has a "good" standing. Check if there is a new version of the specification (at a different URL), or if the specification development has been discontinued (and the features in BCD should be considered "non-standard" from this point on). If the specification cannot be added to browser-specs, but there is a reason it should be in BCD, you can add it to BCD's [specification host exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/linter/test-spec-urls.js). Only do this as a last resort.
+- The specification URL doesn't contain a fragment identifier. You will have to add one. It looks like this: `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`.
+
+## Best practices
+
+In addition to the validated rules above, the following best practices have emerged:
+
+### Events
+
+For events, provide two URLs: one for the `.onevent` property definition, and one for the event itself.
+
+```json
+"spec_url": [
+  "https://drafts.csswg.org/web-animations-1/#dom-animation-oncancel",
+  "https://drafts.csswg.org/web-animations-1/#cancel-event"
+],
+```
+
+### Maplikes, Setlikes, Iterables
+
+When the interface has "entries", "forEach", "get", "has", "keys", "values", "@@iterator" methods and a "size" getter via "maplike", "setlike", or "iterable" IDL constructs, link to the interface containing the definition and not to the IDL standard.
+
+```json
+👍  "spec_url": "https://webaudio.github.io/web-audio-api/#audioparammap",
+
+👍  "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssnumericarray",
+
+👎  "spec_url": "https://webidl.spec.whatwg.org/#dfn-maplike",
+
+👎  "spec_url": "https://webidl.spec.whatwg.org/#dfn-iterable",
+```
+
+### Worker support, secure_context_required
+
+For BCD keys named `worker_support` and `secure_context_required`, link to the main interface specification, since these IDL flags appear alongside the interface definition (for example, `[SecureContext, Exposed=(Window,Worker)]`).

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -8,7 +8,7 @@ Maintaining pointers to specifications from BCD features provides several benefi
 
 - Specifications can show compatibility data inline next to feature definitions.
 - If a `spec_url` is provided, BCD itself or other data consumers, can treat the feature as standardized. In the absence of a `spec_url`, we could say that the feature is non-standard.
-- By using deep links (fragment identifiers), BCD can more precisely identify the feature. This can be helpful when trying to understand descriptions of BCD feature keys, for example.
+- By having validated deep links (fragment identifiers), BCD can more precisely identify the feature and we can be sure it really exists in the provided specification. Fragment ids are also helpful when trying to understand descriptions of BCD behavioral features.
 - It enables statistics and coverage analysis. Which BCD features are standardized? Which standards bodies standardize? And more.
 
 ## Schema definition and validation
@@ -28,6 +28,7 @@ If BCD's linter complains about the provided URL, you will need to check its sta
 - The specification no longer has a "good" standing. Check if there is a new version of the specification (at a different URL), or if the specification development has been discontinued (and the features in BCD should be considered "non-standard" from this point on).
 - If the specification cannot be added to browser-specs, but there is a reason it should be in BCD, you can add it to BCD's [specification host exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/common/spec-urls-exceptions.txt). Only do this as a last resort. The specifications hosted at https://github.com/WebAssembly and https://registry.khronos.org/webgl/extensions/ are part of the exception list by default.
 - The specification URL doesn't contain a fragment identifier. You will have to add one. It looks like this: `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`.
+- The specification URL's fragment identifier does not validate against [webref](https://github.com/w3c/webref) IDs. Try to provide a better fragment identifier. Or, only as a last resort, use text fragments (`~:text=`).
 
 ## Best practices
 
@@ -105,3 +106,7 @@ If the `[SecureContext]` flag appears in front of an WebIDL method definition, u
       "description": "Secure context required",
       "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatorua-useragentdata",
 ```
+
+## Avoid text fragment links
+
+Specification URLs are validated against [webref](https://github.com/w3c/webref) IDs to make sure BCD only records features which are actually defined in the provided specification. Linking to text using `~:text=` fragment identifiers opts out of this validation. Use this opt-out rarely.

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -10,6 +10,7 @@ Maintaining pointers to specifications from BCD features provides several benefi
 - If a `spec_url` is provided, BCD itself or other data consumers, can treat the feature as standardized. In the absence of a `spec_url`, we could say that the feature is non-standard.
 - By having validated deep links (fragment identifiers), BCD can more precisely identify the feature and we can be sure it really exists in the provided specification. Fragment ids are also helpful when trying to understand descriptions of BCD behavioral features.
 - It enables statistics and coverage analysis. Which BCD features are standardized? Which standards bodies standardize? And more.
+- It helps developers and implementers know where to give feedback on a feature's defined behavior.
 
 ## Schema definition and validation
 
@@ -41,6 +42,11 @@ The `spec_url` property allows to take an array of multiple URLs, however, as a 
 If you find yourself in a situation where your BCD (behavioral) feature points to several URLs of a specification, this could actually be a strong hint that you should split up the feature into multiple BCD feature keys.
 
 See below for cases where we actually recommend multiple URLs (events and specifications extending other specifications).
+
+### Removed features
+
+If a feature has been removed from a specification, this is a _de facto_ deprecation (see [Setting `deprecated`](./README.md#setting-deprecated)).
+If possible, set the feature's `spec_url` to point to current specification text that acknowledges the removal (for example, a _Changes_ section).
 
 ### Events
 

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -24,7 +24,7 @@ If a specification is listed in browser-specs and has a [standing](https://githu
 
 If BCD's linter complains about the provided URL, you will need to check its state within browser-specs. Common scenarios include:
 
-- The specification is not yet part of browser-specs. Check whether an issue already exists; if not, open one one and ask whether the W3C would consider adding the specification.
+- The specification is not yet part of browser-specs. Check whether an issue already exists; if not, open one and ask whether the W3C would consider adding the specification.
 - The specification no longer has a "good" standing. Check if there is a new version of the specification (at a different URL), or if the specification development has been discontinued (and the features in BCD should be considered "non-standard" from this point on). If the specification cannot be added to browser-specs, but there is a reason it should be in BCD, you can add it to BCD's [specification host exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/linter/test-spec-urls.js). Only do this as a last resort.
 - The specification URL doesn't contain a fragment identifier. You will have to add one. It looks like this: `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`.
 
@@ -61,6 +61,29 @@ When the interface has "entries", "forEach", "get", "has", "keys", "values", "@@
 👎  "spec_url": "https://webidl.spec.whatwg.org/#dfn-iterable",
 ```
 
-### Worker support, secure_context_required
+### WebIDL flags
 
-For BCD keys named `worker_support` and `secure_context_required`, link to the main interface specification, since these IDL flags appear alongside the interface definition (for example, `[SecureContext, Exposed=(Window,Worker)]`).
+WebIDL flags can map to certain BCD feature keys:
+
+- `[SecureContext]` uses `secure_context_required`
+- `[Exposed=Worker]` (and similar) use `worker_support`
+
+WebIDL flags belong to specific WebIDL features, like an interface or a method. The specifications offer no direct link to flag definitions, therefore the specification URL used for the feature itself should be used.
+
+For example, if the `[SecureContext]` flag appears in front of an WebIDL interface definition, the `spec_url` for the `secure_context_required` feature is the same as the interface's `spec_url`.
+
+```json
+"secure_context_required": {
+  "__compat": {
+    "description": "Secure context required",
+    "spec_url": "https://w3c.github.io/battery/#the-batterymanager-interface",
+```
+
+If the `[SecureContext]` flag appears in front of an WebIDL method definition, use the `spec_url` for the method.
+
+```json
+"secure_context_required": {
+    "__compat": {
+      "description": "Secure context required",
+      "spec_url": "https://wicg.github.io/ua-client-hints/#dom-navigatorua-useragentdata",
+```

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -28,7 +28,7 @@ If BCD's linter complains about the provided URL, you will need to check its sta
 - The specification no longer has a "good" standing. Check if there is a new version of the specification (at a different URL), or if the specification development has been discontinued (and the features in BCD should be considered "non-standard" from this point on).
 - If the specification cannot be added to browser-specs, but there is a reason it should be in BCD, you can add it to BCD's [specification host exception list](https://github.com/mdn/browser-compat-data/blob/main/lint/common/spec-urls-exceptions.txt). Only do this as a last resort. The specifications hosted at https://github.com/WebAssembly and https://registry.khronos.org/webgl/extensions/ are part of the exception list by default.
 - The specification URL doesn't contain a fragment identifier. You will have to add one. It looks like this: `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`.
-- The specification URL's fragment identifier does not validate against [webref](https://github.com/w3c/webref) IDs. Try to provide a better fragment identifier. Or, only as a last resort, use text fragments (`~:text=`).
+- The specification URL's fragment identifier does not validate against [webref](https://github.com/w3c/webref) IDs. Try to provide a better fragment identifier. Or, only as a last resort, use text fragments (`#:~:text=`).
 
 ## Best practices
 
@@ -109,4 +109,4 @@ If the `[SecureContext]` flag appears in front of an WebIDL method definition, u
 
 ## Avoid text fragment links
 
-Specification URLs are validated against [webref](https://github.com/w3c/webref) IDs to make sure BCD only records features which are actually defined in the provided specification. Linking to text using `~:text=` fragment identifiers opts out of this validation. Use this opt-out rarely.
+Specification URLs are validated against [webref](https://github.com/w3c/webref) IDs to make sure BCD only records features which are actually defined in the provided specification. Linking to text using `#:~:text=` fragment identifiers opts out of this validation. Use this opt-out rarely.

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -30,7 +30,11 @@ If BCD's linter complains about the provided URL, you will need to check its sta
 
 ## Best practices
 
-In addition to the validated rules above, the following best practices have emerged:
+In addition to the validated rules above, the following best practices have emerged.
+
+### Aim to provide just one URL
+
+The `spec_url` property allows to take an array of multiple URLs, but most of the time it is best to provide just the most meaningful URL. For example, don't add multiple (historical) versions of specifications.
 
 ### Events
 

--- a/docs/data-guidelines/spec_links.md
+++ b/docs/data-guidelines/spec_links.md
@@ -79,13 +79,13 @@ When a specification extends the definition of another specification, it makes s
 When the interface has "entries", "forEach", "get", "has", "keys", "values", "@@iterator" methods and a "size" getter via "maplike", "setlike", or "iterable" IDL constructs, link to the interface containing the definition and not to the IDL standard.
 
 ```text
-👍  "spec_url": "https://webaudio.github.io/web-audio-api/#audioparammap",
+✅  "spec_url": "https://webaudio.github.io/web-audio-api/#audioparammap",
 
-👍  "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssnumericarray",
+✅  "spec_url": "https://drafts.css-houdini.org/css-typed-om/#cssnumericarray",
 
-👎  "spec_url": "https://webidl.spec.whatwg.org/#dfn-maplike",
+❌  "spec_url": "https://webidl.spec.whatwg.org/#dfn-maplike",
 
-👎  "spec_url": "https://webidl.spec.whatwg.org/#dfn-iterable",
+❌  "spec_url": "https://webidl.spec.whatwg.org/#dfn-iterable",
 ```
 
 ### WebIDL flags

--- a/schemas/compat-data-schema.md
+++ b/schemas/compat-data-schema.md
@@ -183,9 +183,10 @@ The `__compat` object consists of the following:
 - An optional `mdn_url` property which **points to an MDN reference page documenting the feature**.
   It needs to be a valid URL, and should be the language-neutral URL (e.g. use `https://developer.mozilla.org/docs/Web/CSS/text-align` instead of `https://developer.mozilla.org/en-US/docs/Web/CSS/text-align`).
 
-- An optional `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined.
-  Each URL must either contain a fragment identifier (e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`), or else must match the regular-expression pattern `^https://registry.khronos.org/webgl/extensions/[^/]+/` (e.g. `https://registry.khronos.org/webgl/extensions/ANGLE_instanced_arrays/`).
-  Each URL must link to a specification published by a standards body or a formal proposal that may lead to such publication.
+- A `spec_url` property as a URL or an array of URLs, each of which is for a specific part of a specification in which this feature is defined.
+  Each URL must link to a specification published by a standards body or a formal proposal that may lead to such publication. It must also contain a fragment identifier (a deep link, e.g. `https://tc39.es/proposal-promise-allSettled/#sec-promise.allsettled`).
+
+  For more guidance on how to set the `spec_url` property, see the [`spec_url` data guidelines](https://github.com/mdn/browser-compat-data/tree/main/docs/data-guidelines/spec_links.md).
 
 - An optional `tags` property which is an array of strings allowing to assign tags to the feature.
   Each tag in the array must be namespaced. The currently allowed namespaces are:


### PR DESCRIPTION
#### Summary

I would like to move forward with better `spec_url` implementation and validation in BCD.

 In order to review big PRs like https://github.com/mdn/browser-compat-data/pull/29223, I think it makes sense to paint the bigger picture, so this is what this PR does: Document the `spec_url` property properly and start collecting best practices as data guidelines.

#### Test results and supporting details

No tests, this is project documentation only.

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/29223
- https://github.com/mdn/browser-compat-data/issues/29065
- https://github.com/mdn/browser-compat-data/pull/23958
- https://github.com/mdn/browser-compat-data/pull/27671