### PR TITLE
Replace obsolete #enable-generic-sensor-extra-classes Chrome flag with #enable-experimental-web-platform-features

### DIFF
--- a/api/AmbientLightSensor.json
+++ b/api/AmbientLightSensor.json
@@ -8,28 +8,16 @@
           "web-features:ambient-light"
         ],
         "support": {
-          "chrome": [
-            {
-              "version_added": "67",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            },
-            {
-              "version_added": "56",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "Enabled"
-                }
-              ]
-            }
-          ],
+          "chrome": {
+            "version_added": "56",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#enable-experimental-web-platform-features",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
@@ -62,28 +50,16 @@
             "web-features:ambient-light"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-generic-sensor-extra-classes",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              }
-            ],
+            "chrome": {
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
@@ -116,30 +92,17 @@
             "web-features:ambient-light"
           ],
           "support": {
-            "chrome": [
-              {
-                "version_added": "67",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-generic-sensor-extra-classes",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
-              },
-              {
-                "version_added": "56",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ],
-                "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
-              }
-            ],
+            "chrome": {
+              "version_added": "56",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "In Chrome 79, this method stopped returning floats and returned integers to avoid fingerprinting."
+            },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {

--- a/api/Magnetometer.json
+++ b/api/Magnetometer.json
@@ -13,7 +13,7 @@
             "flags": [
               {
                 "type": "preference",
-                "name": "#enable-generic-sensor-extra-classes",
+                "name": "#enable-experimental-web-platform-features",
                 "value_to_set": "Enabled"
               }
             ]
@@ -55,7 +55,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -97,7 +97,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -139,7 +139,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]
@@ -181,7 +181,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]

--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -570,7 +570,7 @@
               "flags": [
                 {
                   "type": "preference",
-                  "name": "#enable-generic-sensor-extra-classes",
+                  "name": "#enable-experimental-web-platform-features",
                   "value_to_set": "Enabled"
                 }
               ]

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -831,7 +831,7 @@
                   "flags": [
                     {
                       "type": "preference",
-                      "name": "#enable-generic-sensor-extra-classes",
+                      "name": "#enable-experimental-web-platform-features",
                       "value_to_set": "Enabled"
                     }
                   ]

--- a/http/headers/Feature-Policy.json
+++ b/http/headers/Feature-Policy.json
@@ -797,7 +797,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "#enable-generic-sensor-extra-classes",
+                    "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
                 ]

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1006,7 +1006,7 @@
                 "flags": [
                   {
                     "type": "preference",
-                    "name": "#enable-generic-sensor-extra-classes",
+                    "name": "#enable-experimental-web-platform-features",
                     "value_to_set": "Enabled"
                   }
                 ]


### PR DESCRIPTION
#### Summary

The `#enable-generic-sensor-extra-classes` Chrome flag was [removed in Chrome 138](https://github.com/chromium/chromium/commit/33bd05253f9a8dc68bd1fb1b67ad38f1ccbbb62d). The affected Generic Sensor features remain available behind the still-supported `#enable-experimental-web-platform-features` flag, so this points the Chrome support statements at that flag instead, keeping the original `version_added`. For `AmbientLightSensor`, which already listed `#enable-experimental-web-platform-features` at an earlier version (56), the now-redundant statement collapses into the existing one.

Affected features: `api.Magnetometer` (+ `x`/`y`/`z`), `api.AmbientLightSensor` (+ constructor/`illuminance`), `api.Permissions`, `html.elements.iframe`, `http.headers.Feature-Policy`, `http.headers.Permissions-Policy`.

#### Test results and supporting details

`npm run lint` passes for all touched files. Chromium removal commit: https://github.com/chromium/chromium/commit/33bd05253f9a8dc68bd1fb1b67ad38f1ccbbb62d

#### Related issues

Fixes #29095