### PR TITLE
Safari 26 supports GPUDevice.adapterInfo

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -112,7 +112,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "26"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Safari 26 supports GPUDevice.adapterInfo

#### Test results and supporting details

Discovered by the collector v10.20.3

#### Related issues

Probably an oversight in https://github.com/mdn/browser-compat-data/pull/27087