### PR TITLE
Node 26 adds Temporal API

### DIFF
--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -842,9 +842,16 @@
         "25.2.0": {
           "release_date": "2025-11-11",
           "release_notes": "https://nodejs.org/en/blog/release/v25.2.0",
-          "status": "current",
+          "status": "retired",
           "engine": "V8",
           "engine_version": "14.1"
+        },
+        "26.0.0": {
+          "release_date": "2026-05-05",
+          "release_notes": "https://nodejs.org/en/blog/release/v26.0.0",
+          "status": "current",
+          "engine": "V8",
+          "engine_version": "14.6"
         }
       }
     }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3212,7 +3212,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -23,7 +23,7 @@
             },
             "firefox_android": "mirror",
             "nodejs": {
-              "version_added": false
+              "version_added": "26.0.0"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -65,7 +65,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -107,7 +107,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -149,7 +149,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -191,7 +191,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -233,7 +233,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -275,7 +275,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -317,7 +317,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -359,7 +359,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -401,7 +401,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -443,7 +443,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -485,7 +485,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -527,7 +527,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -569,7 +569,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -611,7 +611,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -653,7 +653,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -695,7 +695,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -737,7 +737,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -779,7 +779,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -821,7 +821,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -863,7 +863,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -905,7 +905,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -947,7 +947,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -989,7 +989,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1031,7 +1031,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1073,7 +1073,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1115,7 +1115,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -66,7 +66,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -108,7 +108,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -150,7 +150,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -192,7 +192,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -234,7 +234,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -276,7 +276,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -318,7 +318,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -360,7 +360,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -402,7 +402,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -444,7 +444,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -486,7 +486,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -528,7 +528,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -570,7 +570,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -612,7 +612,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -654,7 +654,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -696,7 +696,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -738,7 +738,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -780,7 +780,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -64,7 +64,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -106,7 +106,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -148,7 +148,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -190,7 +190,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -232,7 +232,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -274,7 +274,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -66,7 +66,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -108,7 +108,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -150,7 +150,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -192,7 +192,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -234,7 +234,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -276,7 +276,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -318,7 +318,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -360,7 +360,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -402,7 +402,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -444,7 +444,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -486,7 +486,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -528,7 +528,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -570,7 +570,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -612,7 +612,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -654,7 +654,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -696,7 +696,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -738,7 +738,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -780,7 +780,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -822,7 +822,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -864,7 +864,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -906,7 +906,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -948,7 +948,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -990,7 +990,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1032,7 +1032,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1074,7 +1074,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1116,7 +1116,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1158,7 +1158,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1200,7 +1200,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1242,7 +1242,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1284,7 +1284,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1326,7 +1326,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1370,7 +1370,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1412,7 +1412,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1454,7 +1454,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -66,7 +66,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -108,7 +108,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -150,7 +150,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -192,7 +192,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -234,7 +234,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -276,7 +276,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -318,7 +318,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -360,7 +360,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -402,7 +402,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -444,7 +444,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -486,7 +486,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -528,7 +528,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -570,7 +570,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -612,7 +612,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -654,7 +654,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -696,7 +696,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -738,7 +738,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -780,7 +780,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -822,7 +822,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -864,7 +864,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -906,7 +906,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -948,7 +948,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -990,7 +990,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1032,7 +1032,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1074,7 +1074,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1116,7 +1116,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1158,7 +1158,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1200,7 +1200,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1242,7 +1242,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1284,7 +1284,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1326,7 +1326,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1368,7 +1368,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1410,7 +1410,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1452,7 +1452,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1494,7 +1494,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1536,7 +1536,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1578,7 +1578,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1622,7 +1622,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1664,7 +1664,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1706,7 +1706,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1748,7 +1748,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -66,7 +66,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -108,7 +108,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -150,7 +150,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -192,7 +192,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -234,7 +234,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -276,7 +276,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -318,7 +318,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -360,7 +360,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -402,7 +402,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -444,7 +444,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -486,7 +486,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -528,7 +528,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -65,7 +65,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -107,7 +107,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -149,7 +149,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -191,7 +191,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -233,7 +233,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -275,7 +275,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -317,7 +317,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -359,7 +359,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -401,7 +401,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -443,7 +443,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -485,7 +485,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -527,7 +527,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -569,7 +569,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -611,7 +611,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -653,7 +653,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -695,7 +695,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -737,7 +737,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -779,7 +779,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -821,7 +821,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -863,7 +863,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -66,7 +66,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -108,7 +108,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -150,7 +150,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -192,7 +192,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -234,7 +234,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -276,7 +276,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -318,7 +318,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -360,7 +360,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -402,7 +402,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -444,7 +444,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -486,7 +486,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -528,7 +528,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -570,7 +570,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -612,7 +612,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -654,7 +654,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -696,7 +696,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -738,7 +738,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -780,7 +780,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -822,7 +822,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -864,7 +864,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -906,7 +906,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -948,7 +948,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -990,7 +990,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1032,7 +1032,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -23,7 +23,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",
@@ -66,7 +66,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -108,7 +108,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -150,7 +150,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -192,7 +192,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -234,7 +234,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -276,7 +276,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -318,7 +318,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -360,7 +360,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -402,7 +402,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -444,7 +444,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -486,7 +486,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -528,7 +528,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -570,7 +570,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -612,7 +612,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -654,7 +654,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -696,7 +696,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -738,7 +738,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -780,7 +780,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -822,7 +822,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -864,7 +864,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -906,7 +906,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -948,7 +948,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -990,7 +990,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1032,7 +1032,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1074,7 +1074,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1116,7 +1116,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1158,7 +1158,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1200,7 +1200,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1242,7 +1242,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1284,7 +1284,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1326,7 +1326,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1368,7 +1368,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1410,7 +1410,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1452,7 +1452,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1494,7 +1494,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1536,7 +1536,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1578,7 +1578,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1620,7 +1620,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1662,7 +1662,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1704,7 +1704,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1746,7 +1746,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1788,7 +1788,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1830,7 +1830,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1872,7 +1872,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1914,7 +1914,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -1956,7 +1956,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -2000,7 +2000,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -2042,7 +2042,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -2084,7 +2084,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -2126,7 +2126,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",
@@ -2168,7 +2168,7 @@
                 },
                 "firefox_android": "mirror",
                 "nodejs": {
-                  "version_added": false
+                  "version_added": "26.0.0"
                 },
                 "oculus": "mirror",
                 "opera": "mirror",


### PR DESCRIPTION
#### Summary

Indicate that Node supports the Temporal API in `v26.0.0` ([release notes](https://nodejs.org/en/blog/release/v26.0.0#temporal-api)).

#### Test results and supporting details

Node's Temporal support is based on V8 (see https://github.com/nodejs/node/issues/57127), so all methods should be correctly implemented from the start.

I built a small [test script](https://gist.github.com/blue2cat/513ad5790fefd77551c02428f59e527e) to confirm that Node 26 supports Temporal. 

#### Related issues
Fixes #29611 