### PR TITLE
Chrome 145 supports JPEG XL behind a flag

### DIFF
--- a/mediatypes/image/jxl.json
+++ b/mediatypes/image/jxl.json
@@ -9,11 +9,21 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "notes": "Implemented behind a flag in Chrome 91, but removed in Chrome 110. See [bug 40168998](https://crbug.com/40168998#comment85)."
+              "version_added": "145",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-jxl-image-format",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Earlier flag support was added in Chrome 91 and removed in Chrome 110. See [bug 40168998](https://crbug.com/40168998#comment85)."
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "edge": {
+              "version_added": false,
+              "notes": "Earlier flag support was added in Edge 91 and removed in Edge 110."
+            },
             "firefox": {
               "version_added": "152",
               "flags": [
@@ -25,7 +35,10 @@
               ]
             },
             "firefox_android": "mirror",
-            "opera": "mirror",
+            "opera": {
+              "version_added": false,
+              "notes": "Earlier flag support was added in Opera 77 and removed in Opera 96."
+            },
             "opera_android": "mirror",
             "safari": {
               "version_added": "17",


### PR DESCRIPTION
## Summary

Update JPEG XL (`image/jxl`) support data for Chrome.

Chrome 145 added JPEG XL decoding support behind the `#enable-jxl-image-format` Chrome flag. Chrome Android mirrors this support. Edge and Opera are not mirrored from Chrome for this change because their known JPEG XL support was from the earlier Chromium implementation, which was removed in Edge 110 / Opera 96.

## Details

* Set Chrome support to `version_added: "145"` with the `#enable-jxl-image-format` flag.
* Keep Chrome Android as `mirror`.
* Mark Edge and Opera as unsupported, with notes for their earlier removed flag support.

## References

* https://developer.chrome.com/release-notes/145#jpeg_xl_decoding_support_imagejxl_in_blink
* https://chromestatus.com/feature/5188299478007808
* https://chromestatus.com/feature/5114042131808256
* https://issues.chromium.org/issues/40168998
* https://caniuse.com/jpegxl