### PR TITLE
chore(lint): remove obsolete spec exceptions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-# See GOVERNANCE.md for more about this repository's owners 
+# See GOVERNANCE.md for more about this repository's owners
 # and this project's governance.
 
 # Order is important: The last matching pattern takes precedence.
@@ -21,6 +21,5 @@
 # Exclude some paths
 /.github/ISSUE_TEMPLATE/
 /.github/PULL_REQUEST_TEMPLATE.md
-/lint/common/spec-urls-exceptions.txt
-/lint/common/standard-track-exceptions.txt
+/lint/common/*.txt
 /*.md

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,5 +20,7 @@
 
 # Exclude some paths
 /.github/ISSUE_TEMPLATE/
-/.github/PULL_REQUESET_TEMPLATE.md
+/.github/PULL_REQUEST_TEMPLATE.md
+/lint/common/spec-urls-exceptions.txt
+/lint/common/standard-track-exceptions.txt
 /*.md

--- a/lint/common/spec-urls-exceptions.js
+++ b/lint/common/spec-urls-exceptions.js
@@ -1,0 +1,17 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const exceptionListPath = join(__dirname, './spec-urls-exceptions.txt');
+
+/**
+ * @returns {Promise<string[]>}
+ */
+export const getSpecURLsExceptions = async () =>
+  (await readFile(exceptionListPath, 'utf-8'))
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith('#'));

--- a/lint/common/spec-urls-exceptions.txt
+++ b/lint/common/spec-urls-exceptions.txt
@@ -1,0 +1,45 @@
+# This file lists spec URLs that are accepted by the spec_url linter
+# even though they are not in https://github.com/w3c/browser-specs.
+#
+# Before adding an exception, open an issue with https://github.com/w3c/browser-specs to
+# see if a spec should be added there instead.
+# When adding an exception here, provide a reason and indicate how the exception can be removed.
+
+# Remove once https://github.com/whatwg/html/pull/6715 is resolved.
+https://wicg.github.io/controls-list/
+
+# Unfortunately this doesn't produce a rendered spec, so it isn't in browser-specs.
+# Remove if it is in the main ECMA spec.
+https://github.com/tc39/proposal-regexp-legacy-features/
+
+# See https://github.com/w3c/browser-specs/issues/305.
+# Features with this URL need to be checked after some time
+# if they have been integrated into a real spec.
+https://w3c.github.io/webrtc-extensions/
+
+# This is being used to develop Error.captureStackTrace() standard.
+# Need to be checked after some time to see if integrated into a real spec.
+https://github.com/tc39/proposal-error-capturestacktrace
+
+# Proposals for WebAssembly.
+https://github.com/WebAssembly/spec/blob/main/proposals
+https://github.com/WebAssembly/exception-handling/blob/main/proposals
+https://github.com/WebAssembly/extended-const/blob/main/proposals
+https://github.com/WebAssembly/tail-call/blob/main/proposals
+https://github.com/WebAssembly/threads/blob/main/proposal
+https://github.com/WebAssembly/relaxed-simd/blob/main/proposals
+https://github.com/WebAssembly/multi-memory/blob/main/proposals
+https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md
+https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md
+https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md
+https://github.com/WebAssembly/js-promise-integration
+https://github.com/WebAssembly/branch-hinting/blob/main/proposals/branch-hinting/Overview.md
+
+# Media types.
+https://developers.google.com/speed/webp/docs/riff_container
+https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification
+https://jpeg.org/jpeg/
+https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/
+https://www.iso.org/standard/89035.html
+https://www.rfc-editor.org/rfc/rfc7903
+https://www.w3.org/Graphics/GIF/spec-gif87.txt

