### PR TITLE
Bug 2044712 Add contextualIdentities.getSupportedColors and contextulIdentities.getSupportedIcons for Firefox 153

### DIFF
--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -239,6 +239,52 @@
             }
           }
         },
+        "getSupportedColors": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "Until Firefox for Android 137 `contextualIdentities` is defined but not functional. From Firefox for Android 138 `contextualIdentities` is inaccessible."
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getSupportedIcons": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1638878",
+                "notes": "Until Firefox for Android 137 `contextualIdentities` is defined but not functional. From Firefox for Android 138 `contextualIdentities` is inaccessible."
+              },
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "move": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/contextualIdentities/move",

--- a/webextensions/api/contextualIdentities.json
+++ b/webextensions/api/contextualIdentities.json
@@ -251,8 +251,7 @@
               },
               "firefox_android": {
                 "version_added": false,
-                "impl_url": "https://bugzil.la/1638878",
-                "notes": "Until Firefox for Android 137 `contextualIdentities` is defined but not functional. From Firefox for Android 138 `contextualIdentities` is inaccessible."
+                "impl_url": "https://bugzil.la/1638878"
               },
               "opera": "mirror",
               "safari": {
@@ -274,8 +273,7 @@
               },
               "firefox_android": {
                 "version_added": false,
-                "impl_url": "https://bugzil.la/1638878",
-                "notes": "Until Firefox for Android 137 `contextualIdentities` is defined but not functional. From Firefox for Android 138 `contextualIdentities` is inaccessible."
+                "impl_url": "https://bugzil.la/1638878"
               },
               "opera": "mirror",
               "safari": {


### PR DESCRIPTION
#### Summary

Adds compatibility data for two `contextualIdentities` methods shipped in Firefox 153 ([bug 2044712](https://bugzil.la/2044712)):

- `getSupportedColors`
- `getSupportedIcons`

#### Related issues

Related MDN changes in PR TBC.
