### PR TITLE
Update Firefox WEBGL_compressed_texture_etc[1] support

### DIFF
--- a/api/WEBGL_compressed_texture_etc.json
+++ b/api/WEBGL_compressed_texture_etc.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "55"
           },
           "firefox_android": {
             "version_added": "51"

--- a/api/WEBGL_compressed_texture_etc1.json
+++ b/api/WEBGL_compressed_texture_etc1.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "55"
           },
           "firefox_android": {
             "version_added": "30"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Mark WEBGL_compressed_texture_etc as supported in Firefox desktop.

#### Test results and supporting details

This was marked as supported for mobile only, but per https://bugzilla.mozilla.org/show_bug.cgi?id=1366725 it was actually about WebGL 1 vs WebGL 2 and has been supported for both since at least Firefox 55. Locally running the relevant tests in https://registry.khronos.org/webgl/sdk/tests/webgl-conformance-tests.html?version=1.0.4 works for me in both the v1 and v2 modes.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
