### PR TITLE
Record Deno flag support for `Object.prototype.__proto__`, `WebSocketStream`, and `setImmediate()`

### DIFF
--- a/api/WebSocketStream.json
+++ b/api/WebSocketStream.json
@@ -8,6 +8,15 @@
             "version_added": "124"
           },
           "chrome_android": "mirror",
+          "deno": {
+            "version_added": "1.38",
+            "flags": [
+              {
+                "type": "runtime_flag",
+                "name": "--unstable-net"
+              }
+            ]
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -39,6 +48,15 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.38",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-net"
+                }
+              ]
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -70,6 +88,15 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.38",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-net"
+                }
+              ]
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -101,6 +128,15 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.38",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-net"
+                }
+              ]
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -132,6 +168,15 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.38",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-net"
+                }
+              ]
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -163,6 +208,15 @@
               "version_added": "124"
             },
             "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.38",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-net"
+                }
+              ]
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false

--- a/api/Window.json
+++ b/api/Window.json
@@ -6957,7 +6957,13 @@
             },
             "chrome_android": "mirror",
             "deno": {
-              "version_added": false
+              "version_added": "2.1",
+              "flags": [
+                {
+                  "type": "runtime_flag",
+                  "name": "--unstable-node-globals"
+                }
+              ]
             },
             "edge": {
               "version_added": "12",

--- a/javascript/builtins/Object.json
+++ b/javascript/builtins/Object.json
@@ -1693,9 +1693,26 @@
                 "version_added": "1"
               },
               "chrome_android": "mirror",
-              "deno": {
-                "version_added": false
-              },
+              "deno": [
+                {
+                  "version_added": "2.9",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--unsafe-proto"
+                    }
+                  ]
+                },
+                {
+                  "version_added": "1.39",
+                  "flags": [
+                    {
+                      "type": "runtime_flag",
+                      "name": "--unstable-unsafe-proto"
+                    }
+                  ]
+                }
+              ],
               "edge": {
                 "version_added": "12"
               },


### PR DESCRIPTION
#### Summary

Record three Web features that Deno supports only behind an unstable flag, which BCD previously listed as unsupported (`version_added: false` or missing):

- `javascript.builtins.Object.proto` — `--unstable-unsafe-proto` since 1.39, and the `--unsafe-proto` shorthand since 2.9 (both still work, recorded as two statements).
- `api.WebSocketStream` (all subfeatures) — `--unstable-net` since 1.38 (the granular flag's introduction; the API shipped in 1.13 behind the old blanket `--unstable`).
- `api.Window.setImmediate` — injected as a Node global by `--unstable-node-globals` since 2.1.

#### Test results and supporting details

- `Object.prototype.__proto__` verified in the linked issue via `deno eval --unsafe-proto`/`--unstable-unsafe-proto` (works) vs. no flag (fails). Release notes: <https://deno.com/blog/v1.39#support-for-objectprototype__proto__>, <https://deno.com/blog/v2.9>.
- `WebSocketStream` shipped in [Deno 1.13](https://deno.com/blog/v1.13); `--unstable-net` was introduced in 1.38 (denoland/deno commit `24c3c96`).
- `setImmediate`/`clearImmediate` are injected by `--unstable-node-globals` since 2.1 per the [unstable flags docs](https://docs.deno.com/runtime/reference/cli/unstable_flags/).

#### Related issues

Fixes #29993.