### PR TITLE
Update edge support data in LanguageModel.json

### DIFF
--- a/api/LanguageModel.json
+++ b/api/LanguageModel.json
@@ -16,11 +16,11 @@
           "edge": {
             "version_added": "138",
             "flags": [
-                {
-                  "type": "preference",
-                  "name": "#edge-llm-prompt-api-for-phi-mini",
-                  "value_to_set": "Enabled"
-                }
+              {
+                "type": "preference",
+                "name": "#edge-llm-prompt-api-for-phi-mini",
+                "value_to_set": "Enabled"
+              }
             ]
           },
           "firefox": {
@@ -61,11 +61,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -107,11 +107,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -153,11 +153,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -197,11 +197,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -243,11 +243,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -289,11 +289,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -335,11 +335,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -378,11 +378,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -424,11 +424,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -470,11 +470,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {
@@ -516,11 +516,11 @@
             "edge": {
               "version_added": "138",
               "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#edge-llm-prompt-api-for-phi-mini",
-                    "value_to_set": "Enabled"
-                  }
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
               ]
             },
             "firefox": {

--- a/api/LanguageModel.json
+++ b/api/LanguageModel.json
@@ -13,7 +13,16 @@
           "chrome_android": {
             "version_added": false
           },
-          "edge": "mirror",
+          "edge": {
+            "version_added": "138",
+            "flags": [
+                {
+                  "type": "preference",
+                  "name": "#edge-llm-prompt-api-for-phi-mini",
+                  "value_to_set": "Enabled"
+                }
+            ]
+          },
           "firefox": {
             "version_added": false
           },
@@ -49,7 +58,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -86,7 +104,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -123,7 +150,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -158,7 +194,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -195,7 +240,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -232,7 +286,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -269,7 +332,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -303,7 +375,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -340,7 +421,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -377,7 +467,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },
@@ -414,7 +513,16 @@
             "chrome_android": {
               "version_added": false
             },
-            "edge": "mirror",
+            "edge": {
+              "version_added": "138",
+              "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+              ]
+            },
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

See https://groups.google.com/a/chromium.org/g/blink-dev/c/iR6R7-nQeHI/m/419QMzI_AQAJ
The Edge team still has the LanguageModel API behind a flag. We did not enable it by default like Chrome.

The 138 version and flag come from https://learn.microsoft.com/en-us/microsoft-edge/web-platform/prompt-api#enable-the-prompt-api

#### Test results and supporting details

You can test the API at https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/prompt-api/