### PR TITLE
Firefox 151 adds container style queries

### DIFF
--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -404,7 +404,24 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.style-queries.enabled",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "layout.css.attr.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": [
+                    "https://bugzil.la/1795622",
+                    "https://bugzil.la/1986631",
+                    "https://bugzil.la/1998245"
+                  ]
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -361,15 +361,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.style-queries.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1795622"
+                "version_added": "151"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/at-rules/container.json
+++ b/css/at-rules/container.json
@@ -410,7 +410,6 @@
                     }
                   ],
                   "impl_url": [
-                    "https://bugzil.la/1795622",
                     "https://bugzil.la/1986631",
                     "https://bugzil.la/1998245"
                   ]


### PR DESCRIPTION
#### Summary

- Updated FF suport for `@container style()` queries
- Added FF support for  `@container style()` queries _range syntax_

#### Test results and supporting details

- Tested  `@container style()` queries, using [codepen](https://codepen.io/CodeRedDigital/pen/XJjwdap) in:
  - Firefox Beta 151
  - Firefox Developer Edition 151
  - Firefox Nightly 152
- Tested  `@container style()` queries _range syntax_ with the flag `layout.css.attr.enabled`, using [codepen](https://codepen.io/CodeRedDigital/pen/xbRbXKy) in:
  - Firefox Beta 151
  - Firefox Developer Edition 151
  - Firefox Nightly 152

#### Related issues

- [Content PR](https://github.com/mdn/content/pull/44003)
- [FF Release PR](https://github.com/mdn/content/pull/44002)
