### PR TITLE
Add `<a>` to MathML, deprecate global `href`

### DIFF
--- a/mathml/elements/a.json
+++ b/mathml/elements/a.json
@@ -1,0 +1,74 @@
+{
+  "mathml": {
+    "elements": {
+      "a": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mathml-core/#the-a-element",
+          "tags": [
+            "web-features:mathml"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "152"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "href": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#the-a-element",
+            "tags": [
+              "web-features:mathml"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "152"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/mathml/elements/a.json
+++ b/mathml/elements/a.json
@@ -36,7 +36,7 @@
         },
         "href": {
           "__compat": {
-            "spec_url": "https://w3c.github.io/mathml-core/#the-a-element",
+            "spec_url": "https://w3c.github.io/mathml-core/#dfn-href",
             "tags": [
               "web-features:mathml"
             ],

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -127,6 +127,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "7",
+              "version_removed": "152",
               "impl_url": "https://hg.mozilla.org/mozilla-central/rev/12294b20e4d9"
             },
             "firefox_android": "mirror",
@@ -145,7 +146,7 @@
           "status": {
             "experimental": false,
             "standard_track": false,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },

--- a/mathml/global_attributes.json
+++ b/mathml/global_attributes.json
@@ -127,8 +127,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "7",
-              "version_removed": "152",
-              "impl_url": "https://hg.mozilla.org/mozilla-central/rev/12294b20e4d9"
+              "version_removed": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Adds `<a href>` to MathML support to Firefox 152
- Removes global `href` support from Firefox 152

#### Test results and supporting details

- [MathML Core adding the `<a>` element and deprecating global `href`](https://w3c.github.io/mathml-core/#the-a-element)
- [Firefox 151 deprecating the global `href` attribute](https://bugzilla.mozilla.org/show_bug.cgi?id=2026848) (behind the flag)
- Firefox 152 seems to be shipping it enabled by default (AFAIK)