### PR TITLE
FF153 webrtc config option for MediaCapabilities.encode/decodeInfo()

### DIFF
--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -196,14 +196,7 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "152",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "media.mediacapabilities.webrtc.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
+                    "version_added": "153"
                   },
                   "firefox_android": "mirror",
                   "oculus": "mirror",
@@ -384,14 +377,7 @@
                   "chrome_android": "mirror",
                   "edge": "mirror",
                   "firefox": {
-                    "version_added": "152",
-                    "flags": [
-                      {
-                        "type": "preference",
-                        "name": "media.mediacapabilities.webrtc.enabled",
-                        "value_to_set": "true"
-                      }
-                    ]
+                    "version_added": "153"
                   },
                   "firefox_android": "mirror",
                   "oculus": "mirror",

--- a/api/MediaCapabilities.json
+++ b/api/MediaCapabilities.json
@@ -340,6 +340,7 @@
                   "edge": "mirror",
                   "firefox": {
                     "version_added": "63",
+                    "version_removed": "153",
                     "partial_implementation": true,
                     "notes": "The spec name for this option is `webrtc`."
                   },


### PR DESCRIPTION
FF153 supports the "webrtc" option for [`MediaCapabilities.decodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/decodingInfo) and [`MediaCapabilities.encodingInfo()`](https://developer.mozilla.org/en-US/docs/Web/API/MediaCapabilities/encodingInfo) in https://bugzilla.mozilla.org/show_bug.cgi?id=2037610 and https://bugzilla.mozilla.org/show_bug.cgi?id=2032075

This updates the two subfeatures behind the flag `media.mediacapabilities.webrtc.enabled`.

Note, it also removes `transmission` as an option for encoding, which was previously removed behind the same flag in https://hg-edge.mozilla.org/mozilla-central/rev/95e6d0dc0f14 . I don't know if Chrome supports the option still. 

Related docs work can be tracked in https://github.com/mdn/content/issues/44470