### PR TITLE
[Wasm] Add data for WebAssembly.SuspendError

### DIFF
--- a/webassembly/api/SuspendError.json
+++ b/webassembly/api/SuspendError.json
@@ -1,0 +1,81 @@
+{
+  "webassembly": {
+    "api": {
+      "SuspendError": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/SuspendError",
+          "spec_url": "https://webassembly.github.io/js-promise-integration/js-api/#exceptiondef-suspenderror",
+          "tags": [
+            "web-features:wasm"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "153"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "SuspendError": {
+          "__compat": {
+            "description": "`SuspendError()` constructor",
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/SuspendError/SuspendError",
+            "spec_url": "https://webassembly.github.io/js-promise-integration/js-api/#exceptiondef-suspenderror",
+            "tags": [
+              "web-features:wasm"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "153"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/api/SuspendError.json
+++ b/webassembly/api/SuspendError.json
@@ -6,7 +6,7 @@
           "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/SuspendError",
           "spec_url": "https://webassembly.github.io/js-promise-integration/js-api/#exceptiondef-suspenderror",
           "tags": [
-            "web-features:wasm"
+            "web-features:wasm-jspi"
           ],
           "support": {
             "chrome": {
@@ -43,7 +43,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/JavaScript_interface/SuspendError/SuspendError",
             "spec_url": "https://webassembly.github.io/js-promise-integration/js-api/#exceptiondef-suspenderror",
             "tags": [
-              "web-features:wasm"
+              "web-features:wasm-jspi"
             ],
             "support": {
               "chrome": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

When the BCD for WebAssembly Promise integration was added (see https://github.com/mdn/browser-compat-data/pull/29783), we forgot to add data for the [`WebAssembly.SuspendError`](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/JavaScript_interface/SuspendError#specifications)  interface.

This PR fixes that.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
