### PR TITLE
Safari TP supports async iterable streams

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -526,7 +526,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "26.4"
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Safari support statement for `ReadableStream.@@asyncIterator`.

#### Test results and supporting details

The feature did not ship in Safari 26.4 yet, see [this comment](https://github.com/mdn/browser-compat-data/issues/29708#issuecomment-4500514487).

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29708.