### PR TITLE
Summarizer API shipped in Edge 138, like Chrome

### DIFF
--- a/api/CreateMonitor.json
+++ b/api/CreateMonitor.json
@@ -15,16 +15,7 @@
           "deno": {
             "version_added": false
           },
-          "edge": {
-            "version_added": "138",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#edge-llm-summarization-api-for-phi-mini",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
@@ -65,16 +56,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },

--- a/api/Summarizer.json
+++ b/api/Summarizer.json
@@ -18,16 +18,7 @@
           "deno": {
             "version_added": false
           },
-          "edge": {
-            "version_added": "138",
-            "flags": [
-              {
-                "type": "preference",
-                "name": "#edge-llm-summarization-api-for-phi-mini",
-                "value_to_set": "Enabled"
-              }
-            ]
-          },
+          "edge": "mirror",
           "firefox": {
             "version_added": false
           },
@@ -71,16 +62,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -125,16 +107,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -179,16 +152,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -233,16 +197,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -287,16 +242,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -341,16 +287,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -395,16 +332,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -449,16 +377,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -503,16 +422,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -557,16 +467,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -611,16 +512,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -665,16 +557,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -719,16 +602,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },
@@ -773,16 +647,7 @@
             "deno": {
               "version_added": false
             },
-            "edge": {
-              "version_added": "138",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-summarization-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1524,16 +1524,7 @@
               "chrome_android": {
                 "version_added": false
               },
-              "edge": {
-                "version_added": "138",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-summarization-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
+              "edge": "mirror",
               "firefox": {
                 "version_added": false
               },


### PR DESCRIPTION
#### Summary

This PR makes the Summarizer API support data for Edge mirror Chrome's.

The API shipped with Edge 138, same as Chrome, and is no longer behind a flag.

#### Test results and supporting details

This Edge demo for the Summarizer API works in Edge without enabling a flag: https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/summarizer-api/

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
