### PR TITLE
Firefox Nightly has partial `::-webkit-scrollbar` behind flag

### DIFF
--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -12,8 +12,17 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1432935"
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.fake-webkit-scrollbar.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/1432935",
+              "partial_implementation": true,
+              "notes": "The `@supports selector(::-webkit-scrollbar)` will return `true` but this pseudo-element is note supported. This has been added so that a bug where nested scrollable content was not be reachable could be fixed ([Firefox bug 1977511](https://bugzil.la/1977511))"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -22,7 +22,7 @@
               ],
               "impl_url": "https://bugzil.la/1432935",
               "partial_implementation": true,
-              "notes": "The `@supports selector(::-webkit-scrollbar)` will return `true` but this pseudo-element is note supported. This has been added so that a bug where nested scrollable content was not be reachable could be fixed ([bug 1977511](https://bugzil.la/1977511))"
+              "notes": "The `@supports selector(::-webkit-scrollbar)` returns `true` but this pseudo-element cannot be used to style scrollbars. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -22,7 +22,7 @@
               ],
               "impl_url": "https://bugzil.la/1432935",
               "partial_implementation": true,
-              "notes": "The `@supports selector(::-webkit-scrollbar)` will return `true` but this pseudo-element is note supported. This has been added so that a bug where nested scrollable content was not be reachable could be fixed ([Firefox bug 1977511](https://bugzil.la/1977511))"
+              "notes": "The `@supports selector(::-webkit-scrollbar)` will return `true` but this pseudo-element is note supported. This has been added so that a bug where nested scrollable content was not be reachable could be fixed ([bug 1977511](https://bugzil.la/1977511))"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- partial_implementation and flag for `::-webkit-scrollbar` in Firefox

#### Test results and supporting details

- Tested in the following:
  - Firefox Beta 151 (with flag `layout.css.fake-webkit-scrollbar.enabled`)
  - Firefox Nightly 152 (without flag)

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/44097)