### PR TITLE
Updates for Chrome Android 145

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -4114,8 +4114,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13"
@@ -6631,8 +6630,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13"
@@ -6680,8 +6678,7 @@
               "version_added": "37"
             },
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13"
@@ -6740,8 +6737,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13"

--- a/api/Element.json
+++ b/api/Element.json
@@ -9085,8 +9085,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13",
@@ -9144,8 +9143,7 @@
                 "notes": "Supported on macOS Catalina 10.15.1+, Windows, and ChromeOS. Not yet supported on Linux."
               },
               "chrome_android": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/40290045"
+                "version_added": "144"
               },
               "edge": "mirror",
               "firefox": {

--- a/api/MouseEvent.json
+++ b/api/MouseEvent.json
@@ -596,8 +596,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13"
@@ -669,8 +668,7 @@
               }
             ],
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": {
               "version_added": "13"

--- a/api/Request.json
+++ b/api/Request.json
@@ -1257,9 +1257,7 @@
             "chrome": {
               "version_added": "131"
             },
-            "chrome_android": {
-              "version_added": false
-            },
+            "chrome_android": "mirror",
             "deno": {
               "version_added": false
             },

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -686,8 +686,7 @@
               "version_added": "53"
             },
             "chrome_android": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40290045"
+              "version_added": "144"
             },
             "edge": "mirror",
             "firefox": {

--- a/html/elements/iframe.json
+++ b/html/elements/iframe.json
@@ -2302,8 +2302,7 @@
                   "version_added": "23"
                 },
                 "chrome_android": {
-                  "version_added": false,
-                  "impl_url": "https://crbug.com/40290045"
+                  "version_added": "144"
                 },
                 "edge": "mirror",
                 "firefox": {

--- a/webassembly/jspi.json
+++ b/webassembly/jspi.json
@@ -11,9 +11,7 @@
           "chrome": {
             "version_added": "137"
           },
-          "chrome_android": {
-            "version_added": false
-          },
+          "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
             "version_added": "153"


### PR DESCRIPTION
#### Summary

Results from a collector run (v10.20.3) in Chrome Android 145.

#### Test results and supporting details

The most important update is Pointer Lock on Android in 144: https://chromestatus.com/feature/6739764319485952

For JSPI and Request.duplex, mirror makes sense to me, as a I have no hints why it wouldn't be also supported on Android.