### PR TITLE
Chrome 151 CSS alpha() function

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -45,6 +45,39 @@
             "deprecated": false
           }
         },
+        "alpha": {
+          "__compat": {
+            "description": "`alpha()`",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Values/color_value/alpha",
+            "spec_url": "https://drafts.csswg.org/css-color-5/#relative-alpha",
+            "support": {
+              "chrome": {
+                "version_added": "151"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "preview"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "color": {
           "__compat": {
             "description": "`color()` (Profiled color values)",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -64,7 +64,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "27"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 151 adds support for the CSS color `alpha()` function: see https://chromestatus.com/feature/5070160203481088.

This is already documented, but the support data is missing: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/alpha.

This PR adds the necessary data.

Through testing, I also saw evidence of this working in Firefox preview (Nightly).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
