### PR TITLE
added firefox support for appearance: base-select

### DIFF
--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -120,7 +120,20 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "dom.select.customizable_select.enabled",
+                    "value_to_set": "true"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "layout.css.appearance-base.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1974787"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/appearance.json
+++ b/css/properties/appearance.json
@@ -120,7 +120,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview",
+                "version_added": "149",
                 "flags": [
                   {
                     "type": "preference",
@@ -200,7 +200,20 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "149",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.select.customizable_select.enabled",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "layout.css.appearance-base.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1974787"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -234,7 +247,20 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "149",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "dom.select.customizable_select.enabled",
+                      "value_to_set": "true"
+                    },
+                    {
+                      "type": "preference",
+                      "name": "layout.css.appearance-base.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1974787"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Added Firefox support for `base-select` value for `appearance` CSS property
  - Added support for `<select multiple>`
  - Added support for `<select>`

#### Test results and supporting details

- Tested with the flags:
  - `dom.select.customizable_select.enabled`
  - `layout.css.appearance-base.enabled`
- Worked in:
  - Firefox Beta 152
  - Firefox Dev Edition 152
  - Firefox Nightly 152

#### Related issues

- [FF Release PR](https://github.com/mdn/content/pull/44427)