### PR TITLE
Firefox fully supports `EXT_texture_compression_rgtc`

### DIFF
--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -24,9 +24,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": "65",
-            "partial_implementation": true,
-            "notes": "Only supported on macOS."
+            "version_added": "65"
           },
           "firefox_android": {
             "version_added": false


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark EXT_texture_compression_rgtc as fully supported in Firefox 

#### Test results and supporting details

I'm not sure where the partial implementation came from, but it definitely seems to be true today that this is supported everywhere; see the tests:
* https://registry.khronos.org/webgl/sdk/tests/conformance/extensions/ext-texture-compression-rgtc.html?webglVersion=2&quiet=0&quick=1
* https://registry.khronos.org/webgl/sdk/tests/conformance/extensions/s3tc-and-rgtc.html?webglVersion=2&quiet=0&quick=1

I'm struggling to find any evidence from [bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1494809) that it wasn't supported on all platforms from the start (at least if they had the necessary hardware support).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
