### PR TITLE
Firefox 148 shipped WASM branch-hinting

### DIFF
--- a/webassembly/branch-hinting.json
+++ b/webassembly/branch-hinting.json
@@ -13,8 +13,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/1950729"
+            "version_added": "148"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Reflect fact that branch-hinting is shipped in Firefox 148.

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1950729

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
