### PR TITLE
`text-decoration-skip-ink`: link to Safari rendering bug

### DIFF
--- a/css/properties/text-decoration-skip-ink.json
+++ b/css/properties/text-decoration-skip-ink.json
@@ -59,7 +59,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "notes": "If the `unicode-range` descriptor applies to the font, then some text decoration may not be skipped (see [bug 255159](https://webkit.org/b/255159))."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -93,7 +94,8 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "notes": "If the `unicode-range` descriptor applies to the font, then some text decoration may not be skipped (see [bug 255159](https://webkit.org/b/255159))."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Link to a Safari bug relating to `text-decoration-skip-ink: all` and `auto`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This is a longstanding problem that hasn't been widely complained about, so it's not a partial. But it did come up in my search when `text-decoration-skip-ink: all` advanced to Baseline newly available and I thought I'd include it as a note for completeness.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://webkit.org/b/255159

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
