### PR TITLE
Chrome 147 new Local Network Access support

### DIFF
--- a/api/WebSocket.json
+++ b/api/WebSocket.json
@@ -540,6 +540,40 @@
           }
         }
       },
+      "local_network_access": {
+        "__compat": {
+          "description": "Subject to [Local Network Access](https://developer.mozilla.org/docs/Web/Security/Defenses/Local_network_access) restrictions",
+          "spec_url": "https://wicg.github.io/local-network-access/#integration-with-websockets",
+          "support": {
+            "chrome": {
+              "version_added": "147"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "message_event": {
         "__compat": {
           "description": "`message` event",

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -923,6 +923,40 @@
           }
         }
       },
+      "local_network_access": {
+        "__compat": {
+          "description": "Subject to [Local Network Access](https://developer.mozilla.org/docs/Web/Security/Defenses/Local_network_access) restrictions",
+          "spec_url": "https://wicg.github.io/local-network-access/#integration-with-webtransport",
+          "support": {
+            "chrome": {
+              "version_added": "147"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "protocol": {
         "__compat": {
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-protocol",

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -205,7 +205,7 @@
         },
         "local_network_access": {
           "__compat": {
-            "description": "Subject to [Local Network Access](https://developer.mozilla.org/docs/Web/Security/Defenses/Local_network_access) restrictions",
+            "description": "Subject to [Local Network Access](https://developer.mozilla.org/docs/Web/Security/Defenses/Local_network_access) restrictions when the navigated `WindowClient` is a subframe",
             "support": {
               "chrome": {
                 "version_added": "147"

--- a/api/WindowClient.json
+++ b/api/WindowClient.json
@@ -202,6 +202,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "local_network_access": {
+          "__compat": {
+            "description": "Subject to [Local Network Access](https://developer.mozilla.org/docs/Web/Security/Defenses/Local_network_access) restrictions",
+            "support": {
+              "chrome": {
+                "version_added": "147"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "visibilityState": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From Chrome 147, local network requests made by Service Worker `WindowClient.navigate()`, `WebSocket`, and `WebTransport` are subject to control/restriction by the [Local Network Access](https://developer.mozilla.org/en-US/docs/Web/Security/Defenses/Local_network_access) feature.

See:

- https://chromestatus.com/feature/5172375182245888
- https://chromestatus.com/feature/5197681148428288
- https://chromestatus.com/feature/5126430912544768

This PR adds a data point to try to communicate this in each case. I've described it as a restriction, because now resulting requests can't just be made freely — they will result in user permission prompts.

Also note that I've marked the service worker one as non-standard, as SW mentions in the spec are incomplete in general, and `WindowClient.navigate()` isn't mentioned at all.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
