### PR TITLE
fix(api/ResizeObserverEntry): mark Firefox 93-107 devicePixelContentBoxSize as partial

### DIFF
--- a/api/ResizeObserverEntry.json
+++ b/api/ResizeObserverEntry.json
@@ -168,9 +168,17 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "93"
-            },
+            "firefox": [
+              {
+                "version_added": "108"
+              },
+              {
+                "version_added": "93",
+                "version_removed": "108",
+                "partial_implementation": true,
+                "notes": "Returned incorrect values due to a subpixel snapping bug. See <a href='https://bugzil.la/1774135'>bug 1774135</a> and <a href='https://bugzil.la/1792285'>bug 1792285</a>."
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
Fixes #16769

Firefox 93 added devicePixelContentBoxSize but returned incorrect values due to a subpixel snapping bug. It approximated the device pixel size rather than reading the actual pixel-snapped value from the layout engine, making the API functionally useless for its primary use case.

Two bugs tracked the complete fix:
- Bug 1774135 (https://bugzil.la/1774135): Fixed in Firefox 104
- Bug 1792285 (https://bugzil.la/1792285): Canvas-specific follow-up, fixed in Firefox 108

This PR updates the Firefox entry to reflect the correct history:
- 93-107: partial_implementation: true with notes linking to both bugs
- 108+: full support

The structure mirrors the existing pattern for borderBoxSize and contentBoxSize in the same file.

Per queengooborg's comment in the issue which already specified the exact structure needed.