### PR TITLE
Link Chromium bug for unsupported `:lang()` selector ranges in Chrome

### DIFF
--- a/css/selectors/lang.json
+++ b/css/selectors/lang.json
@@ -54,7 +54,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40811938"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -89,7 +90,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/40811938"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chromium browsers do not implement the Selectors 4 `:lang()` forms that use comma-separated ranges (`:lang(A, B)`) or wildcard subtags (`:lang(*-C)`), despite supporting the base pseudo-class. This updates the BCD entries so those unsupported subfeatures point to the tracked Chromium bug.

- Copilot's PR: https://github.com/tats-u/browser-compat-data/pull/3
- Copilot's log: https://github.com/tats-u/browser-compat-data/sessions/bf851ef8-8cf2-4756-9301-31bb657bb47f

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- https://crbug.com/40811938 (https://issues.chromium.org/issues/40811938)

  > Steps to reproduce the problem:
  > 1.Use asterisk or comma in language range for :lang() pseudo element selector.
  > 2. Or open langSelectors.html file in Chrome on Windows.
  > 
  > What is the expected behavior?
  > Should work as per the W3 specifications: https://drafts.csswg.org/selectors/#the-lang-pseudo
  > 
  > What went wrong?
  > None of the language range selectors, which are valid by W3 specs, work.
  > They work on iPadOS Chrome and Safari browsers though.


#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->

None
