### PR TITLE
Updates for Chrome 150 beta

### DIFF
--- a/api/CSSContainerRule.json
+++ b/api/CSSContainerRule.json
@@ -40,7 +40,7 @@
           "spec_url": "https://drafts.csswg.org/css-conditional-5/#dom-csscontainerrule-conditions",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "150"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -60,7 +60,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1491,6 +1491,37 @@
           }
         }
       },
+      "isReloadNavigation": {
+        "__compat": {
+          "spec_url": "https://fetch.spec.whatwg.org/#dom-request-isreloadnavigation",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "json": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Request/json",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -146,7 +146,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-sanitizer-allowprocessinginstruction",
           "support": {
             "chrome": {
-              "version_added": "149"
+              "version_added": "150"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -282,7 +282,7 @@
           "spec_url": "https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-sanitizer-removeprocessinginstruction",
           "support": {
             "chrome": {
-              "version_added": "149"
+              "version_added": "150"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/background-clip.json
+++ b/css/properties/background-clip.json
@@ -113,7 +113,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "150"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/background.json
+++ b/css/properties/background.json
@@ -228,6 +228,37 @@
             }
           }
         },
+        "border-area": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-backgrounds-4/#valdef-background-clip-border-area",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "border-box": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-box-4/#valdef-box-border-box",

--- a/css/properties/flex-flow.json
+++ b/css/properties/flex-flow.json
@@ -74,6 +74,37 @@
             "deprecated": false
           }
         },
+        "balance": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-flexbox-2/#valdef-flex-wrap-balance",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "column": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-flexbox-1/#valdef-flex-direction-column",

--- a/css/properties/flex-line-count.json
+++ b/css/properties/flex-line-count.json
@@ -1,0 +1,37 @@
+{
+  "css": {
+    "properties": {
+      "flex-line-count": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-flexbox-2/#flex-line-count-property",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/flex-wrap.json
+++ b/css/properties/flex-wrap.json
@@ -54,6 +54,37 @@
             "deprecated": false
           }
         },
+        "balance": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-flexbox-2/#valdef-flex-wrap-balance",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "nowrap": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-flexbox/#valdef-flex-wrap-nowrap",

--- a/css/properties/overscroll-behavior-block.json
+++ b/css/properties/overscroll-behavior-block.json
@@ -88,6 +88,37 @@
             }
           }
         },
+        "chain": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-chain",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "contain": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-contain",

--- a/css/properties/overscroll-behavior-inline.json
+++ b/css/properties/overscroll-behavior-inline.json
@@ -88,6 +88,37 @@
             }
           }
         },
+        "chain": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-chain",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "contain": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-contain",

--- a/css/properties/overscroll-behavior-x.json
+++ b/css/properties/overscroll-behavior-x.json
@@ -92,6 +92,37 @@
             }
           }
         },
+        "chain": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-chain",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "contain": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-contain",

--- a/css/properties/overscroll-behavior-y.json
+++ b/css/properties/overscroll-behavior-y.json
@@ -92,6 +92,37 @@
             }
           }
         },
+        "chain": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-chain",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "contain": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-contain",

--- a/css/properties/overscroll-behavior.json
+++ b/css/properties/overscroll-behavior.json
@@ -90,6 +90,37 @@
             }
           }
         },
+        "chain": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-chain",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "contain": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overscroll/#valdef-overscroll-behavior-contain",

--- a/css/properties/text-fit.json
+++ b/css/properties/text-fit.json
@@ -1,0 +1,130 @@
+{
+  "css": {
+    "properties": {
+      "text-fit": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-text-4/#text-fit-property",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "grow": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-fit-grow",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-fit-none",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "shrink": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-text-fit-shrink",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.17.14) found new features shipping in Chromium 150 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Canary/behind origin trials/enrollment/isolated contexts, it is not considered here.

With this PR, BCD will consider the following 26 features as shipping in Chromium 150 (**bold** features are new keys in BCD).

- api.CSSContainerRule.conditions ([ref](https://chromestatus.com/feature/6196591858941952))
- **api.Request.isReloadNavigation ([ref](https://chromestatus.com/feature/5154214529597440))**
- api.Sanitizer.allowProcessingInstruction (from 149 to 150) ([ref](https://chromestatus.com/feature/6534495085920256))
- api.Sanitizer.removeProcessingInstruction (from 149 to 150) ([ref](https://chromestatus.com/feature/6534495085920256))
- css.properties.background-clip.border-area ([ref](https://chromestatus.com/feature/6234471210811392))
- **css.properties.background.border-area ([ref](https://chromestatus.com/feature/6234471210811392))**
- **css.properties.flex-flow.balance ([ref](https://chromestatus.com/feature/4547107962486784))**
- **css.properties.flex-line-count ([ref](https://chromestatus.com/feature/4547107962486784))**
- **css.properties.flex-wrap.balance ([ref](https://chromestatus.com/feature/4547107962486784))**
- **css.properties.overscroll-behavior-block.chain ([ref](https://chromestatus.com/feature/5176802466201600))**
- **css.properties.overscroll-behavior-inline.chain ([ref](https://chromestatus.com/feature/5176802466201600))**
- **css.properties.overscroll-behavior-x.chain ([ref](https://chromestatus.com/feature/5176802466201600))**
- **css.properties.overscroll-behavior-y.chain ([ref](https://chromestatus.com/feature/5176802466201600))**
- **css.properties.overscroll-behavior.chain ([ref](https://chromestatus.com/feature/5176802466201600))**
- **css.properties.text-fit ([ref](https://chromestatus.com/feature/5104141688635392))**
- **css.properties.text-fit.grow ([ref](https://chromestatus.com/feature/5104141688635392))**
- **css.properties.text-fit.none ([ref](https://chromestatus.com/feature/5104141688635392))**
- **css.properties.text-fit.shrink ([ref](https://chromestatus.com/feature/5104141688635392))**

Updated in different PRs:
- api.HTMLMediaElement.loading
- api.SpeechRecognition.available_static.options_parameter.options_quality_parameter
- api.SpeechRecognition.install_static.options_parameter.options_quality_parameter
- css.types.url.cross-origin
- css.types.url.integrity
- css.types.url.referrer-policy
- html.elements.audio.loading
- html.elements.video.loading

See also https://developer.chrome.com/blog/chrome-150-beta