### PR TITLE
Safari doesn't support createElement's `is` option

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -2213,7 +2213,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": "26"
+                  "version_added": false
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

See https://github.com/WebKit/WebKit/pull/59594#pullrequestreview-3868699049

#### Test results and supporting details

Collector tests were wrong, fixed them now.

#### Related issues

https://github.com/openwebdocs/mdn-bcd-collector/pull/3282