### PR TITLE
fix(update-browser-releases): skip Opera versions before current

### DIFF
--- a/scripts/update-browser-releases/opera.js
+++ b/scripts/update-browser-releases/opera.js
@@ -144,7 +144,7 @@ export const updateOperaReleases = async (options) => {
     const version = /** @type {RegExpMatchArray} */ (
       item.title.match(options.titleVersionPattern)
     )[1];
-    if (version === currentBCDVersion) {
+    if (currentBCDVersion && Number(version) <= Number(currentBCDVersion)) {
       break;
     }
     newItems.push(item);


### PR DESCRIPTION
#### Summary

Updates the `update-browser-releases` script for Opera to skip versions before current.

#### Test results and supporting details

When the Opera RSS feed's newest item is older than the version BCD already tracks as current, the strict-equality break condition never fired, causing already-retired releases to be re-added as current and producing multiple current releases.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29649.