### PR TITLE
FF152 SVGTextPathElement.side

### DIFF
--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -137,6 +137,36 @@
           }
         }
       },
+      "side": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "152"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "spacing": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGTextPathElement/spacing",


### PR DESCRIPTION
FF152 supports the `SVGTextPathElement.side` property in https://bugzilla.mozilla.org/show_bug.cgi?id=2034371

This is non-standard, but agreed to be standardized - see https://github.com/w3c/svgwg/issues/1086

Note it is only supported in Firefox - the corresponding `size` attribute on the SVG `textPath` is only implemented in FF and that is already in BCD.

Related docs work can be tracked in https://github.com/mdn/content/issues/44162