### PR TITLE
Edge's privacy preserving ads API never shipped

### DIFF
--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -54,7 +54,9 @@
               "version_added": "122"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -510,7 +510,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -765,7 +767,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -993,7 +997,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -1101,7 +1107,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -1621,7 +1629,9 @@
               "version_added": "132"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -2098,7 +2108,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -2278,7 +2290,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -3272,7 +3286,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -4831,7 +4847,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },
@@ -5440,7 +5458,9 @@
               "version_added": "128"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/ProtectedAudience.json
+++ b/api/ProtectedAudience.json
@@ -7,7 +7,9 @@
             "version_added": "127"
           },
           "chrome_android": "mirror",
-          "edge": "mirror",
+          "edge": {
+            "version_added": false
+          },
           "firefox": {
             "version_added": false
           },
@@ -36,7 +38,9 @@
               "version_added": "127"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },

--- a/api/SharedStorageWorkletGlobalScope.json
+++ b/api/SharedStorageWorkletGlobalScope.json
@@ -40,7 +40,9 @@
               "version_added": "134"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false
+            },
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As best as I can tell, Edge's variation on Google's protected audience API never shipped and was gated behind a flag. This will make removal dates make more sense.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

See this blog post: https://blogs.windows.com/msedgedev/2024/03/05/new-privacy-preserving-ads-api/ and the discussion on https://github.com/web-platform-dx/web-features/pull/2635.

This was never quite the same as protected audience, but it shared some of the same surface area.

Also, it's slated for removal (like Google's API); see https://github.com/web-platform-dx/web-features/pull/2635#issuecomment-3971985214.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/pull/2635

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
