### PR TITLE
Add granular data for Wasm exception handling instructions

### DIFF
--- a/webassembly/instructions/throw.json
+++ b/webassembly/instructions/throw.json
@@ -6,23 +6,29 @@
           "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/throw",
           "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfthrowx%E2%91%A0",
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
-              "version_added": "137"
+              "version_added": "95"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "16",
-              "version_removed": "79"
+            "deno": {
+              "version_added": "1.15"
             },
+            "edge": "mirror",
             "firefox": {
-              "version_added": "131"
+              "version_added": "100"
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "17.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "18.4"
+              "version_added": "15.2"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/throw.json
+++ b/webassembly/instructions/throw.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "instructions": {
+      "throw": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/throw",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfthrowx%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "131"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/throw_ref.json
+++ b/webassembly/instructions/throw_ref.json
@@ -10,10 +10,15 @@
               "version_added": "137"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "16",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "137"
+              },
+              {
+                "version_added": "16",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "131"
             },

--- a/webassembly/instructions/throw_ref.json
+++ b/webassembly/instructions/throw_ref.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "instructions": {
+      "throw_ref": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/throw_ref",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfthrow_ref%E2%91%A0",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "131"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/try_table.json
+++ b/webassembly/instructions/try_table.json
@@ -1,0 +1,181 @@
+{
+  "webassembly": {
+    "instructions": {
+      "try_table": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/try_table",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsftry_tablemathitbthrefsyntax-catchmathitcatchasthrefsyntax-instrmathitinstrast",
+          "support": {
+            "chrome": {
+              "version_added": "137"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "16",
+              "version_removed": "79"
+            },
+            "firefox": {
+              "version_added": "131"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "18.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "catch": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/try_table/catch",
+            "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfcatchxl",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "16",
+                "version_removed": "79"
+              },
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "catch_all": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/try_table/catch_all",
+            "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfcatch_alll",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "16",
+                "version_removed": "79"
+              },
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "catch_all_ref": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/try_table/catch_all_ref",
+            "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfcatch_all_refl",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "16",
+                "version_removed": "79"
+              },
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "catch_ref": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Exception_handling/try_table/catch_ref",
+            "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-controlmathsfcatch_refxl",
+            "support": {
+              "chrome": {
+                "version_added": "137"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "16",
+                "version_removed": "79"
+              },
+              "firefox": {
+                "version_added": "131"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/try_table.json
+++ b/webassembly/instructions/try_table.json
@@ -10,10 +10,15 @@
               "version_added": "137"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "16",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "137"
+              },
+              {
+                "version_added": "16",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "131"
             },
@@ -44,10 +49,15 @@
                 "version_added": "137"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "16",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "137"
+                },
+                {
+                  "version_added": "16",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "131"
               },
@@ -79,10 +89,15 @@
                 "version_added": "137"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "16",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "137"
+                },
+                {
+                  "version_added": "16",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "131"
               },
@@ -114,10 +129,15 @@
                 "version_added": "137"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "16",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "137"
+                },
+                {
+                  "version_added": "16",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "131"
               },
@@ -149,10 +169,15 @@
                 "version_added": "137"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "16",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "137"
+                },
+                {
+                  "version_added": "16",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "131"
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all [Wasm exception-handling instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Exception_handling).

I'm pretty sure these were all added as part of the final exceptions proposal, so I've made the data the same as in webassembly.exceptionsFinal.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
