### PR TITLE
Safari TP now supports light-dark() on images

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -964,7 +964,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/309689"
                 },
                 "safari_ios": "mirror",


### PR DESCRIPTION
https://webkit.org/blog/18128/release-notes-for-safari-technology-preview-246/

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
