### PR TITLE
FF152 MediaCapabilities.decodingInfo/encodingInfo() - config.type.webrtc option

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -183,41 +183,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-            },
-            "transmission_option": {
-              "__compat": {
-                "description": "`configuration.type.transmission` parameter",
-                "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#transmission",
-                "support": {
-                  "chrome": {
-                    "version_added": "66"
-                  },
-                  "chrome_android": "mirror",
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "63",
-                    "partial_implementation": true,
-                    "notes": "The spec name for this option is `webrtc`."
-                  },
-                  "firefox_android": "mirror",
-                  "oculus": "mirror",
-                  "opera": "mirror",
-                  "opera_android": {
-                    "version_added": "48"
-                  },
-                  "safari": {
-                    "version_added": "13"
-                  },
-                  "safari_ios": "mirror",
-                  "samsunginternet_android": "mirror",
-                  "webview_android": "mirror",
-                  "webview_ios": "mirror"
-                },
-                "status": {
-                  "experimental": false,
-                  "standard_track": false,
-                  "deprecated": true
-                }
               }
             },
             "webrtc_option": {

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -183,7 +183,6 @@
                 "standard_track": true,
                 "deprecated": false
               }
-              }
             },
             "webrtc_option": {
               "__compat": {

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -55,10 +55,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "63",
-              "notes": [
-                "The `webrtc` value of the `type` option is named `transmission`.",
-                "Before Firefox 101, `decodingInfo()` ignored `codecs` parameter options for `av01` codecs (treating them as `av1`)."
-              ]
+              "notes": "Before Firefox 101, `decodingInfo()` ignored `codecs` parameter options for `av01` codecs (treating them as `av1`)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -84,29 +81,27 @@
             "deprecated": false
           }
         },
