### PR TITLE
Privacy Sandbox APIs are non-standard

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8209,7 +8209,6 @@
       "requestStorageAccessFor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/requestStorageAccessFor",
-          "spec_url": "https://privacycg.github.io/requestStorageAccessFor/#dom-document-requeststorageaccessfor",
           "tags": [
             "web-features:related-website-sets"
           ],
@@ -8239,7 +8238,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLAnchorElement.json
+++ b/api/HTMLAnchorElement.json
@@ -81,7 +81,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -90,7 +90,6 @@
       "attributionSrc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAnchorElement/attributionSrc",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -117,7 +116,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -89,7 +89,6 @@
       },
       "attributionSrc": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -116,7 +115,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -49,7 +49,6 @@
       },
       "adAuctionHeaders": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-htmliframeelement-adauctionheaders",
           "support": {
             "chrome": {
               "version_added": "122"
@@ -72,9 +71,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -1093,7 +1092,6 @@
       },
       "sharedStorageWritable": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#html-attr",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -1120,7 +1118,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -180,7 +180,6 @@
       "attributionSrc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLImageElement/attributionSrc",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -207,7 +206,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -1031,7 +1030,6 @@
       },
       "sharedStorageWritable": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#html-attr",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -1058,7 +1056,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/HTMLScriptElement.json
+++ b/api/HTMLScriptElement.json
@@ -92,7 +92,6 @@
       "attributionSrc": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLScriptElement/attributionSrc",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-htmlattributionsrcelementutils-attributionsrc",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -119,7 +118,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -505,7 +505,6 @@
       },
       "canLoadAdAuctionFencedFrame": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-canloadadauctionfencedframe",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -528,9 +527,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -761,7 +760,6 @@
       },
       "clearOriginJoinedAdInterestGroups": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-clearoriginjoinedadinterestgroups",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -784,9 +782,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -990,7 +988,6 @@
       },
       "createAuctionNonce": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#create-auction-nonce",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -1013,9 +1010,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -1099,7 +1096,6 @@
       },
       "deprecatedRunAdAuctionEnforcesKAnonymity": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-deprecatedrunadauctionenforceskanonymity",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -1122,9 +1118,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -1625,7 +1621,6 @@
       },
       "getInterestGroupAdAuctionData": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#getInterestGroupAdAuctionData",
           "support": {
             "chrome": {
               "version_added": "132"
@@ -1648,9 +1643,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -2103,7 +2098,6 @@
       },
       "joinAdInterestGroup": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-joinadinterestgroup",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -2126,9 +2120,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -2284,7 +2278,6 @@
       },
       "leaveAdInterestGroup": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-leaveadinterestgroup",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -2307,9 +2300,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -3278,7 +3271,6 @@
       },
       "protectedAudience": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-protectedaudience",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -3301,9 +3293,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -4812,7 +4804,6 @@
       },
       "runAdAuction": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-runadauction",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -4835,9 +4826,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },
