### PR TITLE
Add `Element.attachShadow()` option `slotAssignment`

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2948,6 +2948,41 @@
               "deprecated": false
             }
           }
+        },
+        "options_slotAssignment_parameter": {
+          "__compat": {
+            "description": "`options.slotAssignment` parameter",
+            "spec_url": "https://dom.spec.whatwg.org/#dom-shadowrootinit-slotassignment",
+            "tags": [
+              "web-features:shadow-dom"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "86"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "92"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "16.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "attributes": {


### PR DESCRIPTION
While following up work for https://github.com/mdn/content/issues/43866 I noticed that `Element.attachShadow()` does not set the BCD for `option.slotAssignment`.

This was added in FF92 in https://bugzilla.mozilla.org/show_bug.cgi?id=1705141

The feature matches the ability to to manual slot assignment in a shadowroot, which is achieved using `HTMLSlotElement.assign()` - for Chrome and Safari I copied those features versions.


Related docs work can be tracked in https://github.com/mdn/content/issues/43866