### PR TITLE
Create a subfeature for multiple webdriver bidi sessions

### DIFF
--- a/webdriver/bidi/session.json
+++ b/webdriver/bidi/session.json
@@ -78,12 +78,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "92",
-                "partial_implementation": true,
-                "notes": [
-                  "Before Firefox 116, capability matching was not supported.",
-                  "Multiple session creation is not supported ([bug 1862018](https://bugzil.la/1862018))."
-                ]
+                "version_added": "92"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -165,6 +160,40 @@
                   "standard_track": true,
                   "deprecated": false
                 }
+              }
+            }
+          },
+          "multiple_sessions": {
+            "__compat": {
+              "description": "Support for multiple concurrent sessions in a single browser instance.",
+              "spec_url": "https://w3c.github.io/webdriver/#sessions",
+              "support": {
+                "chrome": {
+                  "version_added": "126"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false,
+                  "impl_url": "https://bugzil.la/1862018"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false,
+                  "impl_url": "https://webkit.org/b/281722"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
               }
             }
           }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

`webdriver.bidi.session.new` is currently marked as partially implemented because it doesn't support creating multiple sessions. See https://bugzilla.mozilla.org/show_bug.cgi?id=1862018.

However, using multiple parallel sessions isn't something that every bidi user needs to do. You can still use bidi without any issues without this capability.

This PR moves the capability to a new subfeature, and makes `webdriver.bidi.session.new` be supported in Firefox.

#### Test results and supporting details

I did not test this myself, but webdriver bidi WPT tests exist and pass on supporting browsers shows that it is possible create sessions: https://wpt.fyi/results/webdriver/tests/bidi?label=master&label=experimental&aligned

#### Related issues

* https://bugzilla.mozilla.org/show_bug.cgi?id=1862018
* https://github.com/w3c/webdriver-bidi/issues/103