### PR TITLE
Fix some obscure old version ranges

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -1228,7 +1228,7 @@
               },
               "chrome_android": "mirror",
               "edge": {
-                "version_added": "≤15"
+                "version_added": "12"
               },
               "firefox": {
                 "version_added": "1"

--- a/http/mixed-content.json
+++ b/http/mixed-content.json
@@ -10,12 +10,12 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "≤79"
+            "version_added": "44"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "≤23"
+            "version_added": "23"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -49,7 +49,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "≤23"
+              "version_added": "23"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -275,7 +275,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "≤9.1"
+              "version_added": "9"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

These old and obscure version ranges caused some problems in changing feature authoring in web-features , so I'm updating them to avoid a more complex problem.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

There are various citations below, but the short version is:

- Chrome could not have shipped mixed content blocking before Chrome 43 and circumstantial evidence (the dates of Chrome Status entries) suggests Chrome 44.
- Firefox shipped mixed content blocking in Firefox 23, according to release notes and the dates given by related bugs.
- Safari shipped mixed content blocking in Safari 9, according to Stack Overflow questions and user support forum posts. This is consistent with the commit date for shipping it.
- Circumstantial evidence (such as comments in GitHub searches) suggests that _some_ version of IE supported `display: table-caption`, so I think it was supported from Edge 12. This is is a relatively low-confidence item in my research, but I figure there's very little harm in getting it wrong at this point.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/pull/4015
- https://issues.chromium.org/issues/40398476#comment8
- https://chromestatus.com/feature/6263395770695680
- https://chromestatus.com/feature/5823679871057920
- https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/23#security
- https://bugzilla.mozilla.org/show_bug.cgi?id=834836
- https://github.com/WebKit/WebKit/commit/67b65d5017afb949a6d14b2a77f60d35a70c8cfa
- https://stackoverflow.com/questions/32883306/safari-9-disallowed-running-of-insecure-content
- https://discussions.apple.com/thread/7235380?sortBy=rank

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
