### PR TITLE
Fix WebGL 2.0 spec_urls

### DIFF
--- a/api/WebGL2RenderingContext.json
+++ b/api/WebGL2RenderingContext.json
@@ -3,7 +3,7 @@
     "WebGL2RenderingContext": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext",
-        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7",
         "tags": [
           "web-features:webgl2"
         ],
@@ -113,7 +113,7 @@
       "beginQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/beginQuery",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -150,7 +150,7 @@
       "beginTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/beginTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -226,7 +226,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindBuffer",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.1"
           ],
           "tags": [
             "web-features:webgl2"
@@ -264,7 +264,7 @@
       "bindBufferBase": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bindBufferBase",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -301,7 +301,7 @@
       "bindBufferRange": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bindBufferRange",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -340,7 +340,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindFramebuffer",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.6",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.1"
           ],
           "tags": [
             "web-features:webgl2"
@@ -415,7 +415,7 @@
       "bindSampler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bindSampler",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -454,7 +454,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindTexture",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.1"
           ],
           "tags": [
             "web-features:webgl2"
@@ -492,7 +492,7 @@
       "bindTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bindTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -529,7 +529,7 @@
       "bindVertexArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/bindVertexArray",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.17",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.17",
           "tags": [
             "web-features:webgl2"
           ],
@@ -751,7 +751,7 @@
       "blitFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/blitFramebuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4",
           "tags": [
             "web-features:webgl2"
           ],
@@ -971,7 +971,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/checkFramebufferStatus",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.6",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4"
           ],
           "tags": [
             "web-features:webgl2"
@@ -1046,7 +1046,7 @@
       "clearBufferfi": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/clearBuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.11",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.11",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1083,7 +1083,7 @@
       "clearBufferfv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/clearBuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.11",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.11",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1155,7 +1155,7 @@
       "clearBufferiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/clearBuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.11",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.11",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1227,7 +1227,7 @@
       "clearBufferuiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/clearBuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.11",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.11",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1410,7 +1410,7 @@
       "clientWaitSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/clientWaitSync",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.14",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.14",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1593,7 +1593,7 @@
       "compressedTexImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/compressedTexImage3D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1737,7 +1737,7 @@
       "compressedTexSubImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/compressedTexSubImage3D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1774,7 +1774,7 @@
       "copyBufferSubData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/copyBufferSubData",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.3",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.3",
           "tags": [
             "web-features:webgl2"
           ],
@@ -1885,7 +1885,7 @@
       "copyTexSubImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/copyTexSubImage3D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2033,7 +2033,7 @@
       "createQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/createQuery",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2107,7 +2107,7 @@
       "createSampler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/createSampler",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2218,7 +2218,7 @@
       "createTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/createTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2255,7 +2255,7 @@
       "createVertexArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/createVertexArray",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.17",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.17",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2440,7 +2440,7 @@
       "deleteQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteQuery",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2514,7 +2514,7 @@
       "deleteSampler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteSampler",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2588,7 +2588,7 @@
       "deleteSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteSync",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2662,7 +2662,7 @@
       "deleteTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2699,7 +2699,7 @@
       "deleteVertexArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/deleteVertexArray",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.17",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.17",
           "tags": [
             "web-features:webgl2"
           ],
@@ -2995,7 +2995,7 @@
       "drawArraysInstanced": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawArraysInstanced",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.9",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.9",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3032,7 +3032,7 @@
       "drawBuffers": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawBuffers",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.11",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.11",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3106,7 +3106,7 @@
       "drawElementsInstanced": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawElementsInstanced",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.9",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.9",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3328,7 +3328,7 @@
       "drawRangeElements": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/drawRangeElements",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.9",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.9",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3439,7 +3439,7 @@
       "endQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/endQuery",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3476,7 +3476,7 @@
       "endTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/endTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3513,7 +3513,7 @@
       "fenceSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/fenceSync",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.14",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.14",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3698,7 +3698,7 @@
       "framebufferTextureLayer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/framebufferTextureLayer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3883,7 +3883,7 @@
       "getActiveUniformBlockName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getActiveUniformBlockName",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3920,7 +3920,7 @@
       "getActiveUniformBlockParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getActiveUniformBlockParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -3957,7 +3957,7 @@
       "getActiveUniforms": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getActiveUniforms",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4070,7 +4070,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getBufferParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.3"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.3"
           ],
           "tags": [
             "web-features:webgl2"
@@ -4108,7 +4108,7 @@
       "getBufferSubData": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getBufferSubData",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.3",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.3",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4291,7 +4291,7 @@
       "getFragDataLocation": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getFragDataLocation",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.7",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.7",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4330,7 +4330,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getFramebufferAttachmentParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.6",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4"
           ],
           "tags": [
             "web-features:webgl2"
@@ -4368,7 +4368,7 @@
       "getIndexedParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getIndexedParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4405,7 +4405,7 @@
       "getInternalformatParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getInternalformatParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.5",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.5",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4444,7 +4444,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2"
           ],
           "tags": [
             "web-features:webgl2"
@@ -4521,7 +4521,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getProgramParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.9",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.7"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.7"
           ],
           "tags": [
             "web-features:webgl2"
@@ -4559,7 +4559,7 @@
       "getQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getQuery",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4596,7 +4596,7 @@
       "getQueryParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getQueryParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4635,7 +4635,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getRenderbufferParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.7",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.5"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.5"
           ],
           "tags": [
             "web-features:webgl2"
@@ -4673,7 +4673,7 @@
       "getSamplerParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getSamplerParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4895,7 +4895,7 @@
       "getSyncParameter": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getSyncParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.14",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.14",
           "tags": [
             "web-features:webgl2"
           ],
@@ -4934,7 +4934,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getTexParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl2"
@@ -4972,7 +4972,7 @@
       "getTransformFeedbackVarying": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getTransformFeedbackVarying",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5011,7 +5011,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getUniform",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.10",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8"
           ],
           "tags": [
             "web-features:webgl2"
@@ -5049,7 +5049,7 @@
       "getUniformBlockIndex": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getUniformBlockIndex",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5086,7 +5086,7 @@
       "getUniformIndices": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/getUniformIndices",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5162,7 +5162,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getVertexAttrib",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.10",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8"
           ],
           "tags": [
             "web-features:webgl2"
@@ -5274,7 +5274,7 @@
       "invalidateFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/invalidateFramebuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5311,7 +5311,7 @@
       "invalidateSubFramebuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/invalidateSubFramebuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5424,7 +5424,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isEnabled",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2"
           ],
           "tags": [
             "web-features:webgl2"
@@ -5536,7 +5536,7 @@
       "isQuery": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isQuery",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.12",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.12",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5610,7 +5610,7 @@
       "isSampler": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isSampler",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5684,7 +5684,7 @@
       "isSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isSync",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.14",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.14",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5758,7 +5758,7 @@
       "isTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5795,7 +5795,7 @@
       "isVertexArray": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/isVertexArray",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.17",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.17",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5946,7 +5946,7 @@
       "pauseTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/pauseTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -5986,7 +5986,7 @@
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
             "https://registry.khronos.org/webgl/specs/latest/1.0/#PIXEL_STORAGE_PARAMETERS",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2"
           ],
           "tags": [
             "web-features:webgl2"
@@ -6061,7 +6061,7 @@
       "readBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/readBuffer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6172,7 +6172,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/renderbufferStorage",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.7",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.5"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.5"
           ],
           "tags": [
             "web-features:webgl2"
@@ -6210,7 +6210,7 @@
       "renderbufferStorageMultisample": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/renderbufferStorageMultisample",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.5",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.5",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6247,7 +6247,7 @@
       "resumeTransformFeedback": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/resumeTransformFeedback",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6321,7 +6321,7 @@
       "samplerParameterf": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/samplerParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6358,7 +6358,7 @@
       "samplerParameteri": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/samplerParameter",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.13",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.13",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6693,7 +6693,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texImage2D",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl2"
@@ -6735,7 +6735,7 @@
       "texImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/texImage3D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6809,7 +6809,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl2"
@@ -6849,7 +6849,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl2"
@@ -6887,7 +6887,7 @@
       "texStorage2D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/texStorage2D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6924,7 +6924,7 @@
       "texStorage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/texStorage3D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -6963,7 +6963,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texSubImage2D",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#TEXSUBIMAGE2D",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl2"
@@ -7005,7 +7005,7 @@
       "texSubImage3D": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/texSubImage3D",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7077,7 +7077,7 @@
       "transformFeedbackVaryings": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/transformFeedbackVaryings",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.15",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.15",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7262,7 +7262,7 @@
       "uniform1ui": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7299,7 +7299,7 @@
       "uniform1uiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7484,7 +7484,7 @@
       "uniform2ui": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7521,7 +7521,7 @@
       "uniform2uiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7706,7 +7706,7 @@
       "uniform3ui": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7743,7 +7743,7 @@
       "uniform3uiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7928,7 +7928,7 @@
       "uniform4ui": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -7965,7 +7965,7 @@
       "uniform4uiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniform",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8002,7 +8002,7 @@
       "uniformBlockBinding": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformBlockBinding",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.16",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.16",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8111,7 +8111,7 @@
       "uniformMatrix2x3fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8183,7 +8183,7 @@
       "uniformMatrix2x4fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8327,7 +8327,7 @@
       "uniformMatrix3x2fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8399,7 +8399,7 @@
       "uniformMatrix3x4fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8543,7 +8543,7 @@
       "uniformMatrix4x2fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -8615,7 +8615,7 @@
       "uniformMatrix4x3fv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/uniformMatrix",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9232,7 +9232,7 @@
       "vertexAttribDivisor": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribDivisor",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.9",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.9",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9269,7 +9269,7 @@
       "vertexAttribI4i": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribI",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9306,7 +9306,7 @@
       "vertexAttribI4iv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribI",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9378,7 +9378,7 @@
       "vertexAttribI4ui": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribI",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9415,7 +9415,7 @@
       "vertexAttribI4uiv": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribI",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9487,7 +9487,7 @@
       "vertexAttribIPointer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/vertexAttribIPointer",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8",
           "tags": [
             "web-features:webgl2"
           ],
@@ -9598,7 +9598,7 @@
       "waitSync": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGL2RenderingContext/waitSync",
-          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.14",
+          "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.14",
           "tags": [
             "web-features:webgl2"
           ],

--- a/api/WebGLQuery.json
+++ b/api/WebGLQuery.json
@@ -3,7 +3,7 @@
     "WebGLQuery": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLQuery",
-        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.2",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.2",
         "tags": [
           "web-features:webgl2"
         ],

--- a/api/WebGLRenderingContext.json
+++ b/api/WebGLRenderingContext.json
@@ -241,7 +241,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindBuffer",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.1"
           ],
           "tags": [
             "web-features:webgl"
@@ -294,7 +294,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindFramebuffer",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.6",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.1"
           ],
           "tags": [
             "web-features:webgl"
@@ -397,7 +397,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/bindTexture",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.1"
           ],
           "tags": [
             "web-features:webgl"
@@ -850,7 +850,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/checkFramebufferStatus",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.6",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4"
           ],
           "tags": [
             "web-features:webgl"
@@ -3299,7 +3299,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getBufferParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.3"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.3"
           ],
           "tags": [
             "web-features:webgl"
@@ -3502,7 +3502,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getFramebufferAttachmentParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.6",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.4"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.4"
           ],
           "tags": [
             "web-features:webgl"
@@ -3555,7 +3555,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2"
           ],
           "tags": [
             "web-features:webgl"
@@ -3658,7 +3658,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getProgramParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.9",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.7"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.7"
           ],
           "tags": [
             "web-features:webgl"
@@ -3711,7 +3711,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getRenderbufferParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.7",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.5"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.5"
           ],
           "tags": [
             "web-features:webgl"
@@ -4014,7 +4014,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getTexParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl"
@@ -4067,7 +4067,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getUniform",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.10",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8"
           ],
           "tags": [
             "web-features:webgl"
@@ -4170,7 +4170,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/getVertexAttrib",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.10",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.8"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.8"
           ],
           "tags": [
             "web-features:webgl"
@@ -4423,7 +4423,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/isEnabled",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2"
           ],
           "tags": [
             "web-features:webgl"
@@ -4867,7 +4867,7 @@
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.3",
             "https://registry.khronos.org/webgl/specs/latest/1.0/#PIXEL_STORAGE_PARAMETERS",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.2"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.2"
           ],
           "tags": [
             "web-features:webgl"
@@ -5020,7 +5020,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/renderbufferStorage",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.7",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.5"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.5"
           ],
           "tags": [
             "web-features:webgl"
@@ -5523,7 +5523,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texImage2D",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl"
@@ -5580,7 +5580,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl"
@@ -5633,7 +5633,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texParameter",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.8",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl"
@@ -5686,7 +5686,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLRenderingContext/texSubImage2D",
           "spec_url": [
             "https://registry.khronos.org/webgl/specs/latest/1.0/#TEXSUBIMAGE2D",
-            "https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.6"
+            "https://registry.khronos.org/webgl/specs/latest/2.0/#4.7.6"
           ],
           "tags": [
             "web-features:webgl"

--- a/api/WebGLSampler.json
+++ b/api/WebGLSampler.json
@@ -3,7 +3,7 @@
     "WebGLSampler": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLSampler",
-        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.3",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.3",
         "tags": [
           "web-features:webgl2"
         ],

--- a/api/WebGLSync.json
+++ b/api/WebGLSync.json
@@ -3,7 +3,7 @@
     "WebGLSync": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLSync",
-        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.4",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.4",
         "tags": [
           "web-features:webgl2"
         ],

--- a/api/WebGLTransformFeedback.json
+++ b/api/WebGLTransformFeedback.json
@@ -3,7 +3,7 @@
     "WebGLTransformFeedback": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLTransformFeedback",
-        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.5",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.5",
         "tags": [
           "web-features:webgl2"
         ],

--- a/api/WebGLVertexArrayObject.json
+++ b/api/WebGLVertexArrayObject.json
@@ -3,7 +3,7 @@
     "WebGLVertexArrayObject": {
       "__compat": {
         "mdn_url": "https://developer.mozilla.org/docs/Web/API/WebGLVertexArrayObject",
-        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#3.6",
+        "spec_url": "https://registry.khronos.org/webgl/specs/latest/2.0/#4.6",
         "tags": [
           "web-features:webgl2"
         ],


### PR DESCRIPTION
#### Summary

Chapter 3 is chapter 4 now apparently.

#### Test results and supporting details

None. 

#### Related issues

Found by webref id validation https://github.com/mdn/browser-compat-data/pull/23958