### PR TITLE
Fix typo in Chrome notes for `FileSystemHandle.move`

### DIFF
--- a/api/FileSystemHandle.json
+++ b/api/FileSystemHandle.json
@@ -116,7 +116,7 @@
             "chrome": {
               "version_added": "102",
               "partial_implementation": true,
-              "notes": "Directory moves are not supported. The method is only expopsed on `FileSystemFileHandle`, not on `FileSystemHandle` and `FileSystemDirectoryHandle`. See [bug 40198034](https://crbug.com/40198034)."
+              "notes": "Directory moves are not supported. The method is only exposed on `FileSystemFileHandle`, not on `FileSystemHandle` and `FileSystemDirectoryHandle`. See [bug 40198034](https://crbug.com/40198034)."
             },
             "chrome_android": {
               "version_added": "109"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Fix typo: ~expopsed~ exposed

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://github.com/mdn/browser-compat-data/pull/29385#discussion_r3130904028

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
