### PR TITLE
Chrome 148 language-model Permissions-Policy

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -841,6 +841,50 @@
             }
           }
         },
+        "language-model": {
+          "__compat": {
+            "spec_url": "https://webmachinelearning.github.io/prompt-api/#permissions-policy",
+            "support": {
+              "chrome": {
+                "version_added": "148"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": "138",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#edge-llm-prompt-api-for-phi-mini",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "local-fonts": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/local-fonts",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 148 desktop adds support for the Prompt API: see https://chromestatus.com/feature/5134603979063296.

The `LanguageModel` interface already has BCD — see https://github.com/mdn/browser-compat-data/blob/main/api/LanguageModel.json — but we missed the corresponding `Permissions-Policy` `language-model` directive.

This PR adds a data point for that directive.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