--- a/lint/linter/test-spec-urls.js
+++ b/lint/linter/test-spec-urls.js
@@ -18,15 +18,9 @@ const specsExceptions = [
   // Remove once https://github.com/whatwg/html/pull/6715 is resolved
   'https://wicg.github.io/controls-list/',
 
-  // Exception for April Fools' joke for "418 I'm a teapot"
-  'https://www.rfc-editor.org/rfc/rfc2324',
-
   // Unfortunately this doesn't produce a rendered spec, so it isn't in browser-specs
   // Remove if it is in the main ECMA spec
   'https://github.com/tc39/proposal-regexp-legacy-features/',
-
-  // Remove once tc39/ecma262#3221 is merged
-  'https://github.com/tc39/proposal-regexp-modifiers',
 
   // See https://github.com/w3c/browser-specs/issues/305
   // Features with this URL need to be checked after some time

--- a/lint/linter/test-spec-urls.js
+++ b/lint/linter/test-spec-urls.js
@@ -5,55 +5,11 @@ import { styleText } from 'node:util';
 
 import specData from 'web-specs' with { type: 'json' };
 
+import { getSpecURLsExceptions } from '../common/spec-urls-exceptions.js';
+
 /** @import {Linter, LinterData} from '../types.js' */
 /** @import {Logger} from '../utils.js' */
 /** @import {CompatStatement} from '../../types/types.js' */
-
-/*
- * Before adding an exception, open an issue with https://github.com/w3c/browser-specs to
- * see if a spec should be added there instead.
- * When adding an exception here, provide a reason and indicate how the exception can be removed.
- */
-const specsExceptions = [
-  // Remove once https://github.com/whatwg/html/pull/6715 is resolved
-  'https://wicg.github.io/controls-list/',
-
-  // Unfortunately this doesn't produce a rendered spec, so it isn't in browser-specs
-  // Remove if it is in the main ECMA spec
-  'https://github.com/tc39/proposal-regexp-legacy-features/',
-
-  // See https://github.com/w3c/browser-specs/issues/305
-  // Features with this URL need to be checked after some time
-  // if they have been integrated into a real spec
-  'https://w3c.github.io/webrtc-extensions/',
-
-  // This is being used to develop Error.captureStackTrace() standard
-  // Need to be checked after some time to see if integrated into a real spec
-  'https://github.com/tc39/proposal-error-capturestacktrace',
-
-  // Proposals for WebAssembly
-  'https://github.com/WebAssembly/spec/blob/main/proposals',
-  'https://github.com/WebAssembly/exception-handling/blob/main/proposals',
-  'https://github.com/WebAssembly/extended-const/blob/main/proposals',
-  'https://github.com/WebAssembly/tail-call/blob/main/proposals',
-  'https://github.com/WebAssembly/threads/blob/main/proposal',
-  'https://github.com/WebAssembly/relaxed-simd/blob/main/proposals',
-  'https://github.com/WebAssembly/multi-memory/blob/main/proposals',
-  'https://github.com/WebAssembly/memory64/blob/main/proposals/memory64/Overview.md',
-  'https://github.com/WebAssembly/js-string-builtins/blob/main/proposals/js-string-builtins/Overview.md',
-  'https://github.com/WebAssembly/function-references/blob/main/proposals/function-references/Overview.md',
-  'https://github.com/WebAssembly/js-promise-integration',
-  'https://github.com/WebAssembly/branch-hinting/blob/main/proposals/branch-hinting/Overview.md',
-
-  // Media types
-  'https://developers.google.com/speed/webp/docs/riff_container',
-  'https://developers.google.com/speed/webp/docs/webp_lossless_bitstream_specification',
-  'https://jpeg.org/jpeg/',
-  'https://www.adobe.com/devnet-apps/photoshop/fileformatashtml/',
-  'https://www.iso.org/standard/89035.html',
-  'https://www.rfc-editor.org/rfc/rfc7903',
-  'https://www.w3.org/Graphics/GIF/spec-gif87.txt',
-];
 
 const allowedSpecURLs = [
   .../** @type {string[]} */ (
@@ -68,7 +24,7 @@ const allowedSpecURLs = [
       .flat()
       .filter((url) => !!url)
   ),
-  ...specsExceptions,
+  ...(await getSpecURLsExceptions()),
 ];
 
 /**


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the `spec_url` exception list, removing two no longer used entries.

Also extracts this exception list to a `lint/common/spec-url-exceptions.txt`, without requiring approval from `@mdn/engineering`.

#### Test results and supporting details

Checked that the other ones are all still in use, and not in web-specs.

#### Related issues

Triggered by https://github.com/mdn/browser-compat-data/pull/29582#discussion_r3171144136.