### PR TITLE
Mark `baseline-shift: baseline` as deprecated

### DIFF
--- a/css/properties/baseline-shift.json
+++ b/css/properties/baseline-shift.json
@@ -68,7 +68,7 @@
             "status": {
               "experimental": false,
               "standard_track": true,
-              "deprecated": false
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
#### Summary

Marks `baseline-shift: baseline` as deprecated.

#### Test results and supporting details

The spec says:

> User agents may additionally support the keyword baseline as
> computing to 0 if is necessary for them to support legacy SVG content.

See: https://drafts.csswg.org/css-inline-3/#valdef-baseline-shift-baseline

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29513.