### PR TITLE
Chrome 149 path-length CSS property

### DIFF
--- a/css/properties/path-length.json
+++ b/css/properties/path-length.json
@@ -1,0 +1,74 @@
+{
+  "css": {
+    "properties": {
+      "path-length": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty",
+          "tags": [
+            "web-features:svg"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/paths.html#PathLengthProperty:~:text=of-,none",
+            "tags": [
+              "web-features:svg"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/path-length.json
+++ b/css/properties/path-length.json
@@ -9,7 +9,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "150"
+              "version_added": "preview"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -42,7 +42,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "150"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/path-length.json
+++ b/css/properties/path-length.json
@@ -9,7 +9,13 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -42,7 +48,13 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 149 adds support for the SVG `path-length` CSS property: see https://chromestatus.com/feature/4861677550043136. This is supported behind the "Experimental web platform features" flag.

This PR adds data for the new property.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
