### PR TITLE
Issue 29704 webextensions.api.menus.ContextType "tab" support in Chrome-150

### DIFF
--- a/webextensions/api/menus.json
+++ b/webextensions/api/menus.json
@@ -245,7 +245,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "150"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Add details of Chrome support for `"tab"` in `contextMenus` (which is offered on Firefox through the `menus`API.)

#### Related issues

Fixes #29704