### PR TITLE
Chrome 142 supports SVG a element download attribute

### DIFF
--- a/svg/elements/a.json
+++ b/svg/elements/a.json
@@ -52,7 +52,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "142"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 142 adds support for the SVG `<a>` element [`download` attribute](https://svgwg.org/svg2-draft/linking.html#AElementDownloadAttribute); see https://chromestatus.com/feature/6265596395913216.

We already have up-to-date data for the `SVGAElement.download` property, but not the SVG `<a>` element `download` attribute. This PR rectifies that.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
