### PR TITLE
Add Chromium bug links for unsupported `text-autospace` values

### DIFF
--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -11,7 +11,10 @@
           "support": {
             "chrome": {
               "version_added": "140",
-              "notes": "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386))."
+              "notes": [
+                "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386)).",
+                "Only supports the `normal` and `no-autospace` values (see [bug 429178779](https://crbug.com/429178779))."
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -47,7 +50,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/429178779"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -81,7 +85,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/429178779"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -115,7 +120,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/429178779"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -149,7 +155,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/429178779"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -251,7 +258,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/429178779"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -286,7 +294,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://crbug.com/429178779"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/text-autospace.json
+++ b/css/properties/text-autospace.json
@@ -11,10 +11,7 @@
           "support": {
             "chrome": {
               "version_added": "140",
-              "notes": [
-                "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386)).",
-                "Only supports the `normal` and `no-autospace` values (see [bug 429178779](https://crbug.com/429178779))."
-              ]
+              "notes": "The initial value is `no-autospace` instead of `normal` (see [csswg-drafts issue #12386](https://github.com/w3c/csswg-drafts/issues/12386))."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

There's already a bug report for the issue where Chrome doesn't support the minor `text-autospace` attribute values. 

Caution: Copilot slop.

Session Log:

- https://github.com/tats-u/browser-compat-data/pull/5
- https://github.com/tats-u/browser-compat-data/sessions/7dcc9121-6bf0-4698-a299-1b70555287be

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://crbug.com/429178779

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
