### PR TITLE
ci(issue-regex-labeler): revert dot escaping

### DIFF
--- a/.github/issue-regex-labeler.yml
+++ b/.github/issue-regex-labeler.yml
@@ -19,6 +19,9 @@ data:manifests:
 data:mathml:
   - 'mathml\.'
   - '\/docs\/Web\/MathML'
+data:mediatypes:
+  - 'mediatypes\.'
+  - '\/docs\/Web\/Media'
 data:svg:
   - 'svg\.'
   - '\/docs\/Web\/SVG'

--- a/.github/issue-regex-labeler.yml
+++ b/.github/issue-regex-labeler.yml
@@ -1,36 +1,33 @@
 data:api:
-  - 'api\\.'
+  - 'api\.'
   - '\/docs\/Web\/API'
 data:css:
-  - 'css\\.'
+  - 'css\.'
   - '\/docs\/Web\/CSS'
 data:html:
-  - 'html\\.'
+  - 'html\.'
   - '\/docs\/Web\/HTML'
 data:http:
-  - 'http\\.'
+  - 'http\.'
   - '\/docs\/Web\/HTTP'
 data:js:
-  - 'js\\.'
+  - 'js\.'
   - '\/docs\/Web\/JavaScript'
 data:manifests:
-  - 'manifests\\.'
+  - 'manifests\.'
   - '\/docs\/Web\/Progressive_web_apps\/Manifest'
 data:mathml:
-  - 'mathml\\.'
+  - 'mathml\.'
   - '\/docs\/Web\/MathML'
-data:mediatypes:
-  - 'mediatypes\\.'
-  - '\/docs\/Web\/Media'
 data:svg:
-  - 'svg\\.'
+  - 'svg\.'
   - '\/docs\/Web\/SVG'
 data:wasm:
-  - 'webassembly\\.'
+  - 'webassembly\.'
   - '\/docs\/WebAssembly'
 data:webdriver:
-  - 'webdriver\\.'
+  - 'webdriver\.'
   - '\/docs\/Web\/WebDriver'
 data:webext:
-  - 'webextensions\\.'
+  - 'webextensions\.'
   - '\/docs\/Mozilla\/Add-ons'


### PR DESCRIPTION
Unfortunately, it looks like the change broke auto-labeling completely.

Reverts mdn/browser-compat-data#29285