### PR TITLE
updated the firefox relase for -webkit-scrollbar selector as it was moved to 153

### DIFF
--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -12,7 +12,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "152",
+              "version_added": "153",
               "partial_implementation": true,
               "notes": "The `@supports selector(::-webkit-scrollbar)` returns `true` but this pseudo-element cannot be used to style scrollbars. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
             },


### PR DESCRIPTION
#### Summary

- Updated the Firefox Version added to 153 as [it was delayed from 152](https://bugzilla.mozilla.org/show_bug.cgi?id=2038877#c7)

#### Test results and supporting details

- Tested using the following CodePens:
  - [unscrollable-content fix](https://codepen.io/CodeRedDigital/pen/GgNQdNR)
  - [::-webkit-scrollbar width height](https://codepen.io/CodeRedDigital/pen/JobpvEm)
  - [@supports selector(::-webkit-scrollbar)](https://codepen.io/CodeRedDigital/pen/bNBeKOy)
- Works in the following:
  - Firefox Beta 153
  - Firefox Developer Edition 153
  - Firefox Nightly 154

#### Related Pull Requests

- [Firefox release PR](https://github.com/mdn/content/pull/44567)