### PR TITLE
Node.js 26.0.0 Upsert and Iterator sequencing

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -116,7 +116,7 @@
               },
               "firefox_android": "mirror",
               "nodejs": {
-                "version_added": false
+                "version_added": "26.0.0"
               },
               "oculus": "mirror",
               "opera": "mirror",

--- a/javascript/builtins/Map.json
+++ b/javascript/builtins/Map.json
@@ -468,6 +468,9 @@
                 "version_added": "144"
               },
               "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "26.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -509,6 +512,9 @@
                 "version_added": "144"
               },
               "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "26.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/javascript/builtins/WeakMap.json
+++ b/javascript/builtins/WeakMap.json
@@ -323,6 +323,9 @@
                 "version_added": "144"
               },
               "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "26.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -364,6 +367,9 @@
                 "version_added": "144"
               },
               "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": "26.0.0"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",


### PR DESCRIPTION
#### Summary

Adds to the data that Node 26.0.0 supports `[Weak]Map.getOrInsert[Computed]` and `Iterator.concat`

#### Test results and supporting details

Running the following code in Node.js 26.0.0 outputs the expected results:
```javascript
console.log(new Map().getOrInsert("key", "val"));
console.log(Array.from(Iterator.concat([1], [2])));
```

This is noted in the [Node.js 26.0.0 Changelog](https://github.com/nodejs/node/releases/tag/v26.0.0) under the "V8 14.6" section.