### PR TITLE
FF152 TC39 Intl.Locale info proposal

### DIFF
--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -293,7 +293,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -359,7 +366,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -425,7 +439,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -491,7 +512,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -559,7 +587,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -625,7 +660,14 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -699,7 +741,14 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.intl_locale_info",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "nodejs": [


### PR DESCRIPTION
FF152 adds support for the [TC39 Intl.Locale info proposal](https://github.com/tc39/proposal-intl-locale-info) in https://bugzilla.mozilla.org/show_bug.cgi?id=1693576, behind the pref `javascript.options.experimental.intl_locale_info` and **only** in nightly.

This updates the following features with the support information:
  - [`Intl.Locale.prototype.getCalendars()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCalendars)
  - [`Intl.Locale.prototype.getCollations()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getCollations)
  - [`Intl.Locale.prototype.getHourCycles()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getHourCycles)
  - [`Intl.Locale.prototype.getNumberingSystems()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getNumberingSystems)
  - [`Intl.Locale.prototype.getTextInfo()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo)
  - [`Intl.Locale.prototype.getTimeZones()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTimeZones)
  - [`Intl.Locale.prototype.getWeekInfo()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getWeekInfo)


Related docs can be tracked in https://github.com/mdn/content/issues/44172

