### PR TITLE
Update deno support for import attribute with {type: 'css'}

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1763,7 +1763,7 @@
                 },
                 "chrome_android": "mirror",
                 "deno": {
-                  "version_added": false
+                  "version_added": "2.9"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Updates `deno` support for import attributes with {type: 'css'}

Deno 2.9 release notes: https://deno.com/blog/v2.9#css-module-imports

> Deno 2.9 supports importing CSS files as constructable stylesheets using import attributes, matching the CSS module scripts web standard

Example syntax:

```
import sheet from "./styles.css" with { type: "css" };

document.adoptedStyleSheets = [sheet];
```