@@ -5422,7 +5413,6 @@
       },
       "updateAdInterestGroups": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-navigator-updateadinterestgroups",
           "support": {
             "chrome": {
               "version_added": "128"
@@ -5445,9 +5435,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -908,7 +908,6 @@
       "permission_top-level-storage-access": {
         "__compat": {
           "description": "`top-level-storage-access` permission",
-          "spec_url": "https://privacycg.github.io/requestStorageAccessFor/#permissions-integration",
           "tags": [
             "web-features:related-website-sets"
           ],
@@ -938,9 +937,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/ProtectedAudience.json
+++ b/api/ProtectedAudience.json
@@ -2,7 +2,6 @@
   "api": {
     "ProtectedAudience": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/turtledove/#protectedaudience",
         "support": {
           "chrome": {
             "version_added": "127"
@@ -25,14 +24,13 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
-          "standard_track": true,
-          "deprecated": false
+          "experimental": false,
+          "standard_track": false,
+          "deprecated": true
         }
       },
       "queryFeatureSupport": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/turtledove/#dom-protectedaudience-queryfeaturesupport",
           "support": {
             "chrome": {
               "version_added": "127"
@@ -55,9 +53,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       }

--- a/api/Request.json
+++ b/api/Request.json
@@ -192,7 +192,6 @@
           "attributionReporting": {
             "__compat": {
               "description": "`attributionReporting` property",
-              "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-requestinit-attributionreporting",
               "tags": [
                 "web-features:attribution-reporting"
               ],
@@ -225,7 +224,7 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
+                "standard_track": false,
                 "deprecated": true
               }
             }

--- a/api/SharedStorage.json
+++ b/api/SharedStorage.json
@@ -3,7 +3,6 @@
     "SharedStorage": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage",
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorage",
         "tags": [
           "web-features:shared-storage"
         ],
@@ -30,14 +29,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "append": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/append",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-append",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -64,14 +62,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "batchUpdate": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-batchupdate",
           "tags": [
             "web-features:shared-storage-locks"
           ],
@@ -100,7 +97,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -108,7 +105,6 @@
       "clear": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/clear",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-clear",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -135,14 +131,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "createWorklet": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-createworklet",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -171,7 +166,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -179,7 +174,6 @@
       "delete": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/delete",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-delete",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -206,14 +200,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "get": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-get",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -243,14 +236,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "run": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-run",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -279,14 +271,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "selectURL": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-selecturl",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -315,7 +306,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -323,7 +314,6 @@
       "set": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorage/set",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-set",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -350,14 +340,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "worklet": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorage-worklet",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -386,7 +375,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/SharedStorageAppendMethod.json
+++ b/api/SharedStorageAppendMethod.json
@@ -2,7 +2,6 @@
   "api": {
     "SharedStorageAppendMethod": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorageappendmethod",
         "tags": [
           "web-features:shared-storage-locks"
         ],
@@ -31,14 +30,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "SharedStorageAppendMethod": {
         "__compat": {
           "description": "`SharedStorageAppendMethod()` constructor",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageappendmethod-sharedstorageappendmethod",
           "tags": [
             "web-features:shared-storage-locks"
           ],
@@ -67,7 +65,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/SharedStorageClearMethod.json
+++ b/api/SharedStorageClearMethod.json
@@ -2,7 +2,6 @@
   "api": {
     "SharedStorageClearMethod": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorageclearmethod",
         "tags": [
           "web-features:shared-storage-locks"
         ],
@@ -31,14 +30,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "SharedStorageClearMethod": {
         "__compat": {
           "description": "`SharedStorageClearMethod()` constructor",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageclearmethod-sharedstorageclearmethod",
           "tags": [
             "web-features:shared-storage-locks"
           ],
@@ -67,7 +65,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/SharedStorageDeleteMethod.json
+++ b/api/SharedStorageDeleteMethod.json
@@ -2,7 +2,6 @@
   "api": {
     "SharedStorageDeleteMethod": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstoragedeletemethod",
         "tags": [
           "web-features:shared-storage-locks"
         ],
@@ -31,14 +30,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "SharedStorageDeleteMethod": {
         "__compat": {
           "description": "`SharedStorageDeleteMethod()` constructor",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstoragedeletemethod-sharedstoragedeletemethod",
           "tags": [
             "web-features:shared-storage-locks"
           ],
@@ -67,7 +65,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/SharedStorageModifierMethod.json
+++ b/api/SharedStorageModifierMethod.json
@@ -2,7 +2,6 @@
   "api": {
     "SharedStorageModifierMethod": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstoragemodifiermethod",
         "tags": [
           "web-features:shared-storage-locks"
         ],
@@ -31,7 +30,7 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       }

--- a/api/SharedStorageSetMethod.json
+++ b/api/SharedStorageSetMethod.json
@@ -2,7 +2,6 @@
   "api": {
     "SharedStorageSetMethod": {
       "__compat": {
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstoragesetmethod",
         "tags": [
           "web-features:shared-storage-locks"
         ],
@@ -31,14 +30,13 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "SharedStorageSetMethod": {
         "__compat": {
           "description": "`SharedStorageSetMethod()` constructor",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstoragesetmethod-sharedstoragesetmethod",
           "tags": [
             "web-features:shared-storage-locks"
           ],
@@ -67,7 +65,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/SharedStorageWorklet.json
+++ b/api/SharedStorageWorklet.json
@@ -3,7 +3,6 @@
     "SharedStorageWorklet": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorageWorklet",
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorageworklet",
         "tags": [
           "web-features:shared-storage"
         ],
@@ -30,13 +29,12 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "run": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworklet-run",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -63,14 +61,13 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
       },
       "selectURL": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworklet-selecturl",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -97,7 +94,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/SharedStorageWorkletGlobalScope.json
+++ b/api/SharedStorageWorkletGlobalScope.json
@@ -3,7 +3,6 @@
     "SharedStorageWorkletGlobalScope": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorageWorkletGlobalScope",
-        "spec_url": "https://wicg.github.io/shared-storage/#sharedstorageworkletglobalscope",
         "tags": [
           "web-features:shared-storage"
         ],
@@ -30,13 +29,12 @@
         },
         "status": {
           "experimental": false,
-          "standard_track": true,
+          "standard_track": false,
           "deprecated": true
         }
       },
       "interestGroups": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworkletglobalscope-interestgroups",
           "support": {
             "chrome": {
               "version_added": "134"
@@ -60,7 +58,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -68,7 +66,6 @@
       "register": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorageWorkletGlobalScope/register",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworkletglobalscope-register",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -95,7 +92,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }
@@ -103,7 +100,6 @@
       "sharedStorage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SharedStorageWorkletGlobalScope/sharedStorage",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-sharedstorageworkletglobalscope-sharedstorage",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -130,7 +126,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/Window.json
+++ b/api/Window.json
@@ -6867,7 +6867,6 @@
       "sharedStorage": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Window/sharedStorage",
-          "spec_url": "https://wicg.github.io/shared-storage/#dom-window-sharedstorage",
           "tags": [
             "web-features:shared-storage"
           ],
@@ -6897,7 +6896,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/XMLHttpRequest.json
+++ b/api/XMLHttpRequest.json
@@ -1553,7 +1553,6 @@
       "setAttributionReporting": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/XMLHttpRequest/setAttributionReporting",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-xmlhttprequest-setattributionreporting",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -1580,7 +1579,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/api/_globals/fetch.json
+++ b/api/_globals/fetch.json
@@ -173,7 +173,6 @@
         "attributionReporting": {
           "__compat": {
             "description": "`attributionReporting` property",
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#dom-requestinit-attributionreporting",
             "tags": [
               "web-features:attribution-reporting"
             ],
@@ -206,7 +205,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/html/elements/a.json
+++ b/html/elements/a.json
@@ -77,7 +77,6 @@
         },
         "attributionsrc": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-a-attributionsrc",
             "tags": [
               "web-features:attribution-reporting"
             ],
@@ -104,7 +103,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -81,7 +81,6 @@
         },
         "attributionsrc": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-area-attributionsrc",
             "tags": [
               "web-features:attribution-reporting"
             ],
@@ -108,7 +107,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -192,7 +192,6 @@
           },
           "attribution-reporting": {
             "__compat": {
-              "spec_url": "https://wicg.github.io/attribution-reporting-api/#permission-policy-integration",
               "tags": [
                 "web-features:attribution-reporting"
               ],
@@ -219,7 +218,7 @@
               },
               "status": {
                 "experimental": false,
-                "standard_track": true,
+                "standard_track": false,
                 "deprecated": true
               }
             }

--- a/html/elements/img.json
+++ b/html/elements/img.json
@@ -183,7 +183,6 @@
         },
         "attributionsrc": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-img-attributionsrc",
             "tags": [
               "web-features:attribution-reporting"
             ],
@@ -210,7 +209,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/html/elements/script.json
+++ b/html/elements/script.json
@@ -88,7 +88,6 @@
         },
         "attributionsrc": {
           "__compat": {
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#element-attrdef-script-attributionsrc",
             "tags": [
               "web-features:attribution-reporting"
             ],
@@ -115,7 +114,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/http/headers/Attribution-Reporting-Eligible.json
+++ b/http/headers/Attribution-Reporting-Eligible.json
@@ -4,7 +4,6 @@
       "Attribution-Reporting-Eligible": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Attribution-Reporting-Eligible",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#attribution-reporting-eligible",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -31,7 +30,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/Attribution-Reporting-Register-Source.json
+++ b/http/headers/Attribution-Reporting-Register-Source.json
@@ -4,7 +4,6 @@
       "Attribution-Reporting-Register-Source": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Attribution-Reporting-Register-Source",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#parse-source-registration-json",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -31,7 +30,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/Attribution-Reporting-Register-Trigger.json
+++ b/http/headers/Attribution-Reporting-Register-Trigger.json
@@ -4,7 +4,6 @@
       "Attribution-Reporting-Register-Trigger": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Attribution-Reporting-Register-Trigger",
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#create-an-attribution-trigger",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -31,7 +30,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/Attribution-Reporting-Support.json
+++ b/http/headers/Attribution-Reporting-Support.json
@@ -3,7 +3,6 @@
     "headers": {
       "Attribution-Reporting-Support": {
         "__compat": {
-          "spec_url": "https://wicg.github.io/attribution-reporting-api/#attribution-reporting-support",
           "tags": [
             "web-features:attribution-reporting"
           ],
@@ -30,7 +29,7 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
+            "standard_track": false,
             "deprecated": true
           }
         }

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -113,7 +113,6 @@
         "attribution-reporting": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/attribution-reporting",
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#permission-policy-integration",
             "tags": [
               "web-features:feature-policy"
             ],
@@ -140,7 +139,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -150,7 +150,6 @@
         "attribution-reporting": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/attribution-reporting",
-            "spec_url": "https://wicg.github.io/attribution-reporting-api/#permission-policy-integration",
             "tags": [
               "web-features:attribution-reporting"
             ],
@@ -177,7 +176,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": true
             }
           }


### PR DESCRIPTION
#### Summary

Google's "Privacy Sandbox" APIs are no longer part of specifications with a _good_ standing. The standing is now _discontinued_. See https://github.com/w3c/browser-specs/pull/2458.

#### Test results and supporting details

None.

#### Related issues

Unblocks https://github.com/mdn/browser-compat-data/pull/29588.