### PR TITLE
Reconcile Safari `Reporting-Endpoints` `default` data

### DIFF
--- a/http/headers/Reporting-Endpoints.json
+++ b/http/headers/Reporting-Endpoints.json
@@ -88,7 +88,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "16.4"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -119,7 +119,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "16.4"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -151,7 +151,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "16.4"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION


This is my goof, with a bad review on #29539.



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari doesn't support any of the report types that are known to use `default`, so I don't think Safari actually does anything with `default`. This also reconciles the support data with `api.ReportingObserver.ReportingObserver.options_parameter.types_property.deprecation`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Safari has open bugs for deprecation and crash reporting along with concerns on the relevant standards positions issues. There's no good evidence that they implemented anything here, even behind a flag.

It's probably just a bad copy and paste from the ancestor features, which I ought to have caught reviewing https://github.com/mdn/browser-compat-data/pull/29539/. Oops!

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Previously: https://github.com/mdn/browser-compat-data/pull/29539/
- Bug: https://bugs.webkit.org/show_bug.cgi?id=269925
- Bug: https://bugs.webkit.org/show_bug.cgi?id=244899
- Standards position: https://github.com/WebKit/standards-positions/issues/59
- Standards position: https://github.com/WebKit/standards-positions/issues/456

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
