### PR TITLE
Chrome 150 scroll methods return promises

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -9347,6 +9347,38 @@
               "deprecated": false
             }
           }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scroll",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "scroll_event": {
@@ -9531,6 +9563,38 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollby",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -9850,6 +9914,38 @@
                 "standard_track": true,
                 "deprecated": false
               }
+            }
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollintoview",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
             }
           }
         }
@@ -10186,6 +10282,38 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-element-scrollto",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/api/Window.json
+++ b/api/Window.json
@@ -5883,6 +5883,38 @@
               "deprecated": false
             }
           }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-window-scroll",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "scrollbars": {
@@ -6087,6 +6119,38 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-window-scrollby",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }
@@ -6465,6 +6529,38 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "returns_promise": {
+          "__compat": {
+            "description": "Returns a `Promise`",
+            "spec_url": "https://drafts.csswg.org/cssom-view/#dom-window-scrollto",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In Chrome 150 onwards, the standard `Element` and `Window` scroll methods now return promises. See https://chromestatus.com/feature/5082138340491264. This is particularly useful when a scroll operation is not instantaneous (e.g. you've got `scroll-behavior: smooth;` set on the scrolling container), and you want to programmatically react to the scroll operation finishing, for example, by updating the UI.

Affected methods are:

- `Element.scroll()`
- `Element.scrollBy()`
- `Element.scrollIntoView()`
- `Element.scrollTo()`
- `Window.scroll()`
- `Window.scrollBy()`
- `Window.scrollTo()`

My tests revealed that only the standard methods return a promise. Non-standard methods (`Element.scrollIntoViewIfNeeded()`, `Window.scrollByLines()`, `Window.scrollByPages()`) do not, at least not yet.

This PR adds a new data point for each method.

One issue is that the spec says the promises fulfill with `undefined`, whereas Chrome's current behavior is for the promises to fulfill with an object containing a single boolean property, `interrupted`, which indicates whether the scrolling operation was interrupted or not. I'm going to contact the relevant Chrome engineer to ask what the deal is here.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
