### PR TITLE
FF153 RTCTransportStats 

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -4127,7 +4127,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -7819,7 +7819,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -4539,10 +4539,16 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "alternative_name": "transport",
-                "version_added": "31"
-              },
+              "firefox": [
+                {
+                  "version_added": "65"
+                },
+                {
+                  "alternative_name": "transport",
+                  "version_added": "31",
+                  "version_removed": "65"
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -8421,7 +8421,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -8528,7 +8528,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8564,7 +8564,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8579,7 +8579,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -8600,7 +8600,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8636,7 +8636,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8651,7 +8651,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -8672,7 +8672,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8687,7 +8687,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -8708,7 +8708,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8723,7 +8723,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -8744,7 +8744,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8960,7 +8960,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8996,7 +8996,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -9032,7 +9032,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -9068,7 +9068,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -9104,7 +9104,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -6589,7 +6589,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8355,7 +8355,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF153 added support for a number of [RTCTransportStats](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats) in https://bugzilla.mozilla.org/show_bug.cgi?id=1225723 and https://bugzilla.mozilla.org/show_bug.cgi?id=2019389

These include

- [`RTCTransportStats.id`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/id)
- [`RTCTransportStats.type`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/type)
- [`RTCTransportStats.timestamp`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/timestamp)
- [`RTCTransportStats.iceRole`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/iceRole)
- [`RTCTransportStats.iceLocalUsernameFragment`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/iceLocalUsernameFragment)
- [`RTCTransportStats.dtlsState`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/dtlsState)
- [`RTCTransportStats.iceState`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/iceState)
- [`RTCTransportStats.selectedCandidatePairId`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/selectedCandidatePairId)
- [`RTCTransportStats.dtlsRole`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/dtlsRole)
- [`RTCTransportStats.srtpCipher`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/srtpCipher)
- [`RTCTransportStats.tlsVersion`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/tlsVersion)
- [`RTCTransportStats.dtlsCipher`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/dtlsCipher)

Also fixed  cases of transportId that were enabled as well on other interfaces

Related docs can be tracked in https://github.com/mdn/content/issues/44454