### PR TITLE
Chrome 148 localized manifest members

### DIFF
--- a/manifests/webapp/localized_members.json
+++ b/manifests/webapp/localized_members.json
@@ -1,0 +1,43 @@
+{
+  "manifests": {
+    "webapp": {
+      "localized_members": {
+        "__compat": {
+          "description": "`*_localized` members ",
+          "spec_url": "https://www.w3.org/TR/appmanifest/#x_localized-members",
+          "tags": [
+            "web-features:manifest"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "148"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome and Edge 148 desktop have added support for [`*_localized` members](https://www.w3.org/TR/appmanifest/#x_localized-members), aka localizable web app manifests. See https://chromestatus.com/feature/5090807862394880.

This PR adds a general data point for localizable members.

(This PR does not include data for the `dir` and `lang` members, as it turns out they are not supported anywhere.)

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
