### PR TITLE
WebView iOS supports `box-decoration-break` values

### DIFF
--- a/css/properties/box-decoration-break.json
+++ b/css/properties/box-decoration-break.json
@@ -103,9 +103,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,
@@ -147,9 +145,7 @@
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
-              "webview_ios": {
-                "version_added": false
-              }
+              "webview_ios": "mirror"
             },
             "status": {
               "experimental": false,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

WebView iOS supports `box-decoration-break` (with prefix), and it also supports the two values.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29899
