### PR TITLE
Add data for SpeechRecognition quality option

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -299,6 +299,74 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_parameter": {
+          "__compat": {
+            "description": "`options` parameter",
+            "spec_url": "https://webaudio.github.io/web-speech-api/#dictdef-speechrecognitionoptions",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "options_quality_parameter": {
+            "__compat": {
+              "description": "`options.quality` parameter",
+              "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-quality",
+              "support": {
+                "chrome": {
+                  "version_added": "150"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
         }
       },
       "continuous": {
@@ -513,6 +581,74 @@
             "experimental": true,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "options_parameter": {
+          "__compat": {
+            "description": "`options` parameter",
+            "spec_url": "https://webaudio.github.io/web-speech-api/#dictdef-speechrecognitionoptions",
+            "support": {
+              "chrome": {
+                "version_added": "139"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "options_quality_parameter": {
+            "__compat": {
+              "description": "`options.quality` parameter",
+              "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-quality",
+              "support": {
+                "chrome": {
+                  "version_added": "150"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         }
       },

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -333,6 +333,74 @@
               "deprecated": false
             }
           },
+          "options_langs_parameter": {
+            "__compat": {
+              "description": "`options.langs` parameter",
+              "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-langs",
+              "support": {
+                "chrome": {
+                  "version_added": "139"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "options_processLocally_parameter": {
+            "__compat": {
+              "description": "`options.processLocally` parameter",
+              "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-processlocally",
+              "support": {
+                "chrome": {
+                  "version_added": "139"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "options_quality_parameter": {
             "__compat": {
               "description": "`options.quality` parameter",
@@ -614,6 +682,74 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "options_langs_parameter": {
+            "__compat": {
+              "description": "`options.langs` parameter",
+              "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-langs",
+              "support": {
+                "chrome": {
+                  "version_added": "139"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "options_processLocally_parameter": {
+            "__compat": {
+              "description": "`options.processLocally` parameter",
+              "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-processlocally",
+              "support": {
+                "chrome": {
+                  "version_added": "139"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           },
           "options_quality_parameter": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 150 adds support for the [`SpeechRecognitionOptions` `quality` property](https://webaudio.github.io/web-speech-api/#dom-speechrecognitionoptions-quality). See https://chromestatus.com/feature/5136859632107520.

This PR adds a data point for the `options` object overall, and then a subdata point for `quality`, for both methods that use this `options` object — `available()` and `install()`. I am not 100% sure about this structure, but I copied it from https://github.com/mdn/browser-compat-data/blob/c0772004be4201be3fd9e0de1099998bc0654e9c/javascript/builtins/Intl/NumberFormat.json#L229. 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
