### PR TITLE
Safari 27 adds `sizes="auto"` for HTMLImageElement

### DIFF
--- a/api/HTMLImageElement.json
+++ b/api/HTMLImageElement.json
@@ -1118,8 +1118,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
-                "impl_url": "https://webkit.org/b/253143"
+                "version_added": "27"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Updates the Safari statement for `sizes="auto"` on `HTMLImageElement`.

#### Test results and supporting details

See: https://github.com/mdn/browser-compat-data/issues/29403#issuecomment-4199780036

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29403.