### PR TITLE
Updates for Safari TP 247

### DIFF
--- a/css/properties/font-variant-emoji.json
+++ b/css/properties/font-variant-emoji.json
@@ -67,7 +67,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -101,7 +101,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -135,7 +135,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -169,7 +169,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org project (v10.20.2) found new features shipping in Safari Technical Preview 247 on macOS 27.0 Beta which was released tonight. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive.

See also https://webkit.org/blog/18133/release-notes-for-safari-technology-preview-247/

This PR now marks the following features as "preview":
- css.properties.font-variant-emoji.emoji
- css.properties.font-variant-emoji.normal
- css.properties.font-variant-emoji.text
- css.properties.font-variant-emoji.unicode


I'm also seeing CloseWatcher but that was already merged in https://github.com/mdn/browser-compat-data/pull/29961.