### PR TITLE
Sanitizer.removeUnsafe() removes base element

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6292,7 +6292,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "148",
+              "notes": "The `<base>` element is not removed from a configuration's allowlist, potentially allowing manipulation of a document's relative URLs. See [whatwg/html#12664](https://github.com/whatwg/html/pull/12664)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -10837,12 +10837,16 @@
           "support": {
             "chrome": {
               "version_added": "146",
-              "notes": "Chrome 105 to Chrome 118 (inclusive) supported this method with a significantly different specification."
+              "notes": [
+                "Chrome 105 to Chrome 118 (inclusive) supported this method with a significantly different specification.",
+                "Before version 153, the `<base>` element was not removed from a configuration's allowlist, which could manipulate a document's relative URLs. See [whatwg/html#12664](https://github.com/whatwg/html/pull/12664)."
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "148",
+              "notes": "The `<base>` element is not removed from a configuration's allowlist, potentially allowing manipulation of a document's relative URLs. See [whatwg/html#12664](https://github.com/whatwg/html/pull/12664)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -341,6 +341,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "removes_base_element": {
+          "__compat": {
+            "description": "`<base>` element removed.",
+            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-base-element",
+            "tags": [
+              "web-features:sanitizer"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "152"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "replaceElementWithChildren": {

--- a/api/Sanitizer.json
+++ b/api/Sanitizer.json
@@ -317,12 +317,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "146"
+              "version_added": "146",
+              "notes": "Before version 153, the `<base>` element was not removed from a configuration's allowlist, which could manipulate a document's relative URLs. See [whatwg/html#12664](https://github.com/whatwg/html/pull/12664)."
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "148",
+              "notes": "The `<base>` element is not removed from a configuration's allowlist, potentially allowing manipulation of a document's relative URLs. See [whatwg/html#12664](https://github.com/whatwg/html/pull/12664)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -340,41 +342,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "removes_base_element": {
-          "__compat": {
-            "description": "`<base>` element removed.",
-            "spec_url": "https://html.spec.whatwg.org/multipage/semantics.html#the-base-element",
-            "tags": [
-              "web-features:sanitizer"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "152"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
-            }
           }
         }
       },

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -823,7 +823,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "148"
+              "version_added": "148",
+              "notes": "The `<base>` element is not removed from a configuration's allowlist, potentially allowing manipulation of a document's relative URLs. See [whatwg/html#12664](https://github.com/whatwg/html/pull/12664)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
The `<base>` element is now marked unsafe in the sanitizer API  

This updates `Sanitizer.removeUnsafe()` with a subfeature to add when support for removing `<base>` was added. Currently I can see this is Chrome 152 in https://chromiumdash.appspot.com/commits?commit=fd1d0b21860135ab53cea8f5eeffde970eeea0ee&platform=Windows . I don't have visibility of the FF issue but I assume it is not fixed yet https://bugzilla.mozilla.org/show_bug.cgi?id=2046748


Related docs work/issues
- https://github.com/mdn/content/issues/44673
- https://github.com/mdn/content/pull/44697