### PR TITLE
Chrome 146 supports Document.parseHTML + shadowroot.setHTML

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -6287,7 +6287,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "146"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Document.json
+++ b/api/Document.json
@@ -6307,7 +6307,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -838,7 +838,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -818,7 +818,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "146"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

Part of the Sanitizer API which we also marked shipping in Chrome 146.

#### Test results and supporting details

Discovered by the Collector (v20.0.3)
See also https://chromestatus.com/feature/5814067399491584

#### Related issues

Oversight in https://github.com/mdn/browser-compat-data/pull/29033