### PR TITLE
Bug 2036647 support for CSS gradients in `additional_backgrounds` and `theme_frame`

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -918,7 +918,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": "CSS gradients are supported from Firefox 153."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -939,7 +940,8 @@
                 },
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "55"
+                  "version_added": "55",
+                  "notes": "CSS gradients are supported from Firefox 153."
                 },
                 "firefox_android": {
                   "version_added": false
@@ -976,6 +978,27 @@
                 "version_added": false
               },
               "safari_ios": "mirror"
+            }
+          },
+          "additional_backgrounds_size": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "153"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
             }
           },
           "color_scheme": {


### PR DESCRIPTION
#### Summary

Addresses the dev-docs-needed requirements of [Bug 2036647](https://bugzilla.mozilla.org/show_bug.cgi?id=2036647)  "Allow extension themes to use CSS gradients" with:

- notes to indicate the support for CSS gradient in `additional_backgrounds` and `theme_frame`
- addition of the `additional_backgrounds_size` property

#### Related issues

Related MDN content changes made in https://github.com/mdn/content/pull/44551