### PR TITLE
ci(workflows): add needs-triage workflow

### DIFF
--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,16 @@
+name: needs-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    if: github.repository_owner == 'mdn'
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main


### PR DESCRIPTION
### Description

Syncs `.github/workflows/needs-triage.yml` from [`mdn/fred@60f3f48`](https://github.com/mdn/fred/blob/60f3f481de1838e95fbb3fed9495b10f1a590678/.github/workflows/needs-triage.yml).

### Motivation

Ensure that all opened issues, and especially transferred and reopened issues, get the "needs triage" label.

### Additional details

Discussed in the BCD project meeting on 2026-05-06.

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/1564.
