### PR TITLE
`position-area`: `normal` is the initial value in Firefox 151

### DIFF
--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -30,11 +30,17 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "147",
-              "partial_implementation": true,
-              "notes": "The initial value is `auto` instead of `normal` (see [bug 2030351](https://bugzil.la/2030351)."
-            },
+            "firefox": [
+              {
+                "version_added": "151"
+              },
+              {
+                "version_added": "147",
+                "version_removed": "151",
+                "partial_implementation": true,
+                "notes": "The initial value is `auto` instead of `normal` (see [bug 2030351](https://bugzil.la/2030351)."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`position-area: normal` is the default as of Firefox 151.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The collector run https://github.com/mdn/browser-compat-data/pull/29530 added support for `normal`. This PR propagates the change in initial value up to the property.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Previously: https://github.com/mdn/browser-compat-data/pull/29483
- Related: https://github.com/mdn/browser-compat-data/pull/29530
- [Firefox bug 2030351](https://bugzilla.mozilla.org/show_bug.cgi?id=2030351)
- Tests: https://github.com/web-platform-tests/wpt/pull/59307
- In support of resolving https://github.com/web-platform-dx/web-features/issues/3558

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
