### PR TITLE
FF153 JS Source phase imports

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1886,6 +1886,47 @@
             }
           }
         },
+        "import_source": {
+          "__compat": {
+            "description": "Source phase imports (`import source` syntax)",
+            "spec_url": "https://tc39.es/proposal-source-phase-imports/#prod-ImportCall",
+            "support": {
+              "bun": {
+                "version_added": false
+              },
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "deno": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "nodejs": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "service_worker_support": {
           "__compat": {
             "description": "Available in service workers",

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1889,7 +1889,7 @@
         "import_source": {
           "__compat": {
             "description": "Source phase imports (`import source` syntax)",
-            "spec_url": "https://tc39.es/proposal-source-phase-imports/#prod-ImportCall",
+            "spec_url": "https://tc39.es/proposal-source-phase-imports/#sec-import-calls",
             "support": {
               "bun": {
                 "version_added": false


### PR DESCRIPTION
FF153 supports the `import source` syntax in https://bugzilla.mozilla.org/show_bug.cgi?id=2043242. 

This syntax is intended to allow importing WASM modules as source for later compilation in code, and in https://github.com/tc39/proposal-source-phase-imports for similarly importing JS modules. 
As per https://bugzilla.mozilla.org/show_bug.cgi?id=2043242#c15 it isn't yet very useful yet because while the syntax is implemented, the ability to import WASM is only available on nightly and behind a pref.

This adds the subfeature:
- Chrome doesn't yet have an implementation https://cr-status.appspot.com/feature/5796131906519040. No evidence that others do either
- I've set what looks like a reasonable spec URL. Does it work for you? If so we can talk to web spec people since it was giving me an error before.
- I haven't updated the dynamic `import()` syntax even though it mirrors this, because we don't appear to do that for similar things.
- When we support WASM or JS this will actually become useful. We should perhaps add a note for FF to indicate that? Any suggestions as to what?

Related docs work can be tracked in https://github.com/mdn/content/issues/44475
