### PR TITLE
Updates for Firefox Android

### DIFF
--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -266,7 +266,9 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "141"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/DataTransferItem.json
+++ b/api/DataTransferItem.json
@@ -266,9 +266,7 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": {
-              "version_added": false
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/EXT_shader_texture_lod.json
+++ b/api/EXT_shader_texture_lod.json
@@ -25,7 +25,7 @@
             "version_added": "47"
           },
           "firefox_android": {
-            "version_added": false
+            "version_added": "67"
           },
           "oculus": "mirror",
           "opera": "mirror",

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -26,9 +26,7 @@
           "firefox": {
             "version_added": "65"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3252,7 +3252,7 @@
               "version_added": "50"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": "145"
             },
             "oculus": "mirror",
             "opera": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3251,7 +3251,9 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": "mirror",
+            "firefox_android": {
+              "version_added": "141"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/HTMLInputElement.json
+++ b/api/HTMLInputElement.json
@@ -3251,9 +3251,7 @@
             "firefox": {
               "version_added": "50"
             },
-            "firefox_android": {
-              "version_added": "145"
-            },
+            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/OES_texture_half_float_linear.json
+++ b/api/OES_texture_half_float_linear.json
@@ -18,9 +18,7 @@
           "firefox": {
             "version_added": "30"
           },
-          "firefox_android": {
-            "version_added": false
-          },
+          "firefox_android": "mirror",
           "oculus": "mirror",
           "opera": "mirror",
           "opera_android": "mirror",

--- a/api/Request.json
+++ b/api/Request.json
@@ -951,9 +951,7 @@
               "firefox": {
                 "version_added": "50"
               },
-              "firefox_android": {
-                "version_added": false
-              },
+              "firefox_android": "mirror",
               "nodejs": {
                 "version_added": "18.0.0"
               },


### PR DESCRIPTION
#### Summary

Results from a collector run (v10.20.3) in Firefox Android 145.

#### Test results and supporting details

- webkitGetAsEntry: I see no reason why it wouldn't be supported as well.
- EXT_shader_texture_lod: I think this got working as part of https://github.com/webcompat/web-bugs/issues/26281 and https://bugzilla.mozilla.org/show_bug.cgi?id=1524804
- EXT_texture_compression_rgtc, I think this also works on Android, following up on https://github.com/mdn/browser-compat-data/pull/29679
- OES_texture_float_linear: seeing no hints why it wouldn't work on android as well
- Request only-if-cached: seeing no hints why it wouldn't work on android as well

This will advance some web-features to Baseline /cc @ddbeck 