### PR TITLE
fix: pin npx tsc to the typescript package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
 
       - run: npx prettier --check .
 
-      - run: npx tsc --noEmit
+      - run: npx --package=typescript tsc --noEmit
 
   lint:
     runs-on: ubuntu-latest

--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -37,7 +37,7 @@ pre-push:
             run: npx prettier --check .
 
           - name: tsc
-            run: npx tsc --noEmit
+            run: npx --package=typescript tsc --noEmit
 
 post-merge:
   only:


### PR DESCRIPTION
#### Summary

Pin `npx tsc` to the `typescript` package to prevent a dependency-confusion fallback:

- `.github/workflows/test.yml`: `npx tsc --noEmit` → `npx --package=typescript tsc --noEmit`
- `.lefthook.yml`: `npx tsc --noEmit` → `npx --package=typescript tsc --noEmit`

#### Test results and supporting details

`tsc` is a bin of `typescript`. A standalone `tsc` package also exists on npm (a deprecated TypeScript-compiler release); if `typescript` isn't installed locally, `npx tsc` fetches that instead. `typescript` is already a devDependency, so pinning `--package=typescript` (or calling the local bin) guarantees the intended compiler. In CI, `npx` assumes `--yes`, so any fallback fetch happens with no prompt.

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Part of https://github.com/mdn/fred/issues/1680.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
