### PR TITLE
FF153 JavaScript text modules

### DIFF
--- a/api/Request.json
+++ b/api/Request.json
@@ -1221,14 +1221,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "152",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "javascript.options.experimental.import_text",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "153"
               },
               "firefox_android": "mirror",
               "nodejs": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1861,14 +1861,7 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "152",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "javascript.options.experimental.import_text",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "153"
                 },
                 "firefox_android": "mirror",
                 "nodejs": {


### PR DESCRIPTION
FF153 supports JavaScript text modules in https://bugzilla.mozilla.org/show_bug.cgi?id=2039881  (`javascript.options.experimental.import_text` true by default).

This updates that subfeature, and the associated request type.

Related docs can be tracked in https://github.com/mdn/content/issues/44457
