### PR TITLE
Add pref info to responsive iframe sizing data

### DIFF
--- a/api/Window.json
+++ b/api/Window.json
@@ -5137,7 +5137,13 @@
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#dom-window-requestresize",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/frame-sizing.json
+++ b/css/properties/frame-sizing.json
@@ -6,7 +6,13 @@
           "spec_url": "https://drafts.csswg.org/css-sizing-4/#responsive-iframes",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "149",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features"
+                }
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +42,13 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-auto",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +79,13 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-block-size",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,7 +116,13 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-height",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,7 +153,13 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-inline-size",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -160,7 +190,13 @@
             "spec_url": "https://drafts.csswg.org/css-sizing-4/#valdef-frame-sizing-content-width",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "149",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features"
+                  }
+                ]
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -503,7 +503,13 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "preview"
+                  "version_added": "149",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "#enable-experimental-web-platform-features"
+                    }
+                  ]
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

In https://github.com/mdn/browser-compat-data/pull/29911, I added data for the responsive iframe sizing feature. However, I missed information on the pref that must be set to use it.

This PR corrects that issue.

I also discovered that it can be used after enabling the pref as far back as version 149.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
