### PR TITLE
feat: add QUERY method to http standard

### DIFF
--- a/http/methods.json
+++ b/http/methods.json
@@ -286,6 +286,46 @@
             "deprecated": false
           }
         }
+      },
+      "QUERY": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/QUERY",
+          "spec_url": "https://httpwg.org/specs/rfc10008.html#QUERY",
+          "tags": [
+            "web-features:http11"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "≤11"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
#### Summary

Query method is added by RFC 10008, **https://datatracker.ietf.org/doc/html/rfc10008**
Here the pull request when it lands at httpwg and mozilla.org
