### PR TITLE
Firefox 152 adds `Notification.maxActions` + `NotificationEvent.action`

### DIFF
--- a/api/Notification.json
+++ b/api/Notification.json
@@ -797,7 +797,7 @@
             },
             "firefox": [
               {
-                "version_added": "preview"
+                "version_added": "152"
               },
               {
                 "version_added": "138",
@@ -820,7 +820,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/NotificationEvent.json
+++ b/api/NotificationEvent.json
@@ -117,7 +117,7 @@
               "version_added": "17"
             },
             "firefox": {
-              "version_added": "44"
+              "version_added": "152"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
FF152 suports Notification.maxActions, Notification.action,  NotificationEvent.action in Ff152 in https://bugzilla.mozilla.org/show_bug.cgi?id=1959931

The Notification.action was updated in #29718 - this updates the other two.
BCD collector seems to not run well for these - it gives me unknown on the event.

Related docs work can be tracked in https://github.com/mdn/content/issues/44159