### PR TITLE
Add data points about name-only container queries

### DIFF
--- a/css/properties/container-name.json
+++ b/css/properties/container-name.json
@@ -37,7 +37,7 @@
         },
         "name-only_queries": {
           "__compat": {
-            "description": "Query containers can be established with `container-name` only (name-only queries).",
+            "description": "Name-only container queries",
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {

--- a/css/properties/container-name.json
+++ b/css/properties/container-name.json
@@ -35,6 +35,39 @@
             "deprecated": false
           }
         },
+        "name-only_queries": {
+          "__compat": {
+            "description": "Query containers can be established with `container-name` only (name-only queries).",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
+            "support": {
+              "chrome": {
+                "version_added": "148",
+                "impl_url": "https://crbug.com/40287550"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-name-none",

--- a/css/properties/container-name.json
+++ b/css/properties/container-name.json
@@ -41,8 +41,7 @@
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {
-                "version_added": "148",
-                "impl_url": "https://crbug.com/40287550"
+                "version_added": "148"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -103,6 +103,39 @@
             }
           }
         },
+        "name-only_queries": {
+          "__compat": {
+            "description": "`container-type` optional for establishing query containers (name-only queries).",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
+            "support": {
+              "chrome": {
+                "version_added": "148",
+                "impl_url": "https://crbug.com/40287550"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "normal": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-type-normal",

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -109,8 +109,7 @@
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {
-                "version_added": "148",
-                "impl_url": "https://crbug.com/40287550"
+                "version_added": "148"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/container-type.json
+++ b/css/properties/container-type.json
@@ -105,7 +105,7 @@
         },
         "name-only_queries": {
           "__compat": {
-            "description": "`container-type` optional for establishing query containers (name-only queries).",
+            "description": "Name-only container queries",
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {

--- a/css/properties/container.json
+++ b/css/properties/container.json
@@ -72,8 +72,7 @@
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {
-                "version_added": "148",
-                "impl_url": "https://crbug.com/40287550"
+                "version_added": "148"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/container.json
+++ b/css/properties/container.json
@@ -66,6 +66,39 @@
             }
           }
         },
+        "name-only_queries": {
+          "__compat": {
+            "description": "`container-type` optional for establishing query containers (name-only queries).",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
+            "support": {
+              "chrome": {
+                "version_added": "148",
+                "impl_url": "https://crbug.com/40287550"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#valdef-container-name-none",

--- a/css/properties/container.json
+++ b/css/properties/container.json
@@ -68,7 +68,7 @@
         },
         "name-only_queries": {
           "__compat": {
-            "description": "`container-type` optional for establishing query containers (name-only queries).",
+            "description": "Name-only container queries",
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-container-condition",
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 148 adds support for name-only container queries; see https://chromestatus.com/feature/5184267522015232.

The `@container` BCD file already has a data point about name-only container queries, but I thought it would be a good idea to add data points about this to the `container-name`, `container-type`, and `container` property BCD. Those pages will include examples/information about name-only queries, and I think they are common places where people will want this compat info.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
