### PR TITLE
chore(lint): run `lint` after `lint:fix` when files provided

### DIFF
--- a/lint/fix.js
+++ b/lint/fix.js
@@ -25,6 +25,7 @@ import fixStatus from './fixer/status.js';
 import fixMirror from './fixer/mirror.js';
 import fixOverlap from './fixer/overlap.js';
 import fixStandardTrackExceptions from './fixer/standard-track-exceptions.js';
+import lint from './lint.js';
 import { IS_WINDOWS } from './utils.js';
 
 /** @import {Stats} from 'node:fs' */
@@ -145,6 +146,7 @@ if (esMain(import.meta)) {
   const { files = dataFolders, only } = argv;
 
   await main(files, { only });
+  process.exit((await lint(files)) ? 1 : 0);
 }
 
 export default load;

--- a/lint/fix.js
+++ b/lint/fix.js
@@ -146,7 +146,10 @@ if (esMain(import.meta)) {
   const { files = dataFolders, only } = argv;
 
   await main(files, { only });
-  process.exit((await lint(files)) ? 1 : 0);
+  if (argv.files) {
+    // Fails pre-commit hook for lint failures unknown to the fixer.
+    process.exit((await lint(argv.files)) ? 1 : 0);
+  }
 }
 
 export default load;


### PR DESCRIPTION
## Summary

Fixes `npm run lint:fix` so it exits with a failure when unfixable lint errors remain after the fixer runs.

Previously, `lint:fix` could successfully apply available fixes and exit `0`, even when a follow-up `npm run lint` would still fail on the same target files. This made the command report success for cases it could not fully fix.

The fix reuses the normal lint pass after running the existing fixers and exits non-zero when lint errors remain.

Fixes #29615.

## Validation

- `npm run lint:fix -- http/headers/X-Frame-Options.json`
- `npm run lint -- http/headers/X-Frame-Options.json`
- Temporarily reproduced the missing `spec_url` case from #29615 and confirmed `lint:fix` now exits with failure when the remaining lint error is unfixable.
- `npm run format`
- `npm run lint`
- Unit tests passed with the PowerShell-compatible equivalent after the npm script hit Windows `NODE_ENV` shell syntax.