### PR TITLE
Chrome 148 adds `LanguageModel.destroy()`

### DIFF
--- a/api/LanguageModel.json
+++ b/api/LanguageModel.json
@@ -293,6 +293,39 @@
           }
         }
       },
+      "destroy": {
+        "__compat": {
+          "spec_url": "https://webmachinelearning.github.io/writing-assistance-apis/#dom-destroyablemodel-destroy",
+          "support": {
+            "chrome": {
+              "version_added": "148"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "measureContextUsage": {
         "__compat": {
           "spec_url": "https://webmachinelearning.github.io/prompt-api/#dom-languagemodel-measurecontextusage",

--- a/api/LanguageModel.json
+++ b/api/LanguageModel.json
@@ -300,16 +300,17 @@
             "chrome": {
               "version_added": "148"
             },
-            "chrome_android": "mirror",
-            "edge": {
+            "chrome_android": {
               "version_added": false
             },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
             "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": false


### PR DESCRIPTION
#### Summary

LanguageModels can be destroyed ;) 

#### Test results and supporting details

Collector run.

#### Related issues

This was forgotten in https://github.com/mdn/browser-compat-data/pull/29474