### PR TITLE
Fix spec_urls for pointer events

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2996,7 +2996,7 @@
           "description": "`auxclick` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/auxclick_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-auxclick",
+            "https://w3c.github.io/pointerevents/#auxclick",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onauxclick"
           ],
           "tags": [
@@ -3035,7 +3035,7 @@
         "type_pointerevent": {
           "__compat": {
             "description": "Is a `PointerEvent`",
-            "spec_url": "https://w3c.github.io/uievents/#event-type-auxclick",
+            "spec_url": "https://w3c.github.io/pointerevents/#auxclick",
             "tags": [
               "web-features:pointer-events-api"
             ],
@@ -3752,7 +3752,7 @@
           "description": "`click` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/click_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-click",
+            "https://w3c.github.io/pointerevents/#click",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onclick"
           ],
           "tags": [
@@ -3802,7 +3802,7 @@
         "type_pointerevent": {
           "__compat": {
             "description": "Is a `PointerEvent`",
-            "spec_url": "https://w3c.github.io/uievents/#event-type-click",
+            "spec_url": "https://w3c.github.io/pointerevents/#click",
             "tags": [
               "web-features:pointer-events-api"
             ],
@@ -4279,7 +4279,7 @@
         "__compat": {
           "description": "`contextmenu` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/contextmenu_event",
-          "spec_url": "https://w3c.github.io/uievents/#event-type-contextmenu",
+          "spec_url": "https://w3c.github.io/pointerevents/#contextmenu",
           "tags": [
             "web-features:mouse-events"
           ],
@@ -4325,7 +4325,7 @@
         "type_pointerevent": {
           "__compat": {
             "description": "Is a `PointerEvent`",
-            "spec_url": "https://w3c.github.io/uievents/#event-type-contextmenu",
+            "spec_url": "https://w3c.github.io/pointerevents/#contextmenu",
             "tags": [
               "web-features:pointer-events-api"
             ],
@@ -4546,7 +4546,7 @@
           "description": "`dblclick` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/dblclick_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-dblclick",
+            "https://w3c.github.io/pointerevents/#dblclick",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-ondblclick"
           ],
           "tags": [
@@ -6894,7 +6894,7 @@
           "description": "`mousedown` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mousedown_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mousedown",
+            "https://w3c.github.io/pointerevents/#mousedown",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmousedown"
           ],
           "tags": [
@@ -6942,7 +6942,7 @@
           "description": "`mouseenter` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mouseenter_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mouseenter",
+            "https://w3c.github.io/pointerevents/#mouseenter",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmouseenter"
           ],
           "tags": [
@@ -6986,7 +6986,7 @@
           "description": "`mouseleave` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mouseleave_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mouseleave",
+            "https://w3c.github.io/pointerevents/#mouseleave",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmouseleave"
           ],
           "tags": [
@@ -7030,7 +7030,7 @@
           "description": "`mousemove` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mousemove_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mousemove",
+            "https://w3c.github.io/pointerevents/#mousemove",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmousemove"
           ],
           "tags": [
@@ -7078,7 +7078,7 @@
           "description": "`mouseout` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mouseout_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mouseout",
+            "https://w3c.github.io/pointerevents/#mouseout",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmouseout"
           ],
           "tags": [
@@ -7126,7 +7126,7 @@
           "description": "`mouseover` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mouseover_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mouseover",
+            "https://w3c.github.io/pointerevents/#mouseover",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmouseover"
           ],
           "tags": [
@@ -7174,7 +7174,7 @@
           "description": "`mouseup` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/mouseup_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-mouseup",
+            "https://w3c.github.io/pointerevents/#mouseup",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onmouseup"
           ],
           "tags": [
@@ -11575,7 +11575,7 @@
           "description": "`wheel` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/wheel_event",
           "spec_url": [
-            "https://w3c.github.io/uievents/#event-type-wheel",
+            "https://w3c.github.io/pointerevents/#wheel",
             "https://html.spec.whatwg.org/multipage/webappapis.html#handler-onwheel"
           ],
           "tags": [


### PR DESCRIPTION
#### Summary

>  The Mouse Events and Wheel Events section of this specification have been moved to the Pointer Events specification.

 https://w3c.github.io/uievents/#previous-events

#### Test results and supporting details

None.

#### Related issues

Found by webref id validation https://github.com/mdn/browser-compat-data/pull/23958