### PR TITLE
`anchor-size()`: make consistent with `margin`, `inset` data

### DIFF
--- a/css/types/anchor-size.json
+++ b/css/types/anchor-size.json
@@ -38,7 +38,7 @@
         },
         "inset_margin": {
           "__compat": {
-            "description": "Valid in inset and margin property values.",
+            "description": "Valid in `inset` and `margin` property values.",
             "spec_url": "https://www.w3.org/TR/css-logical-1/#inset-properties,https://www.w3.org/TR/css-box-4/#margin-properties",
             "tags": [
               "web-features:anchor-positioning"
@@ -50,8 +50,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1972610"
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This aligns `css.types.anchor-size.inset_margin` with `css.properties.inset.anchor-size`, `css.properties.margin.anchor-size`, and many others.

#### Test results and supporting details

No test results. I'm assuming that the data given by the other features is correct and this one—being different—is wrong.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- I think this was an omission in https://github.com/mdn/browser-compat-data/pull/28649.
- Other anchor position consistency work: https://github.com/mdn/browser-compat-data/pull/29628
- In support of resolving https://github.com/web-platform-dx/web-features/issues/3558

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
