### PR TITLE
CSS `url()` modifiers: set Chrome version, Firefox `impl_url`s

### DIFF
--- a/css/types/url.json
+++ b/css/types/url.json
@@ -52,7 +52,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "150"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -73,7 +73,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -85,7 +85,7 @@
             "spec_url": "https://drafts.csswg.org/css-values-5/#typedef-request-url-modifier-integrity-modifier",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "150"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -121,7 +121,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "150"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -142,7 +142,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/types/url.json
+++ b/css/types/url.json
@@ -57,7 +57,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2038424"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -89,7 +90,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2038424"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -124,7 +126,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2038424"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Update the expected version number for Chrome and link to the Firefox bug for CSS `url()` request modifiers.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

I was tipped off to this by the Chromium engineer, in https://github.com/web-platform-dx/web-features/issues/3930#issuecomment-4543191391.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- [Chrome status entry: CSS URL request modifiers](https://chromestatus.com/feature/5111997147512832)
- [Firefox bug 2038424](https://bugzilla.mozilla.org/show_bug.cgi?id=2038424 "[css-values] Implement url request modifiers")
- https://github.com/web-platform-dx/web-features/issues/3930#issuecomment-4543191391
- Previously:
  - https://github.com/mdn/browser-compat-data/pull/29663
  - https://github.com/mdn/browser-compat-data/pull/29440

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
