### PR TITLE
Chrome 150 ships `light-dark()` for image values

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -944,15 +944,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "148",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "Enabled"
-                    }
-                  ],
-                  "impl_url": "https://crbug.com/491829958"
+                  "version_added": "150"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -973,7 +965,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 150 ships `light-dark()` for image values

#### Test results and supporting details

See issue below.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29767.