### PR TITLE
FF152 TC39 Iterator includes

### DIFF
--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -488,7 +488,7 @@
         },
         "includes": {
           "__compat": {
-            "spec_url": "https://github.com/tc39/proposal-iterator-includes",
+            "spec_url": "https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes",
             "support": {
               "bun": {
                 "version_added": false

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -488,6 +488,7 @@
         },
         "includes": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/includes",
             "spec_url": "https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes",
             "support": {
               "bun": {

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -486,6 +486,56 @@
             }
           }
         },
+        "includes": {
+          "__compat": {
+            "spec_url": "https://github.com/tc39/proposal-iterator-includes",
+            "tags": [
+              "web-features:iterator-methods"
+            ],
+            "support": {
+              "bun": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "152",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "javascript.options.experimental.iterator_includes",
+                    "value_to_set": "true"
+                  }
+                ]
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "map": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/map",

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -489,9 +489,6 @@
         "includes": {
           "__compat": {
             "spec_url": "https://github.com/tc39/proposal-iterator-includes",
-            "tags": [
-              "web-features:iterator-methods"
-            ],
             "support": {
               "bun": {
                 "version_added": false


### PR DESCRIPTION
FF152 adds support for the [TC39 Iterator proposal](https://github.com/tc39/proposal-iterator-includes) in https://bugzilla.mozilla.org/show_bug.cgi?id=2025779 behind pref `javascript.options.experimental.iterator_includes`

This adds the feature for the `Iterator.includes()` builtin.
Note, I can't see evidence it is supported yet by anyone other than FF, which seems reasonable given it is early in the cycle.

It fails because of the spec url which is the github repo. 
I tried https://tc39.es/proposal-iterator-includes/ as well but that didn't work. 
I'm after advice, since it looks in the browser spec repo that tc39 specs are allowed ....

Related docs work can be tracked in https://github.com/mdn/content/issues/44158