### PR TITLE
Updates for Chrome 151 beta

### DIFF
--- a/api/AnimationEvent.json
+++ b/api/AnimationEvent.json
@@ -138,7 +138,7 @@
           "spec_url": "https://drafts.csswg.org/css-animations-2/#dom-animationevent-animation",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Blob.json
+++ b/api/Blob.json
@@ -476,7 +476,7 @@
           "spec_url": "https://w3c.github.io/FileAPI/#dom-blob-textstream",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/PerformanceEntry.json
+++ b/api/PerformanceEntry.json
@@ -266,6 +266,37 @@
           }
         }
       },
+      "navigationId": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/performance-timeline/#dom-performanceentry-navigationid",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "startTime": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/PerformanceEntry/startTime",

--- a/api/Request.json
+++ b/api/Request.json
@@ -2027,7 +2027,7 @@
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-textstream",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Response.json
+++ b/api/Response.json
@@ -1036,7 +1036,7 @@
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-textstream",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -1430,7 +1430,7 @@
           "spec_url": "https://webaudio.github.io/web-speech-api/#dom-speechrecognition-unspokenpunctuation",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/TransitionEvent.json
+++ b/api/TransitionEvent.json
@@ -125,7 +125,7 @@
           "spec_url": "https://drafts.csswg.org/css-transitions-2/#Events-TransitionEvent-animation",
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -211,7 +211,7 @@
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-incomingmaxbuffereddatagrams",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -373,7 +373,7 @@
           "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportdatagramduplexstream-outgoingmaxbuffereddatagrams",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/WheelEvent.json
+++ b/api/WheelEvent.json
@@ -246,6 +246,37 @@
           }
         }
       },
+      "momentum": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/pointerevents/#dom-wheeleventinit-momentum",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "pinch_to_zoom_support": {
         "__compat": {
           "description": "Pinch-to-zoom maps to `WheelEvent` + `ctrl` key.",

--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -142,7 +142,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "151"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/ruby-overhang.json
+++ b/css/properties/ruby-overhang.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "151"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -43,7 +43,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "151"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -98,6 +98,37 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "spaces": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-ruby/#valdef-ruby-overhang-spaces",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.20.2) found new features shipping in Chromium 151 beta which was released on Friday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Canary/behind flags, it is not considered here.

With this PR, BCD will consider the following 18 features as shipping in Chromium 151 (**bold** features are new keys in BCD).

- api.AnimationEvent.animation
- api.Blob.textStream
- **api.PerformanceEntry.navigationId**
- api.Request.textStream
- api.Response.textStream
- api.SpeechRecognition.unspokenPunctuation
- api.TransitionEvent.animation
- api.WebTransportDatagramDuplexStream.incomingMaxBufferedDatagrams
- api.WebTransportDatagramDuplexStream.outgoingMaxBufferedDatagrams
- **api.WheelEvent.momentum**
- css.properties.position-anchor.normal
- css.properties.ruby-overhang
- css.properties.ruby-overhang.auto
- **css.properties.ruby-overhang.spaces**


Updated in different PRs:
- api.HTMLElement.headingOffset
- api.HTMLElement.headingReset
- html.global_attributes.headingoffset
- html.global_attributes.headingreset

See also https://developer.chrome.com/blog/chrome-151-beta