### PR TITLE
Safari 27 beta supports light-dark on image values

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -956,7 +956,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "preview",
+                  "version_added": "27",
                   "impl_url": "https://webkit.org/b/309689"
                 },
                 "safari_ios": "mirror",


### PR DESCRIPTION
It wasn't part of the initial beta, but it is available now.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
