### PR TITLE
Add partial and note to CSSPseudoElement

### DIFF
--- a/api/CSSPseudoElement.json
+++ b/api/CSSPseudoElement.json
@@ -9,7 +9,9 @@
         ],
         "support": {
           "chrome": {
-            "version_added": "149"
+            "version_added": "149",
+            "partial_implementation": true,
+            "notes": "Doesn't inherit from `EventTarget`."
           },
           "chrome_android": "mirror",
           "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 149 adds support for the `CSSPseudoElement` interface and `Element.pseudo()` method; see https://chromestatus.com/feature/5194399398756352.

This PR adds `"partial_implementation": true` to the main interface, with a note to say that it doesn't inherit from `EventTarget`, like the spec says it should. I've tested it.

I also wanted to bring up that, in my local MDN, the BCD support tables for this interface are generated, but the spec tables are not. This doesn't make sense, as the `spec_url` fields are included.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
