### PR TITLE
Change Firefox 155 release date

### DIFF
--- a/browsers/firefox.json
+++ b/browsers/firefox.json
@@ -1108,7 +1108,7 @@
           "engine_version": "154"
         },
         "155": {
-          "release_date": "2026-09-15",
+          "release_date": "2026-09-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/155",
           "status": "planned",
           "engine": "Gecko",

--- a/browsers/firefox_android.json
+++ b/browsers/firefox_android.json
@@ -975,7 +975,7 @@
           "engine_version": "154"
         },
         "155": {
-          "release_date": "2026-09-15",
+          "release_date": "2026-09-01",
           "release_notes": "https://developer.mozilla.org/docs/Mozilla/Firefox/Releases/155",
           "status": "planned",
           "engine": "Gecko",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Change Firefox 155 release date from 2026-09-15 to 2026-09-01.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Firefox 155 will be released on September 1st, not 15th.

This was announced at:
https://groups.google.com/a/mozilla.org/g/dev-platform/c/qlaQ1YSlOP8

The current release schedule is visible at:
https://whattrainisitnow.com/calendar/

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
