### PR TITLE
Fold legacy CSS `position-visibility: anchors-*` values

### DIFF
--- a/css/properties/position-visibility.json
+++ b/css/properties/position-visibility.json
@@ -79,15 +79,22 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "alternative_name": "anchors-valid",
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "27"
-              },
+              "safari": [
+                {
+                  "version_added": "27"
+                },
+                {
+                  "alternative_name": "anchors-valid",
+                  "version_added": "26.2"
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -105,20 +112,28 @@
             "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-visibility-anchor-visible",
             "support": {
               "chrome": {
-                "version_added": false
+                "alternative_name": "anchors-visible",
+                "version_added": "125"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "alternative_name": "anchors-visible",
+                "version_added": "147"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": {
-                "version_added": "27"
-              },
+              "safari": [
+                {
+                  "version_added": "27"
+                },
+                {
+                  "alternative_name": "anchors-visible",
+                  "version_added": "26.2"
+                }
+              ],
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -126,74 +141,6 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "anchors-valid": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-visibility-anchor-valid",
-            "tags": [
-              "web-features:anchor-positioning"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "147"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "26.2"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "anchors-visible": {
-          "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-visibility-anchor-visible",
-            "tags": [
-              "web-features:anchor-positioning"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "125"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "147"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "26.2"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
#### Summary

Merges the legacy CSS `position-visibility: anchors-*` values into `anchor-*`.

#### Test results and supporting details

Verified that Safari 27 beta supports both:

<img width="797" height="208" alt="image" src="https://github.com/user-attachments/assets/312fd519-1e50-4311-80f3-16af2851f960" />


#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/29950.