### PR TITLE
Web Preferences API is behind a flag

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -3106,7 +3106,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#preferences-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/PreferenceManager.json
+++ b/api/PreferenceManager.json
@@ -6,7 +6,14 @@
         "spec_url": "https://drafts.csswg.org/mediaqueries-5/#preference-manager",
         "support": {
           "chrome": {
-            "version_added": "preview"
+            "version_added": "120",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -37,7 +44,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#color-scheme-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -69,7 +83,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#contrast-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -101,7 +122,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#reduced-data-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -133,7 +161,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#reduced-motion-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -165,7 +200,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#reduced-transparency-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/PreferenceObject.json
+++ b/api/PreferenceObject.json
@@ -6,7 +6,14 @@
         "spec_url": "https://drafts.csswg.org/mediaqueries-5/#preference-object-interface",
         "support": {
           "chrome": {
-            "version_added": "preview"
+            "version_added": "120",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -38,7 +45,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#onchange-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -70,7 +84,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#clear-override-method",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -102,7 +123,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#override-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -134,7 +162,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#request-override-method",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -166,7 +201,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#valid-values-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -198,7 +240,14 @@
           "spec_url": "https://drafts.csswg.org/mediaqueries-5/#preference-value-attribute",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "120",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

Thanks to collecting compat data for preview browsers (Nightly, Canary, Safari TP), I can now also see what is *not* in preview! :) The Web Preferences API is behind a flag.

#### Test results and supporting details

- https://issues.chromium.org/issues/40280804
- https://chromiumdash.appspot.com/commit/4fd94e6834d516cb45f7c23ffa592e7caf42b783

#### Related issues

None.
