### PR TITLE
Updates for Firefox Nightly (23-06-2026)

### DIFF
--- a/api/AnimationTimeline.json
+++ b/api/AnimationTimeline.json
@@ -83,7 +83,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -551,7 +551,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -144,7 +144,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1919718"
             },
             "firefox_android": "mirror",

--- a/api/ScrollTimeline.json
+++ b/api/ScrollTimeline.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1676779"
           },
           "firefox_android": "mirror",
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -86,7 +86,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -122,7 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",

--- a/api/ViewTimeline.json
+++ b/api/ViewTimeline.json
@@ -14,7 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
+            "version_added": "preview",
             "impl_url": "https://bugzil.la/1676779"
           },
           "firefox_android": "mirror",
@@ -50,7 +50,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -86,7 +86,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -122,7 +122,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -158,7 +158,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",

--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -134,7 +134,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "notes": "Firefox does not currently support the `auto` value and only accepts values in seconds or milliseconds. It's recommended that _1ms_ is used until `auto` is supported."
               },
               "firefox_android": "mirror",

--- a/css/properties/animation-timeline.json
+++ b/css/properties/animation-timeline.json
@@ -15,14 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "110",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -52,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -83,7 +76,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -119,18 +112,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "110",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-driven-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "notes": [
-                  "Before Firefox 112, zero scroll ranges are treated as 100% instead of 0%. See [bug 1780865](https://bugzil.la/1780865).",
-                  "Supports the deprecated `horizontal` and `vertical` axis values, and not the `x` and `y` values."
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -166,14 +148,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "114",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.scroll-driven-animations.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -176,15 +176,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid-template-masonry-value.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1757446"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -177,15 +177,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "77",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.grid-template-masonry-value.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1757446"
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/link-parameters.json
+++ b/css/properties/link-parameters.json
@@ -1,16 +1,12 @@
 {
   "css": {
     "properties": {
-      "scroll-timeline": {
+      "link-parameters": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/scroll-timeline",
-          "spec_url": "https://drafts.csswg.org/scroll-animations/#scroll-timeline-shorthand",
-          "tags": [
-            "web-features:scroll-driven-animations"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-link-params/#propdef-link-parameters",
           "support": {
             "chrome": {
-              "version_added": "115"
+              "version_added": false
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -22,7 +18,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "26"
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -30,17 +26,17 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": false,
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
         },
         "none": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/scroll-animations/#propdef-scroll-timeline-name:~:text=scroll%2Dtimeline%2Dname-,Value%3A,%5B%20none,-%7C%20%3Cdashed%2Dident",
+            "spec_url": "https://drafts.csswg.org/css-link-params/#valdef-none-none",
             "support": {
               "chrome": {
-                "version_added": "115"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -52,7 +48,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "26"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -60,7 +56,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/scroll-timeline-axis.json
+++ b/css/properties/scroll-timeline-axis.json
@@ -15,19 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "111",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": [
-                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
-                "Supports the deprecated `horizontal` and `vertical` values, and not the `x` and `y` values.",
-                "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -60,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -94,7 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
@@ -129,7 +117,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
@@ -164,7 +152,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",

--- a/css/properties/scroll-timeline-name.json
+++ b/css/properties/scroll-timeline-name.json
@@ -15,18 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "111",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": [
-                "The syntax of the shorthand property uses the fixed order of name and then the axis.",
-                "The `@scroll-timeline` at-rule is replaced with the longhand properties `scroll-timeline-name` and `scroll-timeline-axis` and the shorthand property `scroll-timeline`."
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -56,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/timeline-scope.json
+++ b/css/properties/timeline-scope.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -50,7 +50,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
@@ -85,7 +85,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",

--- a/css/properties/view-timeline-axis.json
+++ b/css/properties/view-timeline-axis.json
@@ -15,15 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Now supports the `x` and `y` values, and also the deprecated `horizontal` and `vertical` values."
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -56,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
@@ -91,7 +83,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
@@ -126,7 +118,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",
@@ -161,7 +153,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",

--- a/css/properties/view-timeline-inset.json
+++ b/css/properties/view-timeline-inset.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1676779"
             },
             "firefox_android": "mirror",
@@ -49,7 +49,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://bugzil.la/1676779"
               },
               "firefox_android": "mirror",

--- a/css/properties/view-timeline-name.json
+++ b/css/properties/view-timeline-name.json
@@ -15,14 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "111",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -52,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/view-timeline.json
+++ b/css/properties/view-timeline.json
@@ -15,15 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "114",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.scroll-driven-animations.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "notes": "Now supports the `x` and `y` values, and also the deprecated `horizontal` and `vertical` values."
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -53,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1953973"
             },
             "firefox_android": "mirror",

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -16,7 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://bugzil.la/1953973"
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org project (v10.19.1) found new features shipping in Firefox Nightly 154 (23-06-2026). Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive.

See also https://www.firefox.com/en-US/firefox/154.0a1/releasenotes/

This PR marks the following features as "preview" (**bold** are new features in BCD):

- api.AnimationTimeline.duration
- api.Element.animate.options_timeline_parameter
- api.HTMLInputElement.alpha
- api.ScrollTimeline
- api.ScrollTimeline.ScrollTimeline
- api.ScrollTimeline.axis
- api.ScrollTimeline.source
- api.ViewTimeline
- api.ViewTimeline.ViewTimeline
- api.ViewTimeline.endOffset
- api.ViewTimeline.startOffset
- api.ViewTimeline.subject
- css.properties.animation-duration.auto
- css.properties.animation-timeline
- css.properties.animation-timeline.auto
- css.properties.animation-timeline.none
- css.properties.animation-timeline.scroll
- css.properties.animation-timeline.view
- css.properties.grid-template-columns.masonry
- css.properties.grid-template-rows.masonry
- **css.properties.link-parameters**
- **css.properties.link-parameters.none**
- css.properties.scroll-timeline-axis
- css.properties.scroll-timeline-axis.block
- css.properties.scroll-timeline-axis.inline
- css.properties.scroll-timeline-axis.x
- css.properties.scroll-timeline-axis.y
- css.properties.scroll-timeline-name
- css.properties.scroll-timeline-name.none
- css.properties.scroll-timeline
- css.properties.scroll-timeline.none
- css.properties.timeline-scope
- css.properties.timeline-scope.all
- css.properties.timeline-scope.none
- css.properties.view-timeline-axis
- css.properties.view-timeline-axis.block
- css.properties.view-timeline-axis.inline
- css.properties.view-timeline-axis.x
- css.properties.view-timeline-axis.y
- css.properties.view-timeline-inset
- css.properties.view-timeline-inset.auto
- css.properties.view-timeline-name
- css.properties.view-timeline-name.none
- css.properties.view-timeline
- css.properties.view-timeline.none
- css.types.sibling-count
- css.types.sibling-index