### PR TITLE
Add `@mdn/bcd-owners` to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,21 +5,17 @@
 # For more detailed information, see:
 # https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-/schemas/ @mdn/bcd-owners
-
-/.github/ @mdn/engineering
-/.vscode/ @mdn/engineering
-/lint/    @mdn/engineering
-/scripts/ @mdn/engineering
-/types/   @mdn/engineering
-/utils/   @mdn/engineering
-/*        @mdn/engineering
-/package.json      @mdn/engineering @mdn-bot @mdn/bcd-releasers
-/package-lock.json @mdn/engineering @mdn-bot @mdn/bcd-releasers
-/SECURITY.md @mdn/engineering
-
-# Exclude some paths
-/.github/ISSUE_TEMPLATE/
-/.github/PULL_REQUEST_TEMPLATE.md
+/.github/           @mdn/bcd-owners @mdn/engineering
+/.github/workflows/                 @mdn/engineering
+/.vscode/           @mdn/bcd-owners @mdn/engineering
+/lint/              @mdn/bcd-owners @mdn/engineering
 /lint/common/*.txt
+/schemas/           @mdn/bcd-owners
+/scripts/           @mdn/bcd-owners @mdn/engineering
+/types/             @mdn/bcd-owners @mdn/engineering
+/utils/             @mdn/bcd-owners @mdn/engineering
+/*                  @mdn/bcd-owners @mdn/engineering
 /*.md
+/package.json       @mdn/bcd-owners @mdn/engineering @mdn-bot
+/package-lock.json  @mdn/bcd-owners @mdn/engineering @mdn-bot
+/SECURITY.md                        @mdn/engineering


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Adds `@mdn/bcd-owners` to CODEOWNERS, for all paths except `.github/workflows/` and `SECURITY.md`.

#### Test results and supporting details

Follow-up on discussions in BCD meetings of 2026-05-05 and 2026-05-12.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
