### PR TITLE
Split up `position-visibility: anchors-{valid,visible}` from their non-deprecated counterparts

### DIFF
--- a/css/properties/position-visibility.json
+++ b/css/properties/position-visibility.json
@@ -79,22 +79,15 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "alternative_name": "anchors-valid",
-                "version_added": "147"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "27"
-                },
-                {
-                  "alternative_name": "anchors-valid",
-                  "version_added": "26.2"
-                }
-              ],
+              "safari": {
+                "version_added": "27"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -112,28 +105,20 @@
             "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-visibility-anchor-visible",
             "support": {
               "chrome": {
-                "alternative_name": "anchors-visible",
-                "version_added": "125"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "alternative_name": "anchors-visible",
-                "version_added": "147"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
-              "safari": [
-                {
-                  "version_added": "27"
-                },
-                {
-                  "alternative_name": "anchors-visible",
-                  "version_added": "26.2"
-                }
-              ],
+              "safari": {
+                "version_added": "27"
+              },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
@@ -143,6 +128,68 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          }
+        },
+        "anchors-valid": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-visibility-anchor-visible:~:text=anchors%2Dvalid",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "147"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
+            }
+          }
+        },
+        "anchors-visible": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#valdef-position-visibility-anchor-visible:~:text=anchors%2Dvisible",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "147"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.2"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": true
             }
           }
         },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

More or less revert https://github.com/mdn/browser-compat-data/pull/29979.

#### Test results and supporting details

These aren't alternative names, they're spec'd aliases. To be able to create a deprecation feature in web-features, I need separate keys for them with the appropriate metadata.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- https://github.com/web-platform-dx/web-features/issues/3558#issuecomment-4979751091
- https://github.com/mdn/browser-compat-data/issues/29950

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
