### PR TITLE
Updates for Safari TP 246

### DIFF
--- a/api/HTMLDialogElement.json
+++ b/api/HTMLDialogElement.json
@@ -165,8 +165,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/284592"
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBIndex.json
+++ b/api/IDBIndex.json
@@ -402,7 +402,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBObjectStore.json
+++ b/api/IDBObjectStore.json
@@ -687,7 +687,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/IDBRecord.json
+++ b/api/IDBRecord.json
@@ -17,7 +17,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -47,7 +47,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -78,7 +78,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -109,7 +109,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/MediaStreamTrackHandle.json
+++ b/api/MediaStreamTrackHandle.json
@@ -1,0 +1,67 @@
+{
+  "api": {
+    "MediaStreamTrackHandle": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/mediacapture-transform/#mediastreamtrackhandle",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": "preview"
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "MediaStreamTrackHandle": {
+        "__compat": {
+          "description": "`MediaStreamTrackHandle()` constructor",
+          "spec_url": "https://w3c.github.io/mediacapture-transform/#dom-mediastreamtrackhandle-mediastreamtrackhandle",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/Window.json
+++ b/api/Window.json
@@ -4093,7 +4093,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/block-ellipsis.json
+++ b/css/properties/block-ellipsis.json
@@ -1,0 +1,68 @@
+{
+  "css": {
+    "properties": {
+      "block-ellipsis": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-overflow-4/#propdef-block-ellipsis",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-block-ellipsis-auto",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/continue.json
+++ b/css/properties/continue.json
@@ -1,28 +1,24 @@
 {
   "css": {
     "properties": {
-      "font-synthesis-style": {
+      "continue": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/font-synthesis-style",
-          "spec_url": "https://drafts.csswg.org/css-fonts/#font-synthesis-style",
-          "tags": [
-            "web-features:font-synthesis-style"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-overflow-4/#propdef-continue",
           "support": {
             "chrome": {
-              "version_added": "97"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "111"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -30,82 +26,14 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         },
         "auto": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-synthesis-style-auto",
-            "tags": [
-              "web-features:font-synthesis-style"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "97"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "111"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16.4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "none": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-synthesis-style-none",
-            "tags": [
-              "web-features:font-synthesis-style"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "97"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "111"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "16.4"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "oblique-only": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-fonts/#valdef-font-synthesis-style-oblique-only",
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-continue-auto",
             "support": {
               "chrome": {
                 "version_added": false
@@ -113,7 +41,38 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "137"
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "discard": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-continue-discard",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -29,6 +29,9 @@
             "opera_android": "mirror",
             "safari": [
               {
+                "version_added": "preview"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "5"
               },

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -49,6 +49,37 @@
             "deprecated": false
           }
         },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-continue-auto",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-line-clamp-none",
@@ -69,7 +100,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.2"
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/max-lines.json
+++ b/css/properties/max-lines.json
@@ -1,0 +1,68 @@
+{
+  "css": {
+    "properties": {
+      "max-lines": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-overflow-4/#propdef-max-lines",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-max-lines-none",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/dialog.json
+++ b/html/elements/dialog.json
@@ -55,7 +55,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Origin-Agent-Cluster.json
+++ b/http/headers/Origin-Agent-Cluster.json
@@ -19,7 +19,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org project (v10.19.1) found new features shipping in Safari Technical Preview 246 on macOS 27.0 Beta  which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive.

See also the [release notes](https://webkit.org/blog/18128/release-notes-for-safari-technology-preview-246/). (This is the first collector run for Safari TP, therefore features shipped in older TPs can appear.)

This PR marks the following features as "preview" (**bold** are new features in BCD):

- api.HTMLDialogElement.closedBy ([ref](https://github.com/WebKit/WebKit/pull/61941))
- api.IDBIndex.getAllRecords ([ref](https://github.com/WebKit/WebKit/pull/61848))
- api.IDBObjectStore.getAllRecords ([ref](https://github.com/WebKit/WebKit/pull/61848))
- api.IDBRecord ([ref](https://github.com/WebKit/WebKit/pull/61848))
- api.IDBRecord.key ([ref](https://github.com/WebKit/WebKit/pull/61848))
- api.IDBRecord.primaryKey ([ref](https://github.com/WebKit/WebKit/pull/61848))
- api.IDBRecord.value ([ref](https://github.com/WebKit/WebKit/pull/61848))
- **api.MediaStreamTrackHandle** ([ref](https://github.com/WebKit/WebKit/pull/55786))
- **api.MediaStreamTrackHandle.MediaStreamTrackHandle** ([ref](https://github.com/WebKit/WebKit/pull/55786))
- api.Window.originAgentCluster ([ref](https://webkit.org/blog/18128/release-notes-for-safari-technology-preview-246/))
- **css.properties.block-ellipsis**
- **css.properties.block-ellipsis.auto**
- **css.properties.continue**
- **css.properties.continue.auto**
- **css.properties.continue.discard**
- css.properties.font-synthesis-style.oblique-only ([ref](https://github.com/WebKit/WebKit/pull/61727))
- **css.properties.line-clamp.auto**
- css.properties.line-clamp.none
- **css.properties.max-lines**
- **css.properties.max-lines.none**
- html.elements.dialog.closedby ([ref](https://github.com/WebKit/WebKit/pull/61941))
- http.headers.Origin-Agent-Cluster ([ref](https://webkit.org/blog/18128/release-notes-for-safari-technology-preview-246/))
