### PR TITLE
Chrome 150 system color web app scope

### DIFF
--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -55,9 +55,12 @@
             ],
             "support": {
               "chrome": {
+                "version_added": "93",
+                "notes": "From version 149, `accent-color: auto` is set only within installed web apps on a user's initial profile."
+              },
+              "chrome_android": {
                 "version_added": "93"
               },
-              "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
                 "version_added": "92"
@@ -78,39 +81,6 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
-            }
-          },
-          "web_app_scope": {
-            "__compat": {
-              "description": "Set only within installed web apps on a user's initial profile.",
-              "support": {
-                "chrome": {
-                  "version_added": "149"
-                },
-                "chrome_android": {
-                  "version_added": false
-                },
-                "edge": "mirror",
-                "firefox": {
-                  "version_added": false
-                },
-                "firefox_android": "mirror",
-                "oculus": "mirror",
-                "opera": "mirror",
-                "opera_android": "mirror",
-                "safari": {
-                  "version_added": false
-                },
-                "safari_ios": "mirror",
-                "samsunginternet_android": "mirror",
-                "webview_android": "mirror",
-                "webview_ios": "mirror"
-              },
-              "status": {
-                "experimental": true,
-                "standard_track": false,
-                "deprecated": false
-              }
             }
           }
         },

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -79,6 +79,39 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "web_app_scope": {
+            "__compat": {
+              "description": "Set only within installed web apps on a user's initial profile.",
+              "support": {
+                "chrome": {
+                  "version_added": "149"
+                },
+                "chrome_android": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": false,
+                "deprecated": false
+              }
+            }
           }
         },
         "currentColor": {

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -56,7 +56,7 @@
             "support": {
               "chrome": {
                 "version_added": "93",
-                "notes": "From version 149, to mitigate fingerprinting risks, `accent-color: auto` returns a fixed value unless used within installed web apps on a user's initial profile."
+                "notes": "From version 149, to mitigate fingerprinting risks, a fixed value is returned for `accent-color: auto` unless used within installed web apps on a user's initial profile."
               },
               "chrome_android": {
                 "version_added": "93"

--- a/css/properties/accent-color.json
+++ b/css/properties/accent-color.json
@@ -56,7 +56,7 @@
             "support": {
               "chrome": {
                 "version_added": "93",
-                "notes": "From version 149, `accent-color: auto` is set only within installed web apps on a user's initial profile."
+                "notes": "From version 149, to mitigate fingerprinting risks, `accent-color: auto` returns a fixed value unless used within installed web apps on a user's initial profile."
               },
               "chrome_android": {
                 "version_added": "93"

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1749,14 +1749,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "115",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "150"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
@@ -1780,6 +1773,39 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
+              }
+            },
+            "web_app_scope": {
+              "__compat": {
+                "description": "Set only within installed web apps on a user's initial profile.",
+                "support": {
+                  "chrome": {
+                    "version_added": "150"
+                  },
+                  "chrome_android": {
+                    "version_added": false
+                  },
+                  "edge": "mirror",
+                  "firefox": {
+                    "version_added": false
+                  },
+                  "firefox_android": "mirror",
+                  "oculus": "mirror",
+                  "opera": "mirror",
+                  "opera_android": "mirror",
+                  "safari": {
+                    "version_added": false
+                  },
+                  "safari_ios": "mirror",
+                  "samsunginternet_android": "mirror",
+                  "webview_android": "mirror",
+                  "webview_ios": "mirror"
+                },
+                "status": {
+                  "experimental": true,
+                  "standard_track": false,
+                  "deprecated": false
+                }
               }
             }
           },

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1749,16 +1749,21 @@
               ],
               "support": {
                 "chrome": {
+                  "version_added": "150",
+                  "notes": "`AccentColor` and `AccentColorText` are set only within installed web apps on a user's initial profile."
+                },
+                "chrome_android": {
                   "version_added": "150"
                 },
-                "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
                   "version_added": "103"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
-                "opera": "mirror",
+                "opera": {
+                  "version_added": "133"
+                },
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "16.5",
@@ -1773,39 +1778,6 @@
                 "experimental": false,
                 "standard_track": true,
                 "deprecated": false
-              }
-            },
-            "web_app_scope": {
-              "__compat": {
-                "description": "Set only within installed web apps on a user's initial profile.",
-                "support": {
-                  "chrome": {
-                    "version_added": "150"
-                  },
-                  "chrome_android": {
-                    "version_added": false
-                  },
-                  "edge": "mirror",
-                  "firefox": {
-                    "version_added": false
-                  },
-                  "firefox_android": "mirror",
-                  "oculus": "mirror",
-                  "opera": "mirror",
-                  "opera_android": "mirror",
-                  "safari": {
-                    "version_added": false
-                  },
-                  "safari_ios": "mirror",
-                  "samsunginternet_android": "mirror",
-                  "webview_android": "mirror",
-                  "webview_ios": "mirror"
-                },
-                "status": {
-                  "experimental": true,
-                  "standard_track": false,
-                  "deprecated": false
-                }
               }
             }
           },

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1761,9 +1761,7 @@
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
-                "opera": {
-                  "version_added": "133"
-                },
+                "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "16.5",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1750,7 +1750,7 @@
               "support": {
                 "chrome": {
                   "version_added": "150",
-                  "notes": "`AccentColor` and `AccentColorText` are set only within installed web apps on a user's initial profile."
+                  "notes": "To mitigate fingerprinting risks, `AccentColor` and `AccentColorText` return fixed values unless used within installed web apps on a user's initial profile."
                 },
                 "chrome_android": {
                   "version_added": "150"

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -1750,7 +1750,7 @@
               "support": {
                 "chrome": {
                   "version_added": "150",
-                  "notes": "To mitigate fingerprinting risks, `AccentColor` and `AccentColorText` return fixed values unless used within installed web apps on a user's initial profile."
+                  "notes": "To mitigate fingerprinting risks, a fixed value is returned for `AccentColor` and `AccentColorText` unless used within installed web apps on a user's initial profile."
                 },
                 "chrome_android": {
                   "version_added": "150"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 150 adds the restriction whereby app system accent colors (`AccentColor` and `AccentColorText` CSS keywords, and `accent-color: auto` ) are limited to installed web apps, and only in the user's initial profile context.

See https://chromestatus.com/feature/5106043975761920. This says 149, but I'm thinking that it must be 150, because the AccentColor and AccentColorText system colors were only shipped as of 150 (see https://chromestatus.com/feature/5068127364186112).

Update: I discussed this with the engineering folks a bit, and two important points came up:

1. This change was made on desktop only.
2.  This change is not specified behavior, but rather Chromium's interpretation of an optional restriction ([specified here](https://www.w3.org/TR/css-color-4/#css-system-colors:~:text=User%20agents%20may,user)). I have therefore elected to represent this change as a Chrome-specific note rather than a completely separate data point.

This PR adds appropriate data points.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
