### PR TITLE
Note Safari IME key event ordering bug affecting isComposing

### DIFF
--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -269,7 +269,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "16.4"
+              "version_added": "16.4",
+              "notes": "In Safari, the `keydown` and `input` events for the key that completes an IME composition session are dispatched after the `compositionend` event, so their `isComposing` value is incorrectly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -273,9 +273,10 @@
                 "version_added": "27"
               },
               {
-              "version_added": "16.4",
-              "partial_implementation": true,
-              "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
+                "version_added": "16.4",
+                "version_removed": "27",
+                "partial_implementation": true,
+                "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
               }
             ],
             "safari_ios": "mirror",

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -270,7 +270,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "16.4",
-              "notes": "In Safari, the `keydown` and `input` events for the key that completes an IME composition session are dispatched after the `compositionend` event, so their `isComposing` value is incorrectly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
+              "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/InputEvent.json
+++ b/api/InputEvent.json
@@ -268,10 +268,16 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
+            "safari": [
+              {
+                "version_added": "27"
+              },
+              {
               "version_added": "16.4",
+              "partial_implementation": true,
               "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
-            },
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -815,10 +815,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10.1",
-              "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
-            },
+            "safari": [
+               {
+                "version_added": "27"
+              },
+              {
+                "version_added": "10.1",
+                "version_removed": "27",
+                "partial_implementation": true,
+                "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -817,7 +817,7 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "10.1",
-              "notes": "In Safari, the `keydown` and `input` events for the key that completes an IME composition session are dispatched after the `compositionend` event, so their `isComposing` value is incorrectly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
+              "notes": "The events for the keystroke that completes an IME composition session fire out of order, causing confusing `isComposing` values. The `keydown` and `input` events dispatch after the `compositionend` event fires instead of before. Consequently, the `isComposing` value is unexpectedly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -816,7 +816,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": [
-               {
+              {
                 "version_added": "27"
               },
               {

--- a/api/KeyboardEvent.json
+++ b/api/KeyboardEvent.json
@@ -816,7 +816,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10.1",
+              "notes": "In Safari, the `keydown` and `input` events for the key that completes an IME composition session are dispatched after the `compositionend` event, so their `isComposing` value is incorrectly `false` instead of `true`. Events fired earlier in the session are unaffected. See [bug 165004](https://webkit.org/b/165004)."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Add Safari notes documenting a known IME composition bug: the `keydown` and `input` events for the key that completes an IME composition session are dispatched *after* the `compositionend` event, so their `isComposing` value is incorrectly `false` instead of `true`. Notes are added to:

- `api.KeyboardEvent.isComposing`
- `api.InputEvent.isComposing`

Support values are left unchanged, since the bug does not warrant marking these features as partial or unsupported. The notes are scoped to the `isComposing` properties only, since that is the observable symptom; the `keydown` and `input` events themselves are correctly supported.

#### Test results and supporting details

The bug is still reproducible in Safari 26.3 on macOS. A fix ([bug 311717](https://webkit.org/b/311717)) is implemented behind the `InputMethodUsesCorrectKeyEventOrder` preference, which is still marked as unstable.

- https://webkit.org/b/165004
- https://webkit.org/b/311717

#### Related issues

Fixes #29998