### PR TITLE
Bug 2034168 extension.isAllowedFileSchemeAccess reflects file access permission

### DIFF
--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -280,10 +280,18 @@
                 "version_added": "12"
               },
               "edge": "mirror",
-              "firefox": {
-                "version_added": "48",
-                "notes": "From Firefox 153, the value returned reflects the \"Access local files on your computer\" option in the extension's permissions settings."
-              },
+              "firefox": [
+                {
+                  "version_added": "153",
+                  "notes": "The value returned reflects the \"Access local files on your computer\" option in the extension's permissions settings."
+                },
+                {
+                  "version_added": "48",
+                  "version_removed": "153",
+                  "partial_implementation": true,
+                  "notes": "Always returns `false`."
+                }
+              ],
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {

--- a/webextensions/api/extension.json
+++ b/webextensions/api/extension.json
@@ -281,7 +281,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "From Firefox 153, the value returned reflects the \"Access local files on your computer\" option in the extension's permissions settings."
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Update to reflect that [Bug 2034168](https://bugzilla.mozilla.org/show_bug.cgi?id=2034168) including a change so that
`extension.isAllowedFileSchemeAccess()` reflects the value of the "Access local files on your computer" option in the extension's permissions settings.

#### Related issues

Four related content changes see PR https://github.com/mdn/content/pull/44328
