### PR TITLE
Add granular data for Wasm definitions

### DIFF
--- a/webassembly/definitions/func.json
+++ b/webassembly/definitions/func.json
@@ -1,0 +1,49 @@
+{
+  "webassembly": {
+    "definitions": {
+      "func": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Definitions/types/func",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#composite-types%E2%91%A2",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/definitions/table.json
+++ b/webassembly/definitions/table.json
@@ -1,0 +1,49 @@
+{
+  "webassembly": {
+    "definitions": {
+      "table": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Definitions/table",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#table-types%E2%91%A0",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/definitions/tag.json
+++ b/webassembly/definitions/tag.json
@@ -6,23 +6,29 @@
           "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Definitions/tag",
           "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#tag-types%E2%91%A0",
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
-              "version_added": "137"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "16",
-              "version_removed": "79"
+            "deno": {
+              "version_added": "1.15"
             },
+            "edge": "mirror",
             "firefox": {
-              "version_added": "131"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "17.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "15.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/definitions/tag.json
+++ b/webassembly/definitions/tag.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "definitions": {
+      "tag": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Definitions/tag",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#tag-types%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "131"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all of the [Wasm definitions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Definitions).

- `func` and `table` have been supported since the start, so they've been given the same support data as other "original" features, such as webassembly.api.Table.
- `tag` is part of the newest exception handling proposal, so has been given the same data as found in webassembly.exceptionsFinal

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
