### PR TITLE
WebView Android 114 mirrored CHIPS support

### DIFF
--- a/http/headers/Set-Cookie.json
+++ b/http/headers/Set-Cookie.json
@@ -157,9 +157,7 @@
               ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
-              "webview_android": {
-                "version_added": false
-              },
+              "webview_android": "mirror",
               "webview_ios": "mirror"
             },
             "status": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

WebView Android 114 mirrored CHIPS support.

#### Test results and supporting details

It's either 114 or 134, but probably 114 according to Android source code comment.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29621.