### PR TITLE
fix(scripts/diff-flat): derive BROWSER_NAMES from bcd.browsers

### DIFF
--- a/scripts/diff-flat.js
+++ b/scripts/diff-flat.js
@@ -15,22 +15,14 @@ import stripAnsi from 'strip-ansi';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
+import bcd from '../index.js';
 import { spawn, walk } from '../utils/index.js';
 
 import { addVersionLast, applyMirroring, transformMD } from './build/index.js';
 import { getMergeBase, getFileContent, getGitDiffStatuses } from './lib/git.js';
 import dataFolders from './lib/data-folders.js';
 
-const BROWSER_NAMES = [
-  'chrome',
-  'chrome_android',
-  'edge',
-  'firefox',
-  'firefox_android',
-  'safari',
-  'safari_ios',
-  'webview_android',
-];
+const BROWSER_NAMES = Object.keys(bcd.browsers);
 
 /** @type {Format[]} */
 const FORMATS = ['html', 'plain'];


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the `diff:flat` script, deriving the full list of browser names from `bcd.browsers` instead of hard-coding an incomplete subset.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Noticed as part of https://github.com/mdn/browser-compat-data/pull/29561.