### PR TITLE
Change `CompressionStream` brotli compression to standard_track

### DIFF
--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -139,7 +139,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -98,7 +98,7 @@
         "brotli": {
           "__compat": {
             "description": "\"brotli\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-brotli",
             "tags": [
               "web-features:compression-streams"
             ],
@@ -148,7 +148,7 @@
         "deflate": {
           "__compat": {
             "description": "\"deflate\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-deflate",
             "tags": [
               "web-features:compression-streams"
             ],
@@ -191,7 +191,7 @@
         "deflate-raw": {
           "__compat": {
             "description": "\"deflate-raw\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-deflate-raw",
             "tags": [
               "web-features:compression-streams"
             ],
@@ -240,7 +240,7 @@
         "gzip": {
           "__compat": {
             "description": "\"gzip\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-gzip",
             "tags": [
               "web-features:compression-streams"
             ],

--- a/api/CompressionStream.json
+++ b/api/CompressionStream.json
@@ -98,6 +98,7 @@
         "brotli": {
           "__compat": {
             "description": "\"brotli\" compression",
+            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
             "tags": [
               "web-features:compression-streams"
             ],

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -139,7 +139,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -98,7 +98,7 @@
         "brotli": {
           "__compat": {
             "description": "\"brotli\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-brotli",
             "tags": [
               "web-features:compression-streams"
             ],
@@ -148,7 +148,7 @@
         "deflate": {
           "__compat": {
             "description": "\"deflate\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-deflate",
             "tags": [
               "web-features:compression-streams"
             ],
@@ -191,7 +191,7 @@
         "deflate-raw": {
           "__compat": {
             "description": "\"deflate-raw\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-deflate-raw",
             "tags": [
               "web-features:compression-streams"
             ],
@@ -240,7 +240,7 @@
         "gzip": {
           "__compat": {
             "description": "\"gzip\" compression",
-            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
+            "spec_url": "https://compression.spec.whatwg.org/#dom-compressionformat-gzip",
             "tags": [
               "web-features:compression-streams"
             ],

--- a/api/DecompressionStream.json
+++ b/api/DecompressionStream.json
@@ -98,6 +98,7 @@
         "brotli": {
           "__compat": {
             "description": "\"brotli\" compression",
+            "spec_url": "https://compression.spec.whatwg.org/#supported-formats",
             "tags": [
               "web-features:compression-streams"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Change CompressionStream brotli standard_track to true

See https://compression.spec.whatwg.org/#supported-formats

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

None

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/whatwg/compression/issues/34
- https://github.com/whatwg/compression/pull/80


<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
