### PR TITLE
Add Firefox impl url for `stretch` sizing value

### DIFF
--- a/css/properties/block-size.json
+++ b/css/properties/block-size.json
@@ -288,7 +288,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/flex-basis.json
+++ b/css/properties/flex-basis.json
@@ -303,7 +303,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/flex.json
+++ b/css/properties/flex.json
@@ -293,7 +293,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/inline-size.json
+++ b/css/properties/inline-size.json
@@ -294,7 +294,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/max-block-size.json
+++ b/css/properties/max-block-size.json
@@ -278,7 +278,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/max-height.json
+++ b/css/properties/max-height.json
@@ -339,7 +339,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/max-inline-size.json
+++ b/css/properties/max-inline-size.json
@@ -284,7 +284,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/max-width.json
+++ b/css/properties/max-width.json
@@ -360,7 +360,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/min-block-size.json
+++ b/css/properties/min-block-size.json
@@ -272,7 +272,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/min-height.json
+++ b/css/properties/min-height.json
@@ -346,7 +346,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/min-inline-size.json
+++ b/css/properties/min-inline-size.json
@@ -278,7 +278,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/min-width.json
+++ b/css/properties/min-width.json
@@ -377,7 +377,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1789477"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add Firefox bug for CSS Sizing Level 4 `stretch` value.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29620.
