### PR TITLE
Add Bun data for File, Resource Timing, and JSTag

### DIFF
--- a/api/File.json
+++ b/api/File.json
@@ -83,6 +83,9 @@
             "web-features:file"
           ],
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
               "version_added": "38"
             },

--- a/api/PerformanceResourceTiming.json
+++ b/api/PerformanceResourceTiming.json
@@ -8,6 +8,9 @@
           "web-features:resource-timing"
         ],
         "support": {
+          "bun": {
+            "version_added": "1.1.37"
+          },
           "chrome": {
             "version_added": "29"
           },
@@ -1257,6 +1260,9 @@
             "web-features:resource-timing"
           ],
           "support": {
+            "bun": {
+              "version_added": "1.1.37"
+            },
             "chrome": {
               "version_added": "45"
             },

--- a/webassembly/api.json
+++ b/webassembly/api.json
@@ -50,6 +50,9 @@
           "description": "`JSTag` static attribute",
           "spec_url": "https://webassembly.github.io/spec/js-api/#dom-webassembly-jstag",
           "support": {
+            "bun": {
+              "version_added": "1.2.3"
+            },
             "chrome": {
               "version_added": "115"
             },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR adds some missing Bun compatibility data for:
- `File()` constructor: Bun 1.0.0
- `PerformanceResourceTiming`: Bun 1.1.37
- `PerformanceResourceTiming.toJSON()`: Bun 1.1.37
- `WebAssembly.JSTag`: Bun 1.2.3

#### Test results and supporting details

I checked support with Docker builds of Bun releases, working backward from the latest until support stopped.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
