### PR TITLE
Bug 1315558 webExtensions Public Suffix API

### DIFF
--- a/webextensions/api/publicSuffix.json
+++ b/webextensions/api/publicSuffix.json
@@ -1,0 +1,102 @@
+{
+  "webextensions": {
+    "api": {
+      "publicSuffix": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": false,
+              "impl_url": "https://crbug.com/40740063"
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "153"
+            },
+            "firefox_android": "mirror",
+            "opera": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror"
+          }
+        },
+        "DomainEncoding": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getDomain": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "getKnownSuffix": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
+        "isKnownSuffix": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -654,6 +654,27 @@
             }
           }
         },
+        "publicSuffix": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false,
+                "impl_url": "https://crbug.com/40740063"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153",
+                "notes": "This permission is granted silently, without a user prompt."
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror"
+            }
+          }
+        },
         "scripting": {
           "__compat": {
             "support": {

--- a/webextensions/manifest/optional_permissions.json
+++ b/webextensions/manifest/optional_permissions.json
@@ -663,8 +663,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "153",
-                "notes": "This permission is granted silently, without a user prompt."
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Addresses the dev-docs-needed requirements for [Bug 1315558](https://bugzilla.mozilla.org/show_bug.cgi?id=1315558) "tld service for webextensions", the implementation of the [Public Suffix API](https://github.com/w3c/webextensions/blob/main/proposals/public-suffix.md).

#### Related issues

Related MDN documentation added in PR TBC.
