### PR TITLE
Add overlap-join value to gap decoration properties

### DIFF
--- a/css/properties/column-rule-inset-cap-end.json
+++ b/css/properties/column-rule-inset-cap-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-cap-start.json
+++ b/css/properties/column-rule-inset-cap-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-cap.json
+++ b/css/properties/column-rule-inset-cap.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-end.json
+++ b/css/properties/column-rule-inset-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-junction-end.json
+++ b/css/properties/column-rule-inset-junction-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-junction-start.json
+++ b/css/properties/column-rule-inset-junction-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-junction.json
+++ b/css/properties/column-rule-inset-junction.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset-start.json
+++ b/css/properties/column-rule-inset-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/column-rule-inset.json
+++ b/css/properties/column-rule-inset.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-cap-end.json
+++ b/css/properties/row-rule-inset-cap-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-cap-start.json
+++ b/css/properties/row-rule-inset-cap-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-cap.json
+++ b/css/properties/row-rule-inset-cap.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-end.json
+++ b/css/properties/row-rule-inset-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-junction-end.json
+++ b/css/properties/row-rule-inset-junction-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-junction-start.json
+++ b/css/properties/row-rule-inset-junction-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-junction.json
+++ b/css/properties/row-rule-inset-junction.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset-start.json
+++ b/css/properties/row-rule-inset-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/row-rule-inset.json
+++ b/css/properties/row-rule-inset.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/rule-inset-cap.json
+++ b/css/properties/rule-inset-cap.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/rule-inset-end.json
+++ b/css/properties/rule-inset-end.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/rule-inset-junction.json
+++ b/css/properties/rule-inset-junction.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/rule-inset-start.json
+++ b/css/properties/rule-inset-start.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/rule-inset.json
+++ b/css/properties/rule-inset.json
@@ -30,6 +30,37 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "overlap-join": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-gaps-1/#valdef-inset-value-overlap-join",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
#### Summary

The latest spec for CSS gap decoration contains an additional value "overlap-join" which Chromium ships as well.

#### Test results and supporting details

Collector run in Chrome 149 release.

#### Related issues

Followup to https://github.com/mdn/browser-compat-data/pull/29624