### PR TITLE
Add Deno 2.9 support for Web Locks and navigator.userAgentData

### DIFF
--- a/api/Lock.json
+++ b/api/Lock.json
@@ -12,6 +12,9 @@
             "version_added": "69"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "2.9"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "96"
@@ -49,6 +52,9 @@
               "version_added": "69"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "96"
@@ -87,6 +93,9 @@
               "version_added": "69"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "96"

--- a/api/LockManager.json
+++ b/api/LockManager.json
@@ -12,6 +12,9 @@
             "version_added": "69"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "2.9"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": "96"
@@ -49,6 +52,9 @@
               "version_added": "69"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "96"
@@ -87,6 +93,9 @@
               "version_added": "69"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "96"

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2308,6 +2308,9 @@
               "version_added": "69"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": "96"
@@ -5617,6 +5620,9 @@
               "version_added": "90"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -5657,6 +5663,9 @@
                 "version_added": "90"
               },
               "chrome_android": "mirror",
+              "deno": {
+                "version_added": "2.9"
+              },
               "edge": "mirror",
               "firefox": {
                 "version_added": false

--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -12,6 +12,9 @@
             "version_added": "90"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "2.9"
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -51,6 +54,9 @@
               "version_added": "90"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -91,6 +97,9 @@
               "notes": "From Chrome 144, whether or not this feature can return high-entropy values can be controlled with the `ch-ua-high-entropy-values` permissions policy."
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -130,6 +139,9 @@
               "version_added": "90"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -169,6 +181,9 @@
               "version_added": "93"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -208,6 +223,9 @@
               "version_added": "93"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/WorkerNavigator.json
+++ b/api/WorkerNavigator.json
@@ -582,7 +582,7 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.9"
             },
             "edge": "mirror",
             "firefox": {
@@ -1133,6 +1133,9 @@
               "version_added": "90"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "2.9"
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/browsers/deno.json
+++ b/browsers/deno.json
@@ -443,6 +443,13 @@
         "2.8": {
           "release_date": "2026-05-22",
           "release_notes": "https://deno.com/blog/v2.8",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "14.9"
+        },
+        "2.9": {
+          "release_date": "2026-06-25",
+          "release_notes": "https://deno.com/blog/v2.9",
           "status": "current",
           "engine": "V8",
           "engine_version": "14.9"


### PR DESCRIPTION
Here's the GH release for Deno 2.9 release: https://github.com/denoland/deno/releases/tag/v2.9.0