### PR TITLE
Updates for Firefox 153 beta

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4073,7 +4073,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -6448,7 +6450,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -6487,7 +6491,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -4071,8 +4071,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -6447,8 +6446,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -6487,8 +6485,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/HTMLAreaElement.json
+++ b/api/HTMLAreaElement.json
@@ -367,6 +367,37 @@
           }
         }
       },
+      "hreflang": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/links.html#dom-a-hreflang",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "153"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "interestForElement": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLAreaElement/interestForElement",
@@ -1069,6 +1100,37 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "type": {
+        "__compat": {
+          "spec_url": "https://html.spec.whatwg.org/multipage/links.html#dom-a-type",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "153"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -155,7 +155,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -290,7 +292,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -589,7 +593,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/HTMLVideoElement.json
+++ b/api/HTMLVideoElement.json
@@ -153,8 +153,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -289,8 +288,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -589,8 +587,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -395,7 +395,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -410,7 +410,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -680,7 +680,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -695,7 +695,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/IDBRecord.json
+++ b/api/IDBRecord.json
@@ -10,7 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "153"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -25,7 +25,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -40,7 +40,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -55,7 +55,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -71,7 +71,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -86,7 +86,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -102,7 +102,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -117,7 +117,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -23,8 +23,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1463402"
+            "version_added": "153"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -76,8 +75,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -122,8 +120,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/PictureInPictureEvent.json
+++ b/api/PictureInPictureEvent.json
@@ -25,7 +25,9 @@
           "firefox": {
             "version_added": "153"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -77,7 +79,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -122,7 +126,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -18,7 +18,9 @@
           "firefox": {
             "version_added": "153"
           },
-          "firefox_android": "mirror",
+          "firefox_android": {
+            "version_added": false
+          },
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",
@@ -56,7 +58,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -99,7 +103,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
@@ -138,7 +144,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/PictureInPictureWindow.json
+++ b/api/PictureInPictureWindow.json
@@ -16,8 +16,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1463402"
+            "version_added": "153"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -55,8 +54,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -99,8 +97,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -139,8 +136,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -93,7 +93,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -651,8 +651,7 @@
             },
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -653,7 +653,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/css/properties/alignment-baseline.json
+++ b/css/properties/alignment-baseline.json
@@ -51,7 +51,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -119,7 +119,38 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5.1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hanging": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-hanging",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -153,7 +184,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -187,7 +218,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/vertical-align.json
+++ b/css/properties/vertical-align.json
@@ -42,6 +42,37 @@
             "deprecated": false
           }
         },
+        "alphabetic": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-alphabetic",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "baseline": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline/#valdef-alignment-baseline-baseline",
@@ -151,6 +182,37 @@
             }
           }
         },
+        "central": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-central",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "first": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-source-first",
@@ -182,6 +244,68 @@
             }
           }
         },
+        "hanging": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-hanging",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "ideographic": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-ideographic",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "last": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline/#valdef-baseline-source-last",
@@ -193,6 +317,37 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "149"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "mathematical": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-inline/#valdef-dominant-baseline-mathematical",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -18,7 +18,9 @@
             "firefox": {
               "version_added": "153"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": false
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/css/selectors/picture-in-picture.json
+++ b/css/selectors/picture-in-picture.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1463402"
+              "version_added": "153"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/html/elements/area.json
+++ b/html/elements/area.json
@@ -229,6 +229,37 @@
             }
           }
         },
