### PR TITLE
Add Chrome support for webdriver.bidi.session.end

### DIFF
--- a/webdriver/bidi/session.json
+++ b/webdriver/bidi/session.json
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/webdriver/bidi/session.json
+++ b/webdriver/bidi/session.json
@@ -39,7 +39,7 @@
             "spec_url": "https://w3c.github.io/webdriver-bidi/#command-session-end",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "126"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/webdriver/bidi/session.json
+++ b/webdriver/bidi/session.json
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

The session.end command is supported in Chrome. Its implementation landed in Chrome 120 (https://chromiumdash.appspot.com/commit/4f3e543d30ce22fed263906c6df47ad4926ccf0b), but it stayed behind the WebDriver BiDi flag until Chrome 126, when BiDi was enabled by default, matching the rest of the session module.

#### Test results and supporting details

* [session.end addition](https://chromiumdash.appspot.com/commit/4f3e543d30ce22fed263906c6df47ad4926ccf0b)

#### Related issues

https://issues.chromium.org/issues/40645108