### PR TITLE
Firefox 152 adds `Element.getAnimations()` `pseudoElement` option

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5256,7 +5256,7 @@
               "deprecated": false
             }
           },
-          "options_pseudoElement_parameter": {
+          "pseudoElement_option": {
             "__compat": {
               "description": "`options.pseudoElement` parameter",
               "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-getanimationsoptions-pseudoelement",

--- a/api/Element.json
+++ b/api/Element.json
@@ -5254,40 +5254,40 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
-            }
-          },
-          "options_pseudoElement_parameter": {
-            "__compat": {
-              "description": "`options.pseudoElement` parameter",
-              "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-getanimationsoptions-pseudoelement",
-              "tags": [
-                "web-features:web-animations"
-              ],
-              "support": {
-                "chrome": {
-                  "version_added": false
+            },
+            "pseudoElement_option": {
+              "__compat": {
+                "description": "`pseudoElement` option",
+                "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-getanimationsoptions-pseudoelement",
+                "tags": [
+                  "web-features:web-animations"
+                ],
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "152"
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
                 },
-                "chrome_android": "mirror",
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "152"
-                },
-                "firefox_android": "mirror",
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror",
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": true,
-                "deprecated": false
+                "status": {
+                  "experimental": true,
+                  "standard_track": true,
+                  "deprecated": false
+                }
               }
             }
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -5254,40 +5254,40 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
-            },
-            "pseudoElement_option": {
-              "__compat": {
-                "description": "`pseudoElement` option",
-                "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-getanimationsoptions-pseudoelement",
-                "tags": [
-                  "web-features:web-animations"
-                ],
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "chrome_android": "mirror",
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "152"
-                  },
-                  "firefox_android": "mirror",
-                  "oculus": "mirror",
-                  "opera": "mirror",
-                  "opera_android": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror",
-                  "samsunginternet_android": "mirror",
-                  "webview_android": "mirror",
-                  "webview_ios": "mirror"
+            }
+          },
+          "options_pseudoElement_parameter": {
+            "__compat": {
+              "description": "`options.pseudoElement` parameter",
+              "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-getanimationsoptions-pseudoelement",
+              "tags": [
+                "web-features:web-animations"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
                 },
-                "status": {
-                  "experimental": true,
-                  "standard_track": true,
-                  "deprecated": false
-                }
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "152"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }

--- a/api/Element.json
+++ b/api/Element.json
@@ -5220,6 +5220,77 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_parameter": {
+          "__compat": {
+            "description": "`options` parameter",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/Element/getAnimations#options",
+            "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-animatable-getanimations-options-options",
+            "tags": [
+              "web-features:web-animations"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "84"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "75"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "13.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "options_pseudoElement_parameter": {
+            "__compat": {
+              "description": "`options.pseudoElement` parameter",
+              "spec_url": "https://drafts.csswg.org/web-animations-1/#dom-getanimationsoptions-pseudoelement",
+              "tags": [
+                "web-features:web-animations"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "152"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
         }
       },
       "getAttribute": {


### PR DESCRIPTION
FF152 adds support for the `options.pseudoElement` param to be passed to [`Element.getAnimations()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/getAnimations#options) in https://bugzilla.mozilla.org/show_bug.cgi?id=1935557

This adds the subfeature. Tested https://wpt.live/web-animations/interfaces/Animatable/getAnimations-pseudoElement-option-on-view-transition.html as not working on current Safari (17) and Chrome.

Note, not caught be collector run by #29718

Related docs work can be tracked in https://github.com/mdn/content/issues/44160