### PR TITLE
`getPublicKey()`: add per-algorithm subfeatures

### DIFF
--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -165,9 +165,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16",
-              "partial_implementation": true,
-              "notes": "Supports only algorithm -7 (ES256). Does not support algorithms -8 (Ed25519) and -257 (RS256). See [bug 312081](https://webkit.org/b/312081)."
+              "version_added": "16"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -180,6 +178,119 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "algorithm_EdDSA": {
+          "__compat": {
+            "description": "`-8` (EdDSA) algorithm keys",
+            "spec_url": "https://w3c.github.io/webauthn/#sctn-public-key-easy:~:text=%2D8%20%28EdDSA%29%2C",
+            "tags": [
+              "web-features:webauthn-public-key-easy"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "notes": "Returns `null`. See [bug 312081](https://webkit.org/b/312081)."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "algorithm_ES256": {
+          "__compat": {
+            "description": "`-7` (ECDSA w/ SHA-256) algorithm keys",
+            "spec_url": "https://w3c.github.io/webauthn/#sctn-public-key-easy:~:text=%2D7%20%28ES256%29%2C",
+            "tags": [
+              "web-features:webauthn-public-key-easy"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "algorithm_RS256": {
+          "__compat": {
+            "description": "`-257` (RSASSA-PKCS1-v1_5 using SHA-256) algorithm keys",
+            "spec_url": "https://w3c.github.io/webauthn/#sctn-public-key-easy:~:text=257%20%28RS256%29%2E",
+            "tags": [
+              "web-features:webauthn-public-key-easy"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "119"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "notes": "Returns `null`. See [bug 312081](https://webkit.org/b/312081)."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
           }
         }
       },

--- a/api/AuthenticatorAttestationResponse.json
+++ b/api/AuthenticatorAttestationResponse.json
@@ -180,7 +180,7 @@
             "deprecated": false
           }
         },
-        "algorithm_EdDSA": {
+        "algorithm_eddsa": {
           "__compat": {
             "description": "`-8` (EdDSA) algorithm keys",
             "spec_url": "https://w3c.github.io/webauthn/#sctn-public-key-easy:~:text=%2D8%20%28EdDSA%29%2C",
@@ -218,7 +218,7 @@
             }
           }
         },
-        "algorithm_ES256": {
+        "algorithm_es256": {
           "__compat": {
             "description": "`-7` (ECDSA w/ SHA-256) algorithm keys",
             "spec_url": "https://w3c.github.io/webauthn/#sctn-public-key-easy:~:text=%2D7%20%28ES256%29%2C",
@@ -255,7 +255,7 @@
             }
           }
         },
-        "algorithm_RS256": {
+        "algorithm_rs256": {
           "__compat": {
             "description": "`-257` (RSASSA-PKCS1-v1_5 using SHA-256) algorithm keys",
             "spec_url": "https://w3c.github.io/webauthn/#sctn-public-key-easy:~:text=257%20%28RS256%29%2E",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Break out algorithm support in `api.AuthenticatorAttestationResponse.getPublicKey` into separate subfeatures.

#### Test results and supporting details

This partially unwinds the change in https://github.com/mdn/browser-compat-data/pull/29458, which marked the whole method as partial.

While these algorithms are a "MUST" requirement in the [specification text](https://w3c.github.io/webauthn/#dom-authenticatorattestationresponse-getpublickey:~:text=null%2E-,User,Ed25519%29%2E), this behavior has been missing from Safari from its inception in 2022 but only reported as a bug a few weeks ago.

This is unlikely to meet our [partial guideline](https://github.com/mdn/browser-compat-data/tree/main/docs/data-guidelines#partial_implementation-general-usage-guidelines). Specifically, the long interval between implementation and bug report suggests that this does not yet have "a demonstrable negative impact on web developers." And although the spec says that these algorithms are strictly required, it's not really creating "confusing feature detection results" when the spec otherwise requires the method to return `null` for unsupported key formats (others not specifically called for by the "MUST" requirement).

Breaking the feature up seems like a good compromise between adherence to the specification text and reflecting the real-world practicalities.

To help name these subfeatures, I referred to the specification text and [the IANA algorithm name and description tables](https://www.iana.org/assignments/cose/cose.xhtml#algorithms).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Previously: https://github.com/mdn/browser-compat-data/pull/29458
- Toward resolving: https://github.com/web-platform-dx/web-features/issues/3995
- https://github.com/web-platform-dx/web-features/pull/4020

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
