### PR TITLE
Translator and LanguageDetector APIs are in Edge 148

### DIFF
--- a/api/LanguageDetector.json
+++ b/api/LanguageDetector.json
@@ -19,7 +19,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "148"
           },
           "firefox": {
             "version_added": false
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -159,7 +159,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -206,7 +206,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -253,7 +253,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -300,7 +300,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -347,7 +347,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false

--- a/api/Translator.json
+++ b/api/Translator.json
@@ -19,7 +19,7 @@
             "version_added": false
           },
           "edge": {
-            "version_added": false
+            "version_added": "148"
           },
           "firefox": {
             "version_added": false
@@ -65,7 +65,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -112,7 +112,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -159,7 +159,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -206,7 +206,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -253,7 +253,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -300,7 +300,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -347,7 +347,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -394,7 +394,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false
@@ -441,7 +441,7 @@
               "version_added": false
             },
             "edge": {
-              "version_added": false
+              "version_added": "148"
             },
             "firefox": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Marking the Translator and LanguageDetector APIs as supported in Edge 148.

#### Test results and supporting details

Tested https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/translator-api/ and https://microsoftedge.github.io/Demos/built-in-ai/playgrounds/languagedetector-api/ in Edge Version 148.0.3967.83 (Official build) (arm64) on Windows 11.

See https://learn.microsoft.com/en-us/microsoft-edge/web-platform/translator-api and https://learn.microsoft.com/en-us/microsoft-edge/web-platform/languagedetector-api