### PR TITLE
Chrome fixed Lazy Loading media in Chrome 150

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -1509,11 +1509,17 @@
             "web-features:loading-lazy-media"
           ],
           "support": {
-            "chrome": {
-              "version_added": "148",
-              "partial_implementation": true,
-              "notes": "Not supported for `<source>`. See [bug 514611050](https://crbug.com/514611050)."
-            },
+            "chrome": [
+              {
+                "version_added": "150"
+              },
+              {
+                "version_added": "148",
+                "version_removed": "150",
+                "partial_implementation": true,
+                "notes": "Not supported for `<source>`. See [bug 514611050](https://crbug.com/514611050)."
+              }
+            ],
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/html/elements/audio.json
+++ b/html/elements/audio.json
@@ -267,11 +267,17 @@
               "web-features:loading-lazy-media"
             ],
             "support": {
-              "chrome": {
-                "version_added": "148",
-                "partial_implementation": true,
-                "notes": "Not supported for `<source>`. See [bug 514611050](https://crbug.com/514611050)."
-              },
+              "chrome": [
+                {
+                  "version_added": "150"
+                },
+                {
+                  "version_added": "148",
+                  "version_removed": "150",
+                  "partial_implementation": true,
+                  "notes": "Not supported for `<source>`. See [bug 514611050](https://crbug.com/514611050)."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {

--- a/html/elements/video.json
+++ b/html/elements/video.json
@@ -425,11 +425,17 @@
               "web-features:loading-lazy-media"
             ],
             "support": {
-              "chrome": {
-                "version_added": "148",
-                "partial_implementation": true,
-                "notes": "Not supported for `<source>`. See [bug 514611050](https://crbug.com/514611050)."
-              },
+              "chrome": [
+                {
+                  "version_added": "150"
+                },
+                {
+                  "version_added": "148",
+                  "version_removed": "150",
+                  "partial_implementation": true,
+                  "notes": "Not supported for `<source>`. See [bug 514611050](https://crbug.com/514611050)."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Bug identified in #29764 was fixed for Chrome 150

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://es-d-18068567920260521-019e4001-931d-7b68-9d65-a44ce3999306.codepen.dev/

Note no video media element loaded in the intial page load

<img width="1624" height="976" alt="image" src="https://github.com/user-attachments/assets/4e449c78-cd7b-48bd-9374-07b973d22b35" />


<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Bug:https://issues.chromium.org/issues/514611050

Fix: https://chromium-review.git.corp.google.com/c/chromium/src/+/7858311

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
