### PR TITLE
Chrome 148 localizable manifest members

### DIFF
--- a/manifests/webapp/dir.json
+++ b/manifests/webapp/dir.json
@@ -1,0 +1,42 @@
+{
+  "manifests": {
+    "webapp": {
+      "dir": {
+        "__compat": {
+          "spec_url": "https://www.w3.org/TR/appmanifest/#dir-member",
+          "tags": [
+            "web-features:manifest"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "148"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/manifests/webapp/lang.json
+++ b/manifests/webapp/lang.json
@@ -1,0 +1,42 @@
+{
+  "manifests": {
+    "webapp": {
+      "lang": {
+        "__compat": {
+          "spec_url": "https://www.w3.org/TR/appmanifest/#lang-member",
+          "tags": [
+            "web-features:manifest"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "148"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/manifests/webapp/localizable_members.json
+++ b/manifests/webapp/localizable_members.json
@@ -1,0 +1,43 @@
+{
+  "manifests": {
+    "webapp": {
+      "localizable_members": {
+        "__compat": {
+          "description": "`*_localized` members ",
+          "spec_url": "https://www.w3.org/TR/appmanifest/#x_localized-members",
+          "tags": [
+            "web-features:manifest"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "148"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome and Edge 148 desktop have added support for [`*_localized` members](https://www.w3.org/TR/appmanifest/#x_localized-members), aka localizable web app manifests. See https://chromestatus.com/feature/5090807862394880.

This PR adds a general data point for localizable members, plus specific data points for the `dir` and `lang` manifest members, which I'm pretty sure were added at the same time (I've pinged engineering to check this) . 

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
