### PR TITLE
Deno 2.6.7 adds `*Map.getOrInsert*()`

### DIFF
--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -460,6 +460,9 @@
                 "version_added": "145"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "2.6.7"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "144"
@@ -498,6 +501,9 @@
                 "version_added": "145"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "2.6.7"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "144"

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -315,6 +315,9 @@
                 "version_added": "145"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "2.6.7"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "144"
@@ -353,6 +356,9 @@
                 "version_added": "145"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "2.6.7"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": "144"


### PR DESCRIPTION
#### Summary

Deno 2.6.7 updated the V8 engine to version 14.5, and the following upsert methods were available.

- Map.prototype.getOrInsert()
- Map.prototype.getOrInsertComputed()
- WeakMap.prototype.getOrInsert()
- WeakMap.prototype.getOrInsertComputed()

#### Test results and supporting details

```
curl -fsSL https://deno.land/install.sh | DENO_INSTALL=./ sh -s -- v2.6.7  # or v2.6.6 for comparison
./bin/deno --version
./bin/deno eval -p "Map.prototype.getOrInsert"
./bin/deno eval -p "Map.prototype.getOrInsertComputed"
./bin/deno eval -p "WeakMap.prototype.getOrInsert"
./bin/deno eval -p "WeakMap.prototype.getOrInsertComputed"
```
The result of the above commands on Deno 2.6.7:
```
$ curl -fsSL https://deno.land/install.sh | DENO_INSTALL=. sh -s -- v2.6.7
######################################################################## 100.0%
Archive:  ./bin/deno.zip
  inflating: ./bin/deno             
Deno was installed successfully to ./bin/deno
Run 'deno --help' to get started

Stuck? Join our Discord https://discord.gg/deno
$ ./bin/deno --version
deno 2.6.7 (stable, release, aarch64-unknown-linux-gnu)
v8 14.5.201.2-rusty
typescript 5.9.2
$ ./bin/deno eval -p "Map.prototype.getOrInsert"
[Function: getOrInsert]
$ ./bin/deno eval -p "Map.prototype.getOrInsertComputed"
[Function: getOrInsertComputed]
$ ./bin/deno eval -p "WeakMap.prototype.getOrInsert"
[Function: getOrInsert]
$ ./bin/deno eval -p "WeakMap.prototype.getOrInsertComputed"
[Function: getOrInsertComputed]
```
The result of the above commands on Deno 2.6.6:
```
$ curl -fsSL https://deno.land/install.sh | DENO_INSTALL=. sh -s -- v2.6.6
######################################################################## 100.0%
Archive:  ./bin/deno.zip
  inflating: ./bin/deno              
Deno was installed successfully to ./bin/deno
Run 'deno --help' to get started

Stuck? Join our Discord https://discord.gg/deno
$ ./bin/deno --version
deno 2.6.6 (stable, release, aarch64-unknown-linux-gnu)
v8 14.2.231.17-rusty
typescript 5.9.2
$ ./bin/deno eval -p "Map.prototype.getOrInsert"
undefined
$ ./bin/deno eval -p "Map.prototype.getOrInsertComputed"
undefined
$ ./bin/deno eval -p "WeakMap.prototype.getOrInsert"
undefined
$ ./bin/deno eval -p "WeakMap.prototype.getOrInsertComputed"
undefined
```

Updated JSON data:
```
$ cat javascript/builtins/Map.json | jq '.javascript.builtins.Map.getOrInsert.__compat.support.deno'
{
  "version_added": "2.6.7"
}
$ cat javascript/builtins/Map.json | jq '.javascript.builtins.Map.getOrInsertComputed.__compat.support.deno'
{
  "version_added": "2.6.7"
}
$ cat javascript/builtins/WeakMap.json | jq '.javascript.builtins.WeakMap.getOrInsert.__compat.support.deno'
{
  "version_added": "2.6.7"
}
$ cat javascript/builtins/WeakMap.json | jq '.javascript.builtins.WeakMap.getOrInsertComputed.__compat.support.deno'
{
  "version_added": "2.6.7"
}
$ npm test

> @mdn/browser-compat-data@7.3.15 test
> npm run format && npm run lint && npm run unittest


> @mdn/browser-compat-data@7.3.15 format
> eslint --cache . && prettier --check --cache . && tsc --noEmit

/home/kwj/repo/ref/js/browser-compat-data/lint/common/spec-urls-exceptions.js
  10:1  warning  Missing JSDoc block description     jsdoc/require-description
  11:1  warning  Missing JSDoc @returns description  jsdoc/require-returns-description

...[snipped]...

/home/kwj/repo/ref/js/browser-compat-data/utils/walkingUtils.js
  15:1  warning  Prefer a more specific type to `*`  jsdoc/reject-any-type
  22:1  warning  Prefer a more specific type to `*`  jsdoc/reject-any-type
  29:1  warning  Prefer a more specific type to `*`  jsdoc/reject-any-type

✖ 202 problems (0 errors, 202 warnings)

Checking formatting...
All matched files use Prettier code style!

> @mdn/browser-compat-data@7.3.15 lint
> node lint/lint.js

Loading and checking files...
Testing browser data...
Testing feature data...
Obsolete - 8 problems (0 errors, 0 warnings, 8 infos):
  ✖ api.Gamepad.secure_context_required - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.GamepadButton.secure_context_required - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.GamepadEvent.secure_context_required - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.GamepadHapticActuator.secure_context_required - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.GamepadPose.secure_context_required - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.Navigator.getGamepads.secure_context_required - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.SVGAElement.text - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
  ✖ api.SVGRenderingIntent - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
Testing all features together...
All data passed linting!
Linters have some exceptions, please help us remove them!
  Flag data has 2 exceptions
   - api.Notification.requireInteraction
   - api.Window.dump
  Obsolete has 1 exception
   - html.elements.track.kind.descriptions

> @mdn/browser-compat-data@7.3.15 unittest
> NODE_ENV=test FORCE_COLOR=1 c8 mocha index.test.js --recursive "{,!(node_modules)/**}/*.test.js"



  Using BCD
    ✔ subscript notation
    ✔ dot notation

...[snipped]...


  descendantKeys()
    ✔ returns empty array if data is invalid


  300 passing (2s)

...[snipped]...
```

Related links:
- [Deno 2.6.7 release](https://github.com/denoland/deno/releases/tag/v2.6.7)
  - feat: V8 14.5
- [Proposal Upsert](https://github.com/tc39/proposal-upsert)

#### Related issues

Fixes #29652

