### PR TITLE
Chrome 151 responsive iframe sizing

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5137,7 +5137,7 @@
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#dom-window-requestresize",
           "support": {
             "chrome": {
-              "version_added": "151"
+              "version_added": "preview"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -5132,6 +5132,37 @@
           }
         }
       },
+      "requestResize": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-sizing-4/#dom-window-requestresize",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "resize_event": {
         "__compat": {
           "description": "`resize` event",

--- a/css/properties/frame-sizing.json
+++ b/css/properties/frame-sizing.json
@@ -1,0 +1,192 @@
+{
+  "css": {
+    "properties": {
+      "frame-sizing": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-sizing-4/#responsive-iframes",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-auto",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "content-block-size": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-block-size",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "content-height": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-height",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "content-inline-size": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-inline-size",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "content-width": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-width",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/frame-sizing.json
+++ b/css/properties/frame-sizing.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#responsive-iframes",
           "support": {
             "chrome": {
-              "version_added": "151"
+              "version_added": "preview"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-auto",
             "support": {
               "chrome": {
-                "version_added": "151"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-block-size",
             "support": {
               "chrome": {
-                "version_added": "151"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +98,7 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-height",
             "support": {
               "chrome": {
-                "version_added": "151"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +129,7 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-inline-size",
             "support": {
               "chrome": {
-                "version_added": "151"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +160,7 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-width",
             "support": {
               "chrome": {
-                "version_added": "151"
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -494,6 +494,41 @@
               }
             }
           },
+          "responsive-embedded-sizing": {
+            "__compat": {
+              "description": "`<meta name=\"responsive-embedded-sizing\">`",
+              "spec_url": "https://drafts.csswg.org/css-sizing-4/#iframe-frame-sizing:~:text=If%20a-,%3Cmeta%20name%3Dresponsive%2Dembedded%2Dsizing%3E",
+              "tags": [
+                "web-features:meta-text-scale"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "151"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "text-scale": {
             "__compat": {
               "description": "`<meta name=\"text-scale\">`",

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -503,7 +503,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "151"
+                  "version_added": "preview"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 151 adds support for responsive iframe sizing; see https://chromestatus.com/feature/5108373464547328.

This relies on three new features:

- The CSS [`frame-sizing`](https://drafts.csswg.org/css-sizing-4/#propdef-frame-sizing) property
- The [`Window.requestResize`](https://drafts.csswg.org/css-sizing-4/#dom-window-requestresize) method
- The [`<meta name=responsive-embedded-sizing>`](https://drafts.csswg.org/css-sizing-4/#iframe-frame-sizing:~:text=If%20a-,%3Cmeta%20name%3Dresponsive%2Dembedded%2Dsizing%3E) meta tag

This PR adds data for all three features.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
