### PR TITLE
FF153 image/jxl supported in nightly

### DIFF
--- a/mediatypes/image/jxl.json
+++ b/mediatypes/image/jxl.json
@@ -25,14 +25,7 @@
               "notes": "Earlier flag support was added in Edge 91 and removed in Edge 110."
             },
             "firefox": {
-              "version_added": "152",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "image.jxl.enabled",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "opera": {


### PR DESCRIPTION
FF153 supports the JXL image in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=2040074 (pref `image.jxl.enabled` now true by default in nightly).

Related docs work can be tracked in https://github.com/mdn/content/issues/44474
