### PR TITLE
Updates for Firefox 152 beta

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -132,6 +132,37 @@
           }
         }
       },
+      "animation": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-animations-2/#dom-animationevent-animation",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "152"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "animationName": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AnimationEvent/animationName",

--- a/api/MathMLElement.json
+++ b/api/MathMLElement.json
@@ -223,7 +223,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Notification.json
+++ b/api/Notification.json
@@ -241,7 +241,7 @@
               "version_added": "18"
             },
             "firefox": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -261,7 +261,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -653,8 +653,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1811291"
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -692,8 +691,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1811291"
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "nodejs": {

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -551,7 +551,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "152"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -119,6 +119,37 @@
           }
         }
       },
+      "animation": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-transitions-2/#Events-TransitionEvent-animation",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "152"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "elapsedTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/TransitionEvent/elapsedTime",

--- a/css/properties/field-sizing.json
+++ b/css/properties/field-sizing.json
@@ -15,8 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1977176"
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -49,8 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1977176"
+                "version_added": "152"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -84,8 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
-                "impl_url": "https://bugzil.la/1977176"
+                "version_added": "152"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -12,17 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.fake-webkit-scrollbar.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1432935",
-              "partial_implementation": true,
-              "notes": "The `@supports selector(::-webkit-scrollbar)` returns `true` but this pseudo-element cannot be used to style scrollbars. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -12,7 +12,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "152"
+              "version_added": "152",
+              "partial_implementation": true,
+              "notes": "The `@supports selector(::-webkit-scrollbar)` returns `true` but this pseudo-element cannot be used to style scrollbars. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.17.13) found new features shipping in Firefox 152 beta which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following features as shipping in Firefox 152 (bold features are new keys in BCD).

- **api.AnimationEvent.animation**
- api.MathMLElement.nonce
- api.Notification.actions
- api.PerformanceResourceTiming.finalResponseHeadersStart
- api.PerformanceResourceTiming.firstInterimResponseStart
- api.RTCPeerConnection.RTCPeerConnection.configuration_rtcpMuxPolicy_parameter
- **api.TransitionEvent.animation**
- css.properties.field-sizing
- css.properties.field-sizing.content
- css.properties.field-sizing.fixed
- css.selectors.-webkit-scrollbar (not sure if removal of partial is correct, see https://github.com/mdn/browser-compat-data/pull/29665, see also https://www.firefox.com/en-US/firefox/152.0beta/releasenotes/)


For more Firefox 152 info, see also https://github.com/mdn/mdn/issues/830 and https://www.firefox.com/en-US/firefox/152.0beta/releasenotes/