### PR TITLE
Firefox v145+ Compression Dictionary (dcb & dcz)

### DIFF
--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -766,7 +766,14 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": false,
+                  "version_added": "145",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.http.dictionaries.enable",
+                      "value_to_set": "true"
+                    }
+                  ],
                   "impl_url": "https://bugzil.la/1918013"
                 },
                 "firefox_android": "mirror",

--- a/html/elements/link.json
+++ b/html/elements/link.json
@@ -765,17 +765,23 @@
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
-                "firefox": {
-                  "version_added": "145",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "network.http.dictionaries.enable",
-                      "value_to_set": "true"
-                    }
-                  ],
-                  "impl_url": "https://bugzil.la/1918013"
-                },
+                "firefox": [
+                  {
+                    "version_added": "preview",
+                    "impl_url": "https://bugzil.la/1882979"
+                  },
+                  {
+                    "version_added": "145",
+                    "flags": [
+                      {
+                        "type": "preference",
+                        "name": "network.http.dictionaries.enable",
+                        "value_to_set": "true"
+                      }
+                    ],
+                    "impl_url": "https://bugzil.la/1918013"
+                  }
+                ],
                 "firefox_android": "mirror",
                 "oculus": "mirror",
                 "opera": "mirror",

--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -97,17 +97,23 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "145",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "network.http.dictionaries.enable",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1917963"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview",
+                  "impl_url": "https://bugzil.la/1882979"
+                },
+                {
+                  "version_added": "145",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.http.dictionaries.enable",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1917963"
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
@@ -140,17 +146,23 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "145",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "network.http.dictionaries.enable",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1917963"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview",
+                  "impl_url": "https://bugzil.la/1882979"
+                },
+                {
+                  "version_added": "145",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.http.dictionaries.enable",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1917963"
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",

--- a/http/headers/Accept-Encoding.json
+++ b/http/headers/Accept-Encoding.json
@@ -98,7 +98,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
                 "impl_url": "https://bugzil.la/1917963"
               },
               "firefox_android": "mirror",
@@ -134,7 +141,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
                 "impl_url": "https://bugzil.la/1917963"
               },
               "firefox_android": "mirror",

--- a/http/headers/Available-Dictionary.json
+++ b/http/headers/Available-Dictionary.json
@@ -15,7 +15,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "145",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.http.dictionaries.enable",
+                  "value_to_set": "true"
+                }
+              ],
               "impl_url": "https://bugzil.la/1917974"
             },
             "firefox_android": "mirror",

--- a/http/headers/Available-Dictionary.json
+++ b/http/headers/Available-Dictionary.json
@@ -14,17 +14,23 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "145",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "network.http.dictionaries.enable",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1917974"
-            },
+            "firefox": [
+              {
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1882979"
+              },
+              {
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1917974"
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -97,17 +97,23 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "145",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "network.http.dictionaries.enable",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1917965"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview",
+                  "impl_url": "https://bugzil.la/1882979"
+                },
+                {
+                  "version_added": "145",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.http.dictionaries.enable",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1917965"
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
@@ -140,17 +146,23 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "145",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "network.http.dictionaries.enable",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/1917965"
-              },
+              "firefox": [
+                {
+                  "version_added": "preview",
+                  "impl_url": "https://bugzil.la/1882979"
+                },
+                {
+                  "version_added": "145",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "network.http.dictionaries.enable",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1917965"
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",

--- a/http/headers/Content-Encoding.json
+++ b/http/headers/Content-Encoding.json
@@ -98,7 +98,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
                 "impl_url": "https://bugzil.la/1917965"
               },
               "firefox_android": "mirror",
@@ -134,7 +141,14 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
                 "impl_url": "https://bugzil.la/1917965"
               },
               "firefox_android": "mirror",

--- a/http/headers/Dictionary-ID.json
+++ b/http/headers/Dictionary-ID.json
@@ -14,17 +14,23 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "145",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "network.http.dictionaries.enable",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1917979"
-            },
+            "firefox": [
+              {
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1882979"
+              },
+              {
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1917979"
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",

--- a/http/headers/Dictionary-ID.json
+++ b/http/headers/Dictionary-ID.json
@@ -15,7 +15,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "145",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.http.dictionaries.enable",
+                  "value_to_set": "true"
+                }
+              ],
               "impl_url": "https://bugzil.la/1917979"
             },
             "firefox_android": "mirror",

--- a/http/headers/Use-As-Dictionary.json
+++ b/http/headers/Use-As-Dictionary.json
@@ -15,7 +15,14 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
+              "version_added": "145",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "network.http.dictionaries.enable",
+                  "value_to_set": "true"
+                }
+              ],
               "impl_url": "https://bugzil.la/1917982"
             },
             "firefox_android": "mirror",

--- a/http/headers/Use-As-Dictionary.json
+++ b/http/headers/Use-As-Dictionary.json
@@ -14,17 +14,23 @@
             },
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "version_added": "145",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "network.http.dictionaries.enable",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/1917982"
-            },
+            "firefox": [
+              {
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/1882979"
+              },
+              {
+                "version_added": "145",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "network.http.dictionaries.enable",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/1917982"
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
StaticPrefList.yaml:
[`FIREFOX_RELEASE_145_END`](https://github.com/mozilla-firefox/firefox/blob/FIREFOX_RELEASE_145_END/modules/libpref/init/StaticPrefList.yaml#L15756-L15760) network.http.dictionaries.enable = false
[`FIREFOX_RELEASE_146_END`](https://github.com/mozilla-firefox/firefox/blob/FIREFOX_RELEASE_146_END/modules/libpref/init/StaticPrefList.yaml#L15759-L15763) network.http.dictionaries.enable = nightly only
[`FIREFOX_147_0_0_RELEASE`](https://github.com/mozilla-firefox/firefox/blob/FIREFOX_147_0_RELEASE/modules/libpref/init/StaticPrefList.yaml#L15901-L15905) network.http.dictionaries.enable = true
[`FIREFOX_147_0_1_RELEASE`](https://github.com/mozilla-firefox/firefox/blob/FIREFOX_147_0_1_RELEASE/modules/libpref/init/StaticPrefList.yaml#L15902-L15906) network.http.dictionaries.enable = false
[`FIREFOX_RELEASE_151_END`](https://github.com/mozilla-firefox/firefox/blob/FIREFOX_RELEASE_151_END/modules/libpref/init/StaticPrefList.yaml#L16342-L16346) network.http.dictionaries.enable = nightly only
[`FIREFOX_NIGHTLY_154_END`](https://github.com/mozilla-firefox/firefox/blob/FIREFOX_NIGHTLY_154_END/modules/libpref/init/StaticPrefList.yaml#L17197-L17201) network.http.dictionaries.enable = nightly only

Ref:
[RFC 9842](https://datatracker.ietf.org/doc/html/rfc9842) Compression Dictionary Transport
[Bug 1882979](https://bugzilla.mozilla.org/show_bug.cgi?id=1882979) [meta] Compression Dictionary Transport
[Bug 1917970](https://bugzilla.mozilla.org/show_bug.cgi?id=1917970) Implement compression dictionaries for brotli and zstd (firefox145)
[canicompress.com](https://canicompress.com/) Cloudflare test site
[caniuse.com](https://caniuse.com/wf-compression-dictionary-transport) ("child support tables")
[developer.mozilla.org](https://developer.mozilla.org/docs/Web/HTTP/Guides/Compression_dictionary_transport#browser_compatibility) MDN

