### PR TITLE
 Bug 1891478 Implement documentId in extension APIs

### DIFF
--- a/webextensions/api/proxy.json
+++ b/webextensions/api/proxy.json
@@ -464,6 +464,44 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "documentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "153"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "parentDocumentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "153"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "settings": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -57,7 +57,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -507,6 +507,48 @@
                 "version_added": "15"
               }
             }
+          },
+          "connectInfo": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "26"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": {
+                  "version_added": "48"
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "14"
+                },
+                "safari_ios": {
+                  "version_added": "15"
+                }
+              }
+            },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            }
           }
         },
         "connectNative": {
@@ -599,6 +641,44 @@
               "safari": {
                 "version_added": false,
                 "impl_url": "https://webkit.org/b/294456"
+              },
+              "safari_ios": "mirror"
+            }
+          },
+          "documentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "116"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "153"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          }
+        },
+        "getDocumentId": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "opera": "mirror",
+              "safari": {
+                "version_added": false
               },
               "safari_ios": "mirror"
             }
@@ -1380,6 +1460,25 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
+              }
+            },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
               }
             },
             "includeTlsChannelId": {

--- a/webextensions/api/runtime.json
+++ b/webextensions/api/runtime.json
@@ -507,48 +507,6 @@
                 "version_added": "15"
               }
             }
-          },
-          "connectInfo": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": "26"
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "45"
-                },
-                "firefox_android": {
-                  "version_added": "48"
-                },
-                "opera": "mirror",
-                "safari": {
-                  "version_added": "14"
-                },
-                "safari_ios": {
-                  "version_added": "15"
-                }
-              }
-            },
-            "documentId": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "153"
-                  },
-                  "firefox_android": "mirror",
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
-              }
-            }
           }
         },
         "connectNative": {
@@ -678,7 +636,7 @@
               "firefox_android": "mirror",
               "opera": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "27"
               },
               "safari_ios": "mirror"
             }
@@ -1460,25 +1418,6 @@
                   "version_added": false
                 },
                 "safari_ios": "mirror"
-              }
-            },
-            "documentId": {
-              "__compat": {
-                "support": {
-                  "chrome": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": "153"
-                  },
-                  "firefox_android": "mirror",
-                  "opera": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror"
-                }
               }
             },
             "includeTlsChannelId": {

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -99,25 +99,6 @@
               "safari_ios": "mirror"
             }
           },
-          "documentId": {
-            "__compat": {
-              "support": {
-                "chrome": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": "153"
-                },
-                "firefox_android": "mirror",
-                "opera": "mirror",
-                "safari": {
-                  "version_added": "18.4"
-                },
-                "safari_ios": "mirror"
-              }
-            }
-          },
           "documentIds": {
             "__compat": {
               "support": {
@@ -126,7 +107,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -98,6 +98,44 @@
               },
               "safari_ios": "mirror"
             }
+          },
+          "documentId": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "153"
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
+          "documentIds": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": "106"
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "opera": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror"
+              }
+            }
           }
         },
         "RegisteredContentScript": {
@@ -236,6 +274,25 @@
                   "version_added": "17"
                 },
                 "safari_ios": "mirror"
+              }
+            },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
               }
             },
             "error": {

--- a/webextensions/api/tabs.json
+++ b/webextensions/api/tabs.json
@@ -1638,6 +1638,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "frameId": {
               "__compat": {
                 "support": {
@@ -4255,6 +4274,25 @@
                 },
                 "safari_ios": {
                   "version_added": "15"
+                }
+              }
+            },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
                 }
               }
             },

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -328,8 +328,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -386,7 +385,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -429,8 +428,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -487,7 +485,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -579,7 +577,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -633,8 +631,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -691,7 +688,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -804,8 +801,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -862,7 +858,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1007,8 +1003,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1065,7 +1060,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1140,8 +1135,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1219,7 +1213,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1281,8 +1275,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",
@@ -1448,8 +1441,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1891478"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -1332,7 +1332,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/webNavigation.json
+++ b/webextensions/api/webNavigation.json
@@ -1498,7 +1498,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "opera": "mirror",

--- a/webextensions/api/webRequest.json
+++ b/webextensions/api/webRequest.json
@@ -1617,6 +1617,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -1740,6 +1759,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -2140,6 +2178,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -2294,6 +2351,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -2703,6 +2779,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -2826,6 +2921,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -3156,6 +3270,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -3279,6 +3412,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -3607,6 +3759,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -3761,6 +3932,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -4125,6 +4315,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -4304,6 +4513,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -4619,6 +4847,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -4786,6 +5033,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -5166,6 +5432,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -5318,6 +5603,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }
@@ -5696,6 +6000,25 @@
                 }
               }
             },
+            "documentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
             "documentUrl": {
               "__compat": {
                 "support": {
@@ -5800,6 +6123,25 @@
                   "opera": "mirror",
                   "safari": {
                     "version_added": false
+                  },
+                  "safari_ios": "mirror"
+                }
+              }
+            },
+            "parentDocumentId": {
+              "__compat": {
+                "support": {
+                  "chrome": {
+                    "version_added": "106"
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": "153"
+                  },
+                  "firefox_android": "mirror",
+                  "opera": "mirror",
+                  "safari": {
+                    "version_added": "18.4"
                   },
                   "safari_ios": "mirror"
                 }


### PR DESCRIPTION
#### Summary

This change addresses the dev-doc-needed requirements of [Bug 1891478](https://bugzilla.mozilla.org/show_bug.cgi?id=1891478) "Implement documentId in extension APIs"

In addition, it includes details of:

- support in Chrome, derived from the Chrome API docs
- support in Safari as identified from the 18.4 release note

No chromium issues were identified for the implementation of features not supported in Chrome.

#### Related issues

Related MDN document changes in https://github.com/mdn/content/pull/44491
