### PR TITLE
Add granular BCD for Wasm value types

### DIFF
--- a/webassembly/types/exnref.json
+++ b/webassembly/types/exnref.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "types": {
+      "exnref": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/exnref",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#reference-types%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "131"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/externref.json
+++ b/webassembly/types/externref.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "types": {
+      "externref": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/externref",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#reference-types%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "96"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/f32.json
+++ b/webassembly/types/f32.json
@@ -1,0 +1,49 @@
+{
+  "webassembly": {
+    "types": {
+      "f32": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/f32",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#number-types%E2%91%A0",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/f64.json
+++ b/webassembly/types/f64.json
@@ -1,0 +1,49 @@
+{
+  "webassembly": {
+    "types": {
+      "f64": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/f64",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#number-types%E2%91%A0",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/funcref.json
+++ b/webassembly/types/funcref.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "types": {
+      "funcref": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/funcref",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#reference-types%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "96"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/i32.json
+++ b/webassembly/types/i32.json
@@ -1,0 +1,49 @@
+{
+  "webassembly": {
+    "types": {
+      "i32": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/i32",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#number-types%E2%91%A0",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/i64.json
+++ b/webassembly/types/i64.json
@@ -1,0 +1,49 @@
+{
+  "webassembly": {
+    "types": {
+      "i64": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/i64",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#number-types%E2%91%A0",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/types/v128.json
+++ b/webassembly/types/v128.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "types": {
+      "v128": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Value_types/v128",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-types%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all of the [Wasm value types](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Value_types).

- `i32`/`i64`/`f32`/`f64` have all been supported since the start, so they've been given the same support data as other "original" features, such as webassembly.api.Table.
- `externref` and `funcref` are part of the reference type proposal, so have been given the same data as found in webassembly.reference-types.
- `exnref` is part of the newest exception handling proposal, so has been given the same data as found in webassembly.exceptionsFinal
- `v128` is part of the original SIMD proposal, so has been given the same data as found in webassembly.fixed-width-SIMD.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
