### PR TITLE
Safari 26.2 has full support for accent-color

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -27,7 +27,7 @@
             "opera_android": "mirror",
             "safari": [
               {
-                "version_added": "26.2",
+                "version_added": "26.2"
               },
               {
                 "version_added": "15.4",

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -25,11 +25,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "15.4",
-              "partial_implementation": true,
-              "notes": "Safari does not maintain minimum contrast for legibility of the control. See [bug 244233](https://webkit.org/b/244233)."
-            },
+            "safari": [
+              {
+                "version_added": "26.2",
+              },
+              {
+                "version_added": "15.4",
+                "version_removed": "26.2",
+                "partial_implementation": true,
+                "notes": "Safari does not maintain minimum contrast for legibility of the control. See [bug 244233](https://webkit.org/b/244233)."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
Sources:
https://bugs.webkit.org/show_bug.cgi?id=244233
https://developer.apple.com/documentation/safari-release-notes/safari-26_2-release-notes

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
