### PR TITLE
`position-area: span-all`: Mark Firefox bug as fixed, consistently

### DIFF
--- a/css/properties/position-area.json
+++ b/css/properties/position-area.json
@@ -1124,11 +1124,17 @@
               ],
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "147",
-                "partial_implementation": true,
-                "notes": "Using `span-all` unexpectedly allows the anchored box to overflow the viewport, obscuring content. Use `place-self: anchor-center` as a workaround. See [bug 2008537](https://bugzil.la/2008537)."
-              },
+              "firefox": [
+                {
+                  "version_added": "148"
+                },
+                {
+                  "version_added": "147",
+                  "version_removed": "148",
+                  "partial_implementation": true,
+                  "notes": "Using `span-all` unexpectedly allows the anchored box to overflow the viewport, obscuring content. Use `place-self: anchor-center` as a workaround. See [bug 2008537](https://bugzil.la/2008537)."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION

#### Summary

[Firefox bug 2008537](https://bugzilla.mozilla.org/show_bug.cgi?id=2008537) is resolved, but this didn't get reflected in every support statement to which it applied.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This was inconsistently resolved in https://github.com/mdn/browser-compat-data/pull/28761. See https://github.com/mdn/browser-compat-data/pull/28761#pullrequestreview-3631096548.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/28761/
- [Firefox bug 2008537](https://bugzilla.mozilla.org/show_bug.cgi?id=2008537)
- Other anchor position consistency work: https://github.com/mdn/browser-compat-data/pull/29626
- In support of resolving https://github.com/web-platform-dx/web-features/issues/3558

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