+        "hreflang": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-hreflang",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "implicit_noopener": {
           "__compat": {
             "description": "`target=\"_blank\"` implies `rel=\"noopener\"` behavior",
@@ -716,6 +747,37 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "type": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-type",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1024,7 +1024,9 @@
                 "firefox": {
                   "version_added": "153"
                 },
-                "firefox_android": "mirror",
+                "firefox_android": {
+                  "version_added": false
+                },
                 "oculus": "mirror",
                 "opera": {
                   "version_added": false

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -1022,8 +1022,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
-                  "impl_url": "https://bugzil.la/1463402"
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -1040,7 +1039,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -701,7 +701,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "nodejs": {

--- a/javascript/builtins/Intl/Locale.json
+++ b/javascript/builtins/Intl/Locale.json
@@ -301,14 +301,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -382,14 +375,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -463,14 +449,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -544,14 +523,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -625,14 +597,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -706,14 +671,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [
@@ -788,14 +746,7 @@
                 ],
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "preview",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.intl_locale_info",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": [

--- a/webassembly/jspi.json
+++ b/webassembly/jspi.json
@@ -16,7 +16,7 @@
           },
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "153"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -31,7 +31,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.19.1) found new features shipping in Firefox 153 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following features as shipping in Firefox 153 (**bold** features are new keys in BCD).

- api.Document.exitPictureInPicture
- api.Document.pictureInPictureElement
- api.Document.pictureInPictureEnabled
- **api.HTMLAreaElement.hreflang**
- **api.HTMLAreaElement.type**
- api.HTMLVideoElement.enterpictureinpicture_event
- api.HTMLVideoElement.leavepictureinpicture_event
- api.HTMLVideoElement.requestPictureInPicture
- api.IDBIndex.getAllRecords
- api.IDBObjectStore.getAllRecords
- api.IDBRecord
- api.IDBRecord.key
- api.IDBRecord.primaryKey
- api.IDBRecord.value
- api.PictureInPictureEvent
- api.PictureInPictureEvent.PictureInPictureEvent
- api.PictureInPictureEvent.pictureInPictureWindow
- api.PictureInPictureWindow
- api.PictureInPictureWindow.height
- api.PictureInPictureWindow.resize_event
- api.PictureInPictureWindow.width
- api.RTCDtlsTransport.getRemoteCertificates
- api.RTCStatsReport.type_inbound-rtp.transportId
- api.RTCStatsReport.type_outbound-rtp.transportId
- api.RTCStatsReport.type_remote-inbound-rtp.transportId
- api.RTCStatsReport.type_remote-outbound-rtp.transportId
- api.RTCStatsReport.type_transport
- api.RTCStatsReport.type_transport.dtlsCipher
- api.RTCStatsReport.type_transport.dtlsRole
- api.RTCStatsReport.type_transport.dtlsState
- api.RTCStatsReport.type_transport.iceLocalUsernameFragment
- api.RTCStatsReport.type_transport.iceRole
- api.RTCStatsReport.type_transport.iceState
- api.RTCStatsReport.type_transport.id
- api.RTCStatsReport.type_transport.selectedCandidatePairId
- api.RTCStatsReport.type_transport.srtpCipher
- api.RTCStatsReport.type_transport.timestamp
- api.RTCStatsReport.type_transport.tlsVersion
- api.RTCStatsReport.type_transport.type
- api.ShadowRoot.pictureInPictureElement
- css.properties.alignment-baseline.alphabetic
- css.properties.alignment-baseline.central
- **css.properties.alignment-baseline.hanging**
- css.properties.alignment-baseline.ideographic
- css.properties.alignment-baseline.mathematical
- **css.properties.vertical-align.alphabetic**
- **css.properties.vertical-align.central**
- **css.properties.vertical-align.hanging**
- **css.properties.vertical-align.ideographic**
- **css.properties.vertical-align.mathematical**
- css.selectors.picture-in-picture
- **html.elements.area.hreflang**
- **html.elements.area.type**
- html.elements.iframe.allow.picture-in-picture
- javascript.builtins.Error.stackTraceLimit
- javascript.builtins.Intl.Locale.getCalendars
- javascript.builtins.Intl.Locale.getCollations
- javascript.builtins.Intl.Locale.getHourCycles
- javascript.builtins.Intl.Locale.getNumberingSystems
- javascript.builtins.Intl.Locale.getTextInfo
- javascript.builtins.Intl.Locale.getTimeZones
- javascript.builtins.Intl.Locale.getWeekInfo
- webassembly.jspi

Updated in different PRs:

- webdriver.bidi.browser.setClientWindowState.height_parameter
- webdriver.bidi.browser.setClientWindowState.width_parameter
- webdriver.bidi.browser.setClientWindowState.x_parameter
- webdriver.bidi.browser.setClientWindowState.y_parameter
- webdriver.bidi.emulation.setLocaleOverride.dedicated_and_shared_workers
- webextensions.api.contextualIdentities.getSupportedColors
- webextensions.api.contextualIdentities.getSupportedIcons
- webextensions.api.extension.isAllowedFileSchemeAccess
- webextensions.api.proxy.onRequest.documentId
- webextensions.api.proxy.onRequest.parentDocumentId
- webextensions.api.publicSuffix
- webextensions.api.publicSuffix.DomainEncoding
- webextensions.api.publicSuffix.getDomain
- webextensions.api.publicSuffix.getKnownSuffix
- webextensions.api.publicSuffix.isKnownSuffix
- webextensions.api.runtime.MessageSender.documentId
- webextensions.api.runtime.getContexts.documentId
- webextensions.api.runtime.getDocumentId
- webextensions.api.scripting.InjectionTarget.documentIds
- webextensions.api.scripting.executeScript.InjectionResult.documentId
- webextensions.api.tabs.connect.connectInfo.documentId
- webextensions.api.tabs.sendMessage.options.documentId
- webextensions.api.userScripts.execute
- webextensions.api.webNavigation.getAllFrames.documentId
- webextensions.api.webNavigation.getAllFrames.parentDocumentId
- webextensions.api.webNavigation.getFrame.documentId
- webextensions.api.webNavigation.getFrame.parentDocumentId
- webextensions.api.webNavigation.onBeforeNavigate.parentDocumentId
- webextensions.api.webNavigation.onCommitted.documentId
- webextensions.api.webNavigation.onCommitted.parentDocumentId
- webextensions.api.webNavigation.onCompleted.documentId
- webextensions.api.webNavigation.onCompleted.parentDocumentId
- webextensions.api.webNavigation.onDOMContentLoaded.documentId
- webextensions.api.webNavigation.onDOMContentLoaded.parentDocumentId
- webextensions.api.webNavigation.onErrorOccurred.documentId
- webextensions.api.webNavigation.onErrorOccurred.parentDocumentId
- webextensions.api.webNavigation.onHistoryStateUpdated.documentId
- webextensions.api.webNavigation.onHistoryStateUpdated.parentDocumentId
- webextensions.api.webNavigation.onReferenceFragmentUpdated.documentId
- webextensions.api.webNavigation.onReferenceFragmentUpdated.parentDocumentId
- webextensions.api.webRequest.onAuthRequired.details.documentId
- webextensions.api.webRequest.onAuthRequired.details.parentDocumentId
- webextensions.api.webRequest.onBeforeRedirect.details.documentId
- webextensions.api.webRequest.onBeforeRedirect.details.parentDocumentId
- webextensions.api.webRequest.onBeforeRequest.details.documentId
- webextensions.api.webRequest.onBeforeRequest.details.parentDocumentId
- webextensions.api.webRequest.onBeforeSendHeaders.details.documentId
- webextensions.api.webRequest.onBeforeSendHeaders.details.parentDocumentId
- webextensions.api.webRequest.onCompleted.details.documentId
- webextensions.api.webRequest.onCompleted.details.parentDocumentId
- webextensions.api.webRequest.onErrorOccurred.details.documentId
- webextensions.api.webRequest.onErrorOccurred.details.parentDocumentId
- webextensions.api.webRequest.onHeadersReceived.details.documentId
- webextensions.api.webRequest.onHeadersReceived.details.parentDocumentId
- webextensions.api.webRequest.onResponseStarted.details.documentId
- webextensions.api.webRequest.onResponseStarted.details.parentDocumentId
- webextensions.api.webRequest.onSendHeaders.details.documentId
- webextensions.api.webRequest.onSendHeaders.details.parentDocumentId
- webextensions.manifest.optional_permissions.publicSuffix

For more Firefox 153 info, see also https://github.com/mdn/mdn/issues/839 and https://www.firefox.com/en-US/firefox/153.0beta/releasenotes/