### PR TITLE
Deno 2.8 supports OffscreenCanvas `webgpu` context

### DIFF
--- a/api/OffscreenCanvas.json
+++ b/api/OffscreenCanvas.json
@@ -413,7 +413,7 @@
                 "version_added": "121"
               },
               "deno": {
-                "version_added": false
+                "version_added": "2.8"
               },
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
#### Summary

Update `api.OffscreenCanvas.webgpu_context` to record Deno support starting in 2.8 (previously `false`).

#### Test results and supporting details

Bisected locally with `dvm`, confirming the boundary matches Deno's introduction of `OffscreenCanvas`:

| Version | `new OffscreenCanvas(32,32).getContext('webgpu')` |
|---|---|
| 2.7.14 | `ReferenceError: OffscreenCanvas is not defined` |
| 2.8.0 | returns a `GPUCanvasContext` |
| 2.9.1 | returns a `GPUCanvasContext` |

#### Related issues

Fixes #29923