### PR TITLE
Chrome 150: update `url()` modifiers

### DIFF
--- a/css/types/url.json
+++ b/css/types/url.json
@@ -52,8 +52,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/435625756"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -79,6 +78,38 @@
             }
           }
         },
+        "integrity": {
+          "__compat": {
+            "description": "`integrity()` modifier",
+            "spec_url": "https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-integrity-modifier",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "referrer-policy": {
           "__compat": {
             "description": "`referrer-policy()` modifier",
@@ -88,8 +119,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/435625756"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`integrity()` has an implementation now and the others are in Canary.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This adds the `integrity()` data (which is really my aim here—to get a key for web-features), but I didn't set a version number since it's quite early. It's possible this feature could slip.

- Chrome status: https://chromestatus.com/feature/5111997147512832 (also https://chromiumdash.appspot.com/commit/e1c6eac824e2decccd515c525396fbe17c61ac4c)
- WPT: https://wpt.fyi/results/css/css-values/urls/url-request-modifiers-computed.sub.html?

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Previously: https://github.com/mdn/browser-compat-data/pull/29440

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
