### PR TITLE
Updates for Chrome 149 beta

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -9,7 +9,7 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "147"
+            "version_added": "149"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -49,7 +49,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "147"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -86,7 +86,7 @@
           "spec_url": "https://drafts.csswg.org/css-pseudo-4/#dom-csspseudoelement-parent",
           "support": {
             "chrome": {
-              "version_added": "147"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -117,7 +117,7 @@
           "spec_url": "https://drafts.csswg.org/css-pseudo-4/#dom-csspseudoelement-pseudo",
           "support": {
             "chrome": {
-              "version_added": "147"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -152,7 +152,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "147"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -8233,7 +8233,7 @@
           "spec_url": "https://www.w3.org/TR/css-pseudo-4/#window-interface",
           "support": {
             "chrome": {
-              "version_added": "147"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -141,6 +141,37 @@
           }
         }
       },
+      "allowProcessingInstruction": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-allowprocessinginstruction",
+          "support": {
+            "chrome": {
+              "version_added": "149"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "get": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Sanitizer/get",
@@ -241,6 +272,37 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeProcessingInstruction": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/sanitizer-api/#dom-sanitizer-removeprocessinginstruction",
+          "support": {
+            "chrome": {
+              "version_added": "149"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/column-rule-break.json
+++ b/css/properties/column-rule-break.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-break",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-intersection",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-none",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-normal",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/column-rule-inset-cap-end.json
+++ b/css/properties/column-rule-inset-cap-end.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "column-rule-inset-cap-end": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-cap-end",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/column-rule-inset-cap-start.json
+++ b/css/properties/column-rule-inset-cap-start.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "column-rule-inset-cap-start": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-cap-start",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/column-rule-inset-cap.json
+++ b/css/properties/column-rule-inset-cap.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "column-rule-inset-cap": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-cap",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/column-rule-inset-end.json
+++ b/css/properties/column-rule-inset-end.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-end",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/column-rule-inset-junction-end.json
+++ b/css/properties/column-rule-inset-junction-end.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "column-rule-inset-junction-end": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-junction-end",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/column-rule-inset-junction-start.json
+++ b/css/properties/column-rule-inset-junction-start.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "column-rule-inset-junction-start": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-junction-start",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/column-rule-inset-junction.json
+++ b/css/properties/column-rule-inset-junction.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "column-rule-inset-junction": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-junction",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/column-rule-inset-start.json
+++ b/css/properties/column-rule-inset-start.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-start",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/column-rule-inset.json
+++ b/css/properties/column-rule-inset.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/column-rule-visibility-items.json
+++ b/css/properties/column-rule-visibility-items.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-visibility-items",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-all",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-around",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-between",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-normal",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/row-rule-break.json
+++ b/css/properties/row-rule-break.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-break",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-intersection",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-none",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-normal",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/row-rule-color.json
+++ b/css/properties/row-rule-color.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-color",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/row-rule-inset-cap-end.json
+++ b/css/properties/row-rule-inset-cap-end.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "row-rule-inset-cap-end": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-cap-end",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/row-rule-inset-cap-start.json
+++ b/css/properties/row-rule-inset-cap-start.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "row-rule-inset-cap-start": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-column-rule-inset-cap-start",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/row-rule-inset-cap.json
+++ b/css/properties/row-rule-inset-cap.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "row-rule-inset-cap": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-cap",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/row-rule-inset-end.json
+++ b/css/properties/row-rule-inset-end.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-end",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/row-rule-inset-junction-end.json
+++ b/css/properties/row-rule-inset-junction-end.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "row-rule-inset-junction-end": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-junction-end",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/row-rule-inset-junction-start.json
+++ b/css/properties/row-rule-inset-junction-start.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "row-rule-inset-junction-start": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-junction-start",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/row-rule-inset-junction.json
+++ b/css/properties/row-rule-inset-junction.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "row-rule-inset-junction": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-junction",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/row-rule-inset-start.json
+++ b/css/properties/row-rule-inset-start.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset-start",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/row-rule-inset.json
+++ b/css/properties/row-rule-inset.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-inset",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/row-rule-style.json
+++ b/css/properties/row-rule-style.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-style",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +160,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -191,7 +191,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -222,7 +222,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -253,7 +253,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -284,7 +284,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -315,7 +315,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/row-rule-visibility-items.json
+++ b/css/properties/row-rule-visibility-items.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-visibility-items",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-all",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-around",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-between",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-normal",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/row-rule-width.json
+++ b/css/properties/row-rule-width.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule-width",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/row-rule.json
+++ b/css/properties/row-rule.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-row-rule",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +160,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -191,7 +191,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -222,7 +222,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -253,7 +253,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -284,7 +284,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -315,7 +315,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -346,7 +346,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -377,7 +377,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -408,7 +408,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -439,7 +439,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -470,7 +470,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule-break.json
+++ b/css/properties/rule-break.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-break",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-intersection",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-none",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-break-normal",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule-color.json
+++ b/css/properties/rule-color.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-color",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-color-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule-inset-cap.json
+++ b/css/properties/rule-inset-cap.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "rule-inset-cap": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset-cap",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/rule-inset-end.json
+++ b/css/properties/rule-inset-end.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset-end",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/rule-inset-junction.json
+++ b/css/properties/rule-inset-junction.json
@@ -1,9 +1,9 @@
 {
   "css": {
     "properties": {
-      "rule-inset": {
+      "rule-inset-junction": {
         "__compat": {
-          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset",
+          "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset-junction",
           "support": {
             "chrome": {
               "version_added": "149"

--- a/css/properties/rule-inset-start.json
+++ b/css/properties/rule-inset-start.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-inset-start",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/rule-overlap.json
+++ b/css/properties/rule-overlap.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-overlap",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-rule-overlap-column-over-row",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-rule-overlap-row-over-column",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule-style.json
+++ b/css/properties/rule-style.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-style",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +160,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -191,7 +191,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -222,7 +222,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -253,7 +253,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -284,7 +284,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -315,7 +315,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-style-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule-visibility-items.json
+++ b/css/properties/rule-visibility-items.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-visibility-items",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-all",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-around",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-between",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-column-rule-visibility-items-normal",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule-width.json
+++ b/css/properties/rule-width.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule-width",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-line-width-list",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/rule.json
+++ b/css/properties/rule.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-gaps-1/#propdef-rule",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +160,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -191,7 +191,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -222,7 +222,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -253,7 +253,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -284,7 +284,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -315,7 +315,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -346,7 +346,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -377,7 +377,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -408,7 +408,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -439,7 +439,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -470,7 +470,7 @@
             "spec_url": "https://drafts.csswg.org/css-gaps-1/#typedef-gap-rule",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/shape-outside.json
+++ b/css/properties/shape-outside.json
@@ -345,7 +345,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -416,7 +416,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -452,7 +452,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "149"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -1189,7 +1189,7 @@
                   "version_added": "1.2.18"
                 },
                 "chrome": {
-                  "version_added": false
+                  "version_added": "149"
                 },
                 "chrome_android": "mirror",
                 "deno": {


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.17.12) found new features shipping in Chromium 149 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Canary/behind origin trials/enrollment/isolated contexts, it is not considered here.

With this PR, BCD will consider the following 135 features as shipping in Chromium 149 (**bold** features are new keys in BCD).

CSSPseudoElement was previously marked as shipping in 147 but from looking at https://issues.chromium.org/issues/40639103 it seems that some flag flipping was going on, so maybe this got delayed to 149:
- api.CSSPseudoElement
- api.CSSPseudoElement.element
- api.CSSPseudoElement.parent
- api.CSSPseudoElement.pseudo
- api.CSSPseudoElement.type
- api.Element.pseudo

Sanitizing processing instructions, https://issuetracker.google.com/issues/503180637
**- api.Sanitizer.allowProcessingInstruction**
**- api.Sanitizer.removeProcessingInstruction**

Shape outside https://chromestatus.com/feature/5080980370096128, https://chromestatus.com/feature/6323071520735232
- css.properties.shape-outside.path
- css.properties.shape-outside.rect
- css.properties.shape-outside.xywh

Locale variants https://chromestatus.com/feature/4709921706868736
- javascript.builtins.Intl.Locale.variants

CSS Gap Decoration, https://chromestatus.com/feature/5157805733183488), **(all keys are new)**
- css.properties.column-rule-break 
- css.properties.column-rule-break.intersection
- css.properties.column-rule-break.none
- css.properties.column-rule-break.normal
- css.properties.column-rule-inset-cap-end
- css.properties.column-rule-inset-cap-start
- css.properties.column-rule-inset-cap
- css.properties.column-rule-inset-end
- css.properties.column-rule-inset-junction-end
- css.properties.column-rule-inset-junction-start
- css.properties.column-rule-inset-junction
- css.properties.column-rule-inset-start
- css.properties.column-rule-inset
- css.properties.column-rule-visibility-items
- css.properties.column-rule-visibility-items.all
- css.properties.column-rule-visibility-items.around
- css.properties.column-rule-visibility-items.between
- css.properties.column-rule-visibility-items.normal
- css.properties.row-rule-break
- css.properties.row-rule-break.intersection
- css.properties.row-rule-break.none
- css.properties.row-rule-break.normal
- css.properties.row-rule-color
- css.properties.row-rule-color.currentColor
- css.properties.row-rule-color.transparent
- css.properties.row-rule-inset-cap-end
- css.properties.row-rule-inset-cap-start
- css.properties.row-rule-inset-cap
- css.properties.row-rule-inset-end
- css.properties.row-rule-inset-junction-end
- css.properties.row-rule-inset-junction-start
- css.properties.row-rule-inset-junction
- css.properties.row-rule-inset-start
- css.properties.row-rule-inset
- css.properties.row-rule-style
- css.properties.row-rule-style.dashed
- css.properties.row-rule-style.dotted
- css.properties.row-rule-style.double
- css.properties.row-rule-style.groove
- css.properties.row-rule-style.hidden
- css.properties.row-rule-style.inset
- css.properties.row-rule-style.none
- css.properties.row-rule-style.outset
- css.properties.row-rule-style.ridge
- css.properties.row-rule-style.solid
- css.properties.row-rule-visibility-items
- css.properties.row-rule-visibility-items.all
- css.properties.row-rule-visibility-items.around
- css.properties.row-rule-visibility-items.between
- css.properties.row-rule-visibility-items.normal
- css.properties.row-rule-width
- css.properties.row-rule-width.medium
- css.properties.row-rule-width.thick
- css.properties.row-rule-width.thin
- css.properties.row-rule
- css.properties.row-rule.currentColor
- css.properties.row-rule.dashed
- css.properties.row-rule.dotted
- css.properties.row-rule.double
- css.properties.row-rule.groove
- css.properties.row-rule.hidden
- css.properties.row-rule.inset
- css.properties.row-rule.medium
- css.properties.row-rule.none
- css.properties.row-rule.outset
- css.properties.row-rule.ridge
- css.properties.row-rule.solid
- css.properties.row-rule.thick
- css.properties.row-rule.thin
- css.properties.row-rule.transparent
- css.properties.rule-break
- css.properties.rule-break.intersection
- css.properties.rule-break.none
- css.properties.rule-break.normal
- css.properties.rule-color
- css.properties.rule-color.currentColor
- css.properties.rule-color.transparent
- css.properties.rule-inset-cap
- css.properties.rule-inset-end
- css.properties.rule-inset-junction
- css.properties.rule-inset-start
- css.properties.rule-inset
- css.properties.rule-overlap
- css.properties.rule-overlap.column-over-row
- css.properties.rule-overlap.row-over-column
- css.properties.rule-style
- css.properties.rule-style.dashed
- css.properties.rule-style.dotted
- css.properties.rule-style.double
- css.properties.rule-style.groove
- css.properties.rule-style.hidden
- css.properties.rule-style.inset
- css.properties.rule-style.none
- css.properties.rule-style.outset
- css.properties.rule-style.ridge
- css.properties.rule-style.solid
- css.properties.rule-visibility-items
- css.properties.rule-visibility-items.all
- css.properties.rule-visibility-items.around
- css.properties.rule-visibility-items.between
- css.properties.rule-visibility-items.normal
- css.properties.rule-width
- css.properties.rule-width.medium
- css.properties.rule-width.thick
- css.properties.rule-width.thin
- css.properties.rule
- css.properties.rule.currentColor
- css.properties.rule.dashed
- css.properties.rule.dotted
- css.properties.rule.double
- css.properties.rule.groove
- css.properties.rule.hidden
- css.properties.rule.inset
- css.properties.rule.medium
- css.properties.rule.none
- css.properties.rule.outset
- css.properties.rule.ridge
- css.properties.rule.solid
- css.properties.rule.thick
- css.properties.rule.thin
- css.properties.rule.transparent

Updated in a different PR:
- manifests.webapp.migrate_from
- manifests.webapp.migrate_to

See also https://developer.chrome.com/blog/chrome-149-beta