### PR TITLE
Safari TP supports `requestIdleCallback` behind flag

### DIFF
--- a/api/IdleDeadline.json
+++ b/api/IdleDeadline.json
@@ -21,7 +21,14 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "preview",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "requestIdleCallback",
+                "value_to_set": "true"
+              }
+            ]
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,8 +62,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/164193"
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "requestIdleCallback",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -91,8 +104,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/164193"
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "requestIdleCallback",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -768,8 +768,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/164193"
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "requestIdleCallback",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -5117,8 +5123,14 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/285049"
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "requestIdleCallback",
+                  "value_to_set": "true"
+                }
+              ]
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari TP supports `requestIdleCallback` behind flag

#### Test results and supporting details

See https://github.com/mdn/browser-compat-data/issues/24573#issuecomment-2897269529.

Checked quickly that the flag is still disabled by default in TP.

#### Related issues

Fixes https://github.com/mdn/browser-compat-data/issues/24573.