### PR TITLE
Safari 26.4 adds navigational-prefetch behind a flag

### DIFF
--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -412,7 +412,13 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26.4",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "SpeculationRules prefetch"
+                  }
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Safari supports `navigational-prefetch` `deliveryType` in Resource Timing behind a flag.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

- Turn on the flag
- Visit https://chrome.dev/prerender-demos/prefetch.html
- Click on the first link

Results:

<img width="1310" height="833" alt="image" src="https://github.com/user-attachments/assets/9a0be035-a0ff-415c-b3fa-9827eeee6600" />


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
