### PR TITLE
Add notes on `text-autospace` initial-value mismatch

### DIFF
--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -10,20 +10,23 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "140"
+              "version_added": "140",
+              "notes": "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386))."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
               "version_added": "145",
-              "impl_url": "https://bugzil.la/1869577"
+              "impl_url": "https://bugzil.la/1869577",
+              "notes": "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386))."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "18.4",
+              "notes": "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386))."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

`text-autospace` is opt-out (initial value is `normal`) in CSS Text Module 4 spec and MDN, but actually opt-in (initial value is `no-autospaca`) in all browsers. It should be noted.

Notice: I have Copilot edit (GPT-5.4):

Agent-Logs-Url: https://github.com/tats-u/browser-compat-data/sessions/2e6e0f19-da52-49ba-be0e-4355deca2c50
Agent-Logs-Url: https://github.com/tats-u/browser-compat-data/sessions/67de7613-fb42-4b68-8eb6-a88d58032bbb

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://github.com/w3c/csswg-drafts/issues/12386

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
