### PR TITLE
Fix some `api.HTML*` spec_urls per webref id validation

### DIFF
--- a/api/HTMLButtonElement.json
+++ b/api/HTMLButtonElement.json
@@ -239,7 +239,7 @@
       "disabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/disabled",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-disabled",
           "tags": [
             "web-features:button"
           ],
@@ -470,7 +470,7 @@
       "formNoValidate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/formNoValidate",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formnovalidate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-formnovalidate",
           "tags": [
             "web-features:button"
           ],
@@ -516,7 +516,7 @@
       "formTarget": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/formTarget",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formtarget",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-formtarget",
           "tags": [
             "web-features:button"
           ],
@@ -639,7 +639,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLButtonElement/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-button-name",
           "tags": [
             "web-features:button"
           ],

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -326,7 +326,7 @@
       "autofocus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/autofocus",
-          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-fe-autofocus",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-fe-autofocus",
           "tags": [
             "web-features:autofocus"
           ],
@@ -1636,7 +1636,7 @@
       "inert": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLElement/inert",
-          "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inert",
+          "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-inert",
           "tags": [
             "web-features:inert"
           ],
@@ -1670,7 +1670,7 @@
         "ignores_find_in_page": {
           "__compat": {
             "description": "Element is ignored for the purposes of find-in-page.",
-            "spec_url": "https://html.spec.whatwg.org/multipage/interaction.html#dom-inert",
+            "spec_url": "https://html.spec.whatwg.org/multipage/dom.html#dom-inert",
             "tags": [
               "web-features:inert"
             ],

--- a/api/HTMLEmbedElement.json
+++ b/api/HTMLEmbedElement.json
@@ -88,7 +88,7 @@
       "getSVGDocument": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLEmbedElement/getSVGDocument",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-media-getsvgdocument-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-media-getsvgdocument",
           "tags": [
             "web-features:embed"
           ],
@@ -134,7 +134,10 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLEmbedElement/height",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-embed-height",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:embed"
           ],
@@ -309,7 +312,10 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLEmbedElement/width",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:embed"
           ],

--- a/api/HTMLFieldSetElement.json
+++ b/api/HTMLFieldSetElement.json
@@ -264,7 +264,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFieldSetElement/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-fieldset-name",
           "tags": [
             "web-features:fieldset"
           ],

--- a/api/HTMLFormElement.json
+++ b/api/HTMLFormElement.json
@@ -538,7 +538,7 @@
       "noValidate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/noValidate",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-novalidate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#dom-fs-novalidate",
           "tags": [
             "web-features:form"
           ],
@@ -916,7 +916,7 @@
       "target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLFormElement/target",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-target",
+          "spec_url": "https://html.spec.whatwg.org/multipage/forms.html#dom-fs-target",
           "tags": [
             "web-features:form"
           ],

--- a/api/HTMLGeolocationElement.json
+++ b/api/HTMLGeolocationElement.json
@@ -151,7 +151,7 @@
       "initialPermissionStatus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/initialPermissionStatus",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-initialpermissionstatus",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-powerfulfeatureobserver-initialpermissionstatus",
           "tags": [
             "web-features:geolocation-element"
           ],
@@ -188,7 +188,7 @@
       "invalidReason": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/invalidReason",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-invalidreason",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-invalidreason",
           "tags": [
             "web-features:geolocation-element"
           ],
@@ -225,7 +225,7 @@
       "isValid": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/isValid",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-isvalid",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-isvalid",
           "tags": [
             "web-features:geolocation-element"
           ],
@@ -300,7 +300,7 @@
       "permissionStatus": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/permissionStatus",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-permissionstatus",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-powerfulfeatureobserver-permissionstatus",
           "tags": [
             "web-features:geolocation-element"
           ],
@@ -375,7 +375,7 @@
         "__compat": {
           "description": "`promptaction` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/promptaction_event",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-onpromptaction",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-powerfulfeatureobserver-onpromptaction",
           "tags": [
             "web-features:geolocation-element"
           ],
@@ -413,7 +413,7 @@
         "__compat": {
           "description": "`promptdismiss` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/promptdismiss_event",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-onpromptdismiss",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-powerfulfeatureobserver-onpromptdismiss",
           "tags": [
             "web-features:geolocation-element"
           ],
@@ -451,7 +451,7 @@
         "__compat": {
           "description": "`validationstatuschange` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/validationstatuschange_event",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-inpagepermissionmixin-onvalidationstatuschange",
+          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-activationblockersmixin-onvalidationstatuschange",
           "tags": [
             "web-features:geolocation-element"
           ],

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -525,7 +525,7 @@
       "getSVGDocument": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/getSVGDocument",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-media-getsvgdocument-dev",
+          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-media-getsvgdocument",
           "tags": [
             "web-features:iframe"
           ],
@@ -571,7 +571,10 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/height",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-dim-height",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:iframe"
           ],
@@ -1245,7 +1248,10 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLIFrameElement/width",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-dim-width",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:iframe"
           ],

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -864,7 +864,7 @@
       "formNoValidate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formNoValidate",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formnovalidate",
+          "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-fs-formnovalidate",
           "tags": [
             "web-features:input"
           ],
@@ -910,7 +910,7 @@
       "formTarget": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/formTarget",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formtarget",
+          "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-fs-formtarget",
           "tags": [
             "web-features:input"
           ],
@@ -1439,7 +1439,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLInputElement/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name",
+          "spec_url": "https://html.spec.whatwg.org/multipage/input.html#dom-fe-name",
           "tags": [
             "web-features:input"
           ],

--- a/api/HTMLObjectElement.json
+++ b/api/HTMLObjectElement.json
@@ -607,7 +607,10 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/height",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-object-height",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:object"
           ],
@@ -1084,7 +1087,10 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLObjectElement/width",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#dom-object-width",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:object"
           ],

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -294,7 +294,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-output-name",
           "tags": [
             "web-features:output"
           ],

--- a/api/HTMLSelectElement.json
+++ b/api/HTMLSelectElement.json
@@ -507,7 +507,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSelectElement/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-name",
           "tags": [
             "web-features:select"
           ],

--- a/api/HTMLSourceElement.json
+++ b/api/HTMLSourceElement.json
@@ -43,7 +43,10 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/height",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-source-height",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "support": {
             "chrome": {
               "version_added": "90"
@@ -274,7 +277,10 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLSourceElement/width",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/embedded-content.html#dom-source-width",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "support": {
             "chrome": {
               "version_added": "90"

--- a/api/HTMLTextAreaElement.json
+++ b/api/HTMLTextAreaElement.json
@@ -256,7 +256,7 @@
       "disabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/disabled",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-disabled",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-disabled",
           "tags": [
             "web-features:textarea"
           ],
@@ -470,7 +470,7 @@
       "name": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLTextAreaElement/name",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fe-name",
+          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-name",
           "tags": [
             "web-features:textarea"
           ],

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -223,7 +223,10 @@
       "height": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/height",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-height",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#dom-video-height",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:video"
           ],
@@ -804,7 +807,10 @@
       "width": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLVideoElement/width",
-          "spec_url": "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dom-dim-width",
+          "spec_url": [
+            "https://html.spec.whatwg.org/multipage/media.html#dom-video-width",
+            "https://html.spec.whatwg.org/multipage/embedded-content-other.html#dimension-attributes"
+          ],
           "tags": [
             "web-features:video"
           ],


### PR DESCRIPTION
#### Summary

Found via webref id validation done in https://github.com/mdn/browser-compat-data/pull/23958

Seems like some restructuring happened in the HTML spec. 

#### Test results and supporting details

None.

#### Related issues

None.