### PR TITLE
Node 26.5.0 added `Blob.textStream()`, `Request.textStream()`, `Response.textStream()`

### DIFF
--- a/api/Blob.json
+++ b/api/Blob.json
@@ -484,6 +484,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "26.5.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/Request.json
+++ b/api/Request.json
@@ -2035,6 +2035,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "26.5.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/Response.json
+++ b/api/Response.json
@@ -1044,6 +1044,9 @@
               "version_added": false
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "26.5.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/browsers/nodejs.json
+++ b/browsers/nodejs.json
@@ -849,6 +849,13 @@
         "26.0.0": {
           "release_date": "2026-05-05",
           "release_notes": "https://nodejs.org/en/blog/release/v26.0.0",
+          "status": "retired",
+          "engine": "V8",
+          "engine_version": "14.6"
+        },
+        "26.5.0": {
+          "release_date": "2026-07-08",
+          "release_notes": "https://nodejs.org/en/blog/release/v26.5.0",
           "status": "current",
           "engine": "V8",
           "engine_version": "14.6"


### PR DESCRIPTION
#### Summary

Issue - https://github.com/nodejs/node/pull/64036
Release notes - https://nodejs.org/en/blog/release/v26.5.0#new-release-key