### PR TITLE
Updates for Chrome 150 release

### DIFF
--- a/api/GPUComputePassEncoder.json
+++ b/api/GPUComputePassEncoder.json
@@ -656,6 +656,37 @@
           }
         }
       },
+      "setImmediates": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubindingcommandsmixin-setimmediates",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setPipeline": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUComputePassEncoder/setPipeline",

--- a/api/GPURenderBundleEncoder.json
+++ b/api/GPURenderBundleEncoder.json
@@ -780,6 +780,37 @@
           }
         }
       },
+      "setImmediates": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubindingcommandsmixin-setimmediates",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setIndexBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderBundleEncoder/setIndexBuffer",

--- a/api/GPURenderPassEncoder.json
+++ b/api/GPURenderPassEncoder.json
@@ -1064,6 +1064,37 @@
           }
         }
       },
+      "setImmediates": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-gpubindingcommandsmixin-setimmediates",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "setIndexBuffer": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPURenderPassEncoder/setIndexBuffer",

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -978,6 +978,37 @@
           }
         }
       },
+      "maxImmediateSize": {
+        "__compat": {
+          "spec_url": "https://gpuweb.github.io/gpuweb/#dom-supported-limits-maximmediatesize",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "maxInterStageShaderComponents": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/GPUSupportedLimits#instance_properties",

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -43,6 +43,192 @@
           "deprecated": false
         }
       },
+      "getAttribute": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-getattribute",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "getAttributeNames": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-getattributenames",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hasAttribute": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-hasattribute",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hasAttributes": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-hasattributes",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "removeAttribute": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-removeattribute",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setAttribute": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-setattribute",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sheet": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/ProcessingInstruction/sheet",
@@ -117,6 +303,37 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "toggleAttribute": {
+        "__compat": {
+          "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-toggleattribute",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
#### Summary

Updates for the release version of Chrome 150. Discovered by the OWD BCD collector v10.20.2.

#### Test results and supporting details

- GPU changes: https://chromestatus.com/feature/5199437611794432
- ProcessingInstructions in HTML: https://chromestatus.com/feature/6534495085920256

#### Related issues

This is a follow-up to https://github.com/mdn/browser-compat-data/pull/29799.
