### PR TITLE
added firefox support for Named timeline range keyframe selectors

### DIFF
--- a/css/at-rules/keyframes.json
+++ b/css/at-rules/keyframes.json
@@ -154,8 +154,15 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1676779"
+                "version_added": "152",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.scroll-driven-animations.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1824875"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Added firefox support for `<timeline-range-name>` in `@keyframes` selectors

#### Test results and supporting details

- Tested with [this codepen](https://codepen.io/CodeRedDigital/pen/azpmMar)
  - Firefox Nightly 153 (no flag)
  - Firefox Dev Edition 152 `layout.css.scroll-driven-animations.enabled`
  - Firefox Beta 152 `layout.css.scroll-driven-animations.enabled`
  - Firefox 151 `layout.css.scroll-driven-animations.enabled` - does not work

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/44456)