### PR TITLE
Fx152: Update supported release for JPEG XL

### DIFF
--- a/mediatypes/image/jxl.json
+++ b/mediatypes/image/jxl.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
+              "version_added": "152",
               "flags": [
                 {
                   "type": "preference",


### PR DESCRIPTION
#### Summary

JPEG XL is available behind a preference in Fx152 beta and release (enabled by default in Nightly).

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=2016688

#### Related issues

Doc issue: https://github.com/mdn/content/issues/44418
Experimental release note update: https://github.com/mdn/content/pull/44476
