### PR TITLE
Safari TP takes transforms into account for anchor positioning

### DIFF
--- a/css/properties/anchor-name.json
+++ b/css/properties/anchor-name.json
@@ -91,12 +91,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": [
-                  "https://webkit.org/b/289743",
-                  "https://webkit.org/b/309921",
-                  "https://webkit.org/b/307660"
-                ]
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari TP now handles anchor positioning after layout.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

It was mentioned [in the release notes](https://webkit.org/blog/17962/release-notes-for-safari-technology-preview-244/#:~:text=Added%20support%20for%20transform%2Daware%20anchor%20positioning) and I tried it out with [this demo](https://codepen.io/yisi/pen/eYaJopE).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/issues/3558
- https://webkit.org/b/307660
- https://webkit.org/b/309921
- https://webkit.org/b/289743

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
