### PR TITLE
Update Firefox support for Crash Reporting API

### DIFF
--- a/api/CrashReportContext.json
+++ b/api/CrashReportContext.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -48,7 +48,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -118,7 +118,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -1075,7 +1075,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
## Problem

Firefox 152 enables the Crash Reporting API in Nightly builds via `dom.reporting.crash.enabled`, but BCD still listed the CrashReportContext storage APIs as unsupported in Firefox.

## Root cause

The Gecko change only flips the Crash Reporting API preference for Nightly builds, so the existing Chromium-only data needed Firefox support entries behind that preference.

## Solution

Update Firefox support for:

- `api.CrashReportContext`
- `api.CrashReportContext.delete`
- `api.CrashReportContext.initialize`
- `api.CrashReportContext.set`
- `api.Window.crashReport`

Each entry is marked as added in Firefox 152 behind `dom.reporting.crash.enabled`.

## Tests

- `npx --yes npm@11.12.1 --prefix C:\Users\kirti\Documents\PRs\browser-compat-data run lint -- api/CrashReportContext.json api/Window.json`
- `C:\Users\kirti\Documents\PRs\browser-compat-data\node_modules\.bin\prettier.cmd --check C:\Users\kirti\Documents\PRs\browser-compat-data\api\CrashReportContext.json C:\Users\kirti\Documents\PRs\browser-compat-data\api\Window.json`
- `node -e "const fs=require('fs'); for (const f of ['C:/Users/kirti/Documents/PRs/browser-compat-data/api/CrashReportContext.json','C:/Users/kirti/Documents/PRs/browser-compat-data/api/Window.json']) JSON.parse(fs.readFileSync(f,'utf8')); console.log('JSON OK')"`
- `git diff --check`

## References

- mdn/content#44297
- [Firefox bug 2036160](https://bugzil.la/2036160)