### PR TITLE
Chrome 142 enterPictureInPictureReason parameter in MediaSession.setA…

### DIFF
--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -172,6 +172,123 @@
             "deprecated": false
           }
         },
+        "callback": {
+          "__compat": {
+            "description": "Action handler callback",
+            "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactionhandler-details",
+            "tags": [
+              "web-features:media-session"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "73"
+              },
+              "chrome_android": {
+                "version_added": "57"
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "82"
+              },
+              "firefox_android": {
+                "version_added": "82",
+                "partial_implementation": true,
+                "notes": "Firefox exposes the API, but does not provide a corresponding user-facing media control interface."
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          },
+          "enterPictureInPictureReason": {
+            "__compat": {
+              "description": "`enterPictureInPictureReason` callback parameter",
+              "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactiondetails-enterpictureinpicturereason",
+              "tags": [
+                "web-features:media-session"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "142"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": {
+                  "version_added": false
+                },
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          }
+        },
+        "enterpictureinpicture_type": {
+          "__compat": {
+            "description": "`\"enterpictureinpicture\"` type",
+            "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionaction-enterpictureinpicture",
+            "tags": [
+              "web-features:media-session"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": false
+              },
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "hangup_type": {
           "__compat": {
             "description": "`\"hangup\"` type",

--- a/api/MediaSession.json
+++ b/api/MediaSession.json
@@ -216,7 +216,7 @@
           },
           "enterPictureInPictureReason": {
             "__compat": {
-              "description": "`enterPictureInPictureReason` callback parameter",
+              "description": "`enterPictureInPictureReason` callback option",
               "spec_url": "https://w3c.github.io/mediasession/#dom-mediasessionactiondetails-enterpictureinpicturereason",
               "tags": [
                 "web-features:media-session"


### PR DESCRIPTION
…ctionHandler() callback

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 142 adds support for the `enterPictureInPictureReason` property that is included in the [`MediaSession.setActionHandler()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaSession/setActionHandler) callback function's dictionary parameter when the action handler's `type` is `enterpictureinpicture`.

This PR tries to add appropriate data points for this new functionality. Note that I've also included a data point for the `enterpictureinpicture` type, as that was also missing.

See:

- https://chromestatus.com/feature/6415506970116096 for `enterPictureInPictureReason`
- https://chromestatus.com/feature/6245717716238336 for `enterpictureinpicture` action type

I've set Android WebView to `false` for both of these, as basic support for `setActionHandler()` is reported as `false` in most places, but weirdly `true` for `enterPictureInPictureReason`

I'm not so sure about the data structure I've used here, so you'll have to advise on that. I've tried to do something close to what is already there.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
