### PR TITLE
FF152 with clause {type: "text"}

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1206,6 +1206,51 @@
               "deprecated": false
             }
           }
+        },
+        "text": {
+          "__compat": {
+            "description": "`text` value",
+            "spec_url": "https://fetch.spec.whatwg.org/#concept-request-destination",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "152",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.import_text",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "duplex": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1857,7 +1857,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": "2.8.0"
+                  "version_added": "2.8"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1749,6 +1749,7 @@
           "type_css": {
             "__compat": {
               "description": "`with {type: 'css'}`",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import/with#css_modules_type_css",
               "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#css-module-script",
               "tags": [
                 "web-features:css-modules"
@@ -1794,6 +1795,7 @@
           "type_json": {
             "__compat": {
               "description": "`with {type: 'json'}`",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import/with#json_modules_type_json",
               "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#json-module-script",
               "tags": [
                 "web-features:json-modules"
@@ -1836,6 +1838,55 @@
               },
               "status": {
                 "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "type_text": {
+            "__compat": {
+              "description": "`with {type: 'text'}`",
+              "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/import/with#text_modules_type_text",
+              "spec_url": "https://html.spec.whatwg.org/multipage/webappapis.html#text-module-script",
+              "support": {
+                "bun": {
+                  "version_added": "1.1.5"
+                },
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "152",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.import_text",
+                      "value_to_set": "true"
+                    }
+                  ]
+                },
+                "firefox_android": "mirror",
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1857,7 +1857,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": "2.4"
+                  "version_added": "2.8.0"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1857,7 +1857,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "2.4"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
FF152 adds support for importing text modules in https://bugzilla.mozilla.org/show_bug.cgi?id=2024854 (this uses the `with` clause `{type: "text"}`.

This adds the text type subfeature, and corresponding `text` destination for fetch requests. This doesn't seem to be supported in Chrome or Safari (quick search). I've set other platforms to false, except for BUN

Related docs work can be tracked in https://github.com/mdn/content/issues/44166