### PR TITLE
Update Firefox data for appearance: base-select

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -120,7 +120,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.appearance-base-select.enabled",
+                    "value_to_set": "true"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -187,7 +194,14 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "149",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.appearance-base-select.enabled",
+                      "value_to_set": "true"
+                    }
+                  ]
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",


### PR DESCRIPTION
### Summary
Update Firefox compatibility data for `appearance: base-select` and the single-dropdown customizable select subfeature.

### Details
Firefox bug 1974787 was fixed for Firefox 149 and added `appearance: base-select` behind `layout.css.appearance-base-select.enabled`. This updates the general `base-select` value and the single-dropdown subfeature with the corresponding preference flag.

I left the listbox and multiple-dropdown subfeatures unchanged because the Firefox bug documents the customizable `<select>` value, but does not establish those separate subfeatures.

### Tests
- `npm run lint -- css/properties/appearance.json`
- `prettier --check css/properties/appearance.json`
- `node -e "JSON.parse(require('fs').readFileSync('css/properties/appearance.json','utf8')); console.log('valid json')"`
- `git diff --check`

### Related
- https://bugzilla.mozilla.org/show_bug.cgi?id=1974787
- mdn/content#44299