-        "configuration_keySystemConfiguration_parameter": {
+        "configuration_parameter": {
           "__compat": {
-            "description": "`configuration.keySystemConfiguration` parameter",
-            "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#keysystemconfiguration",
-            "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-keysystemconfiguration",
-            "tags": [
-              "web-features:encrypted-media-extensions"
-            ],
+            "description": "`configuration` parameter",
+            "spec_url": "https://w3c.github.io/media-capabilities/#dictdef-mediadecodingconfiguration",
             "support": {
               "chrome": {
-                "version_added": "80"
+                "version_added": "66"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "129"
+                "version_added": "63"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
-              "opera_android": "mirror",
+              "opera_android": {
+                "version_added": "48"
+              },
               "safari": {
-                "version_added": false
+                "version_added": "13"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -117,6 +112,155 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "keySystemConfiguration_parameter": {
+            "__compat": {
+              "description": "`configuration.keySystemConfiguration` parameter",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#keysystemconfiguration",
+              "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-keysystemconfiguration",
+              "tags": [
+                "web-features:encrypted-media-extensions"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "80"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "129"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "type_parameter": {
+            "__compat": {
+              "description": "`configuration.type` parameter",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#type",
+              "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-type",
+              "support": {
+                "chrome": {
+                  "version_added": "66"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": {
+                  "version_added": "48"
+                },
+                "safari": {
+                  "version_added": "13"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "transmission_option": {
+              "__compat": {
+                "description": "`configuration.type.transmission` parameter",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#transmission",
+                "support": {
+                  "chrome": {
+                    "version_added": "66"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "63",
+                    "partial_implementation": true,
+                    "notes": "The spec name for this option is `webrtc`."
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": "48"
+                  },
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            },
+            "webrtc_option": {
+              "__compat": {
+                "description": "`configuration.type.webrtc` parameter",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#webrtc",
+                "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingtype-webrtc",
+                "support": {
+                  "chrome": {
+                    "version_added": "66"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "152",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "media.mediacapabilities.webrtc.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": {
+                    "version_added": "48"
+                  },
+                  "safari": {
+                    "version_added": "13"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
             }
           }
         }
@@ -135,8 +279,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "63",
-              "notes": "The `webrtc` value of the `type` option is named `transmission`."
+              "version_added": "63"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -154,6 +297,157 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "configuration_parameter": {
+          "__compat": {
+            "description": "`configuration` parameter",
+            "spec_url": "https://w3c.github.io/media-capabilities/#dictdef-mediaencodingconfiguration",
+            "tags": [
+              "web-features:media-capabilities"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "101"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "63"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "type_parameter": {
+            "__compat": {
+              "description": "`configuration.type` parameter",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo#type",
+              "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediaencodingconfiguration-type",
+              "tags": [
+                "web-features:media-capabilities"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "101"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "15.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            },
+            "transmission_option": {
+              "__compat": {
+                "description": "`configuration.type.transmission` parameter",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo#transmission",
+                "tags": [
+                  "web-features:media-capabilities"
+                ],
+                "support": {
+                  "chrome": {
+                    "version_added": "101"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "63",
+                    "partial_implementation": true,
+                    "notes": "The spec name for this option is `webrtc`."
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "15.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": false,
+                  "deprecated": true
+                }
+              }
+            },
+            "webrtc_option": {
+              "__compat": {
+                "description": "`configuration.type.webrtc` parameter",
+                "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo#webrtc",
+                "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediaencodingtype-webrtc",
+                "tags": [
+                  "web-features:media-capabilities"
+                ],
+                "support": {
+                  "chrome": {
+                    "version_added": "101"
+                  },
+                  "chrome_android": "mirror",
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "152",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "media.mediacapabilities.webrtc.enabled",
+                        "value_to_set": "true"
+                      }
+                    ]
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": "15.4"
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": false,
+                  "standard_track": true,
+                  "deprecated": false
+                }
+              }
+            }
           }
         }
       }

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -114,9 +114,9 @@
               "deprecated": false
             }
           },
-          "keySystemConfiguration_parameter": {
+          "keySystemConfiguration": {
             "__compat": {
-              "description": "`configuration.keySystemConfiguration` parameter",
+              "description": "`keySystemConfiguration` property",
               "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#keysystemconfiguration",
               "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-keysystemconfiguration",
               "tags": [
@@ -150,9 +150,9 @@
               }
             }
           },
-          "type_parameter": {
+          "type": {
             "__compat": {
-              "description": "`configuration.type` parameter",
+              "description": "`type` property",
               "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#type",
               "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingconfiguration-type",
               "support": {
@@ -186,7 +186,7 @@
             },
             "webrtc_option": {
               "__compat": {
-                "description": "`configuration.type.webrtc` parameter",
+                "description": "`configuration.type.webrtc` option",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/decodingInfo#webrtc",
                 "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediadecodingtype-webrtc",
                 "support": {
@@ -297,9 +297,9 @@
               "deprecated": false
             }
           },
-          "type_parameter": {
+          "type": {
             "__compat": {
-              "description": "`configuration.type` parameter",
+              "description": "`type` property",
               "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo#type",
               "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediaencodingconfiguration-type",
               "tags": [
@@ -334,7 +334,7 @@
             },
             "transmission_option": {
               "__compat": {
-                "description": "`configuration.type.transmission` parameter",
+                "description": "`configuration.type.transmission` option",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo#transmission",
                 "tags": [
                   "web-features:media-capabilities"
@@ -371,7 +371,7 @@
             },
             "webrtc_option": {
               "__compat": {
-                "description": "`configuration.type.webrtc` parameter",
+                "description": "`configuration.type.webrtc` option",
                 "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaCapabilities/encodingInfo#webrtc",
                 "spec_url": "https://w3c.github.io/media-capabilities/#dom-mediaencodingtype-webrtc",
                 "tags": [


### PR DESCRIPTION
FF152 adds support for the `configuration.type.webrtc` option to be passed to [`MediaCapabilities.decodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo#webrtc) and [`MediaCapabilities.encodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/encodingInfo#webrtc) , and removes the non-standard "alias" `transmission` that has been around since FF63ish. The addition is behind the flag `media.mediacapabilities.webrtc.enabled`. Bug is https://bugzilla.mozilla.org/show_bug.cgi?id=1825286

To do this I have created a structure of nested features to mirror the `configuration` option, which has `type` property, and below that has the new `webrtc` and `transmission` (to be removed when this is merged). Also moved an existing key below that configuraiton option.

Related docs work can be tracked in https://github.com/mdn/content/issues/44174

