### PR TITLE
Gamepad API no longer requires secure context

### DIFF
--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -77,9 +77,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -61,7 +61,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "91"
+              "version_added": "91",
+              "version_removed": "125"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Gamepad.json
+++ b/api/Gamepad.json
@@ -49,14 +49,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#restrict-gamepad-access",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -46,14 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#restrict-gamepad-access",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -74,9 +74,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/GamepadButton.json
+++ b/api/GamepadButton.json
@@ -58,7 +58,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "91"
+              "version_added": "91",
+              "version_removed": "125"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -114,9 +114,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -98,7 +98,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "91"
+              "version_added": "91",
+              "version_removed": "125"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/GamepadEvent.json
+++ b/api/GamepadEvent.json
@@ -86,14 +86,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#restrict-gamepad-access",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -46,14 +46,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "86",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#restrict-gamepad-access",
-                  "value_to_set": "Enabled"
-                }
-              ]
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -58,7 +58,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "91"
+              "version_added": "91",
+              "version_removed": "125"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/GamepadHapticActuator.json
+++ b/api/GamepadHapticActuator.json
@@ -75,8 +75,8 @@
           },
           "status": {
             "experimental": false,
-            "standard_track": true,
-            "deprecated": false
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -66,9 +66,9 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
+            "experimental": false,
+            "standard_track": false,
+            "deprecated": true
           }
         }
       },

--- a/api/GamepadPose.json
+++ b/api/GamepadPose.json
@@ -50,7 +50,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "91"
+              "version_added": "91",
+              "version_removed": "125"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1518,14 +1518,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "86",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#restrict-gamepad-access",
-                    "value_to_set": "Enabled"
-                  }
-                ]
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1551,9 +1551,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         }

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1530,7 +1530,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "91"
+                "version_added": "91",
+                "version_removed": "125"
               },
               "firefox_android": {
                 "version_added": false

--- a/lint/common/standard-track-exceptions.txt
+++ b/lint/common/standard-track-exceptions.txt
@@ -216,11 +216,6 @@ api.GPURenderBundleEncoder.setVertexBuffer.unset_vertex_buffer
 api.GPURenderPassEncoder.setBindGroup.unset_bind_group
 api.GPURenderPassEncoder.setVertexBuffer.unset_vertex_buffer
 api.GPUSupportedFeatures.feature_subgroups.subgroup_id_num_subgroups
-api.Gamepad.secure_context_required
-api.GamepadButton.secure_context_required
-api.GamepadEvent.secure_context_required
-api.GamepadHapticActuator.secure_context_required
-api.GamepadPose.secure_context_required
 api.Geolocation.secure_context_required
 api.GeolocationCoordinates.secure_context_required
 api.GeolocationPosition.secure_context_required
@@ -404,7 +399,6 @@ api.NDEFRecord.secure_context_required
 api.Navigator.authentication
 api.Navigator.geolocation.secure_context_required
 api.Navigator.getBattery.secure_context_required
-api.Navigator.getGamepads.secure_context_required
 api.Navigator.mediaDevices.secure_context_required
 api.Navigator.registerProtocolHandler.scheme_parameter_bitcoin
 api.Navigator.registerProtocolHandler.scheme_parameter_ftp


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates Gamepad API's `secure_context_required` features:

- Chrome unshipped the flag.
- Firefox 125 unshipped the requirement.
- Mark the feature as deprecated, non-standard.

#### Test results and supporting details

- Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1870037

#### Related issues

Extracted from https://github.com/mdn/browser-compat-data/pull/29223.