### PR TITLE
Add granular data for Wasm memory instructions

### DIFF
--- a/webassembly/instructions/memory_copy.json
+++ b/webassembly/instructions/memory_copy.json
@@ -1,0 +1,71 @@
+{
+  "webassembly": {
+    "instructions": {
+      "memory_copy": {
+        "__compat": {
+          "description": "memory.copy",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/copy",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemorycopyx_1x_2",
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "78"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multi_memory": {
+          "__compat": {
+            "description": "multi-memory",
+            "spec_url": "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/memory_copy.json
+++ b/webassembly/instructions/memory_copy.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "78"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/webassembly/instructions/memory_fill.json
+++ b/webassembly/instructions/memory_fill.json
@@ -13,7 +13,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "78"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/webassembly/instructions/memory_fill.json
+++ b/webassembly/instructions/memory_fill.json
@@ -1,0 +1,71 @@
+{
+  "webassembly": {
+    "instructions": {
+      "memory_fill": {
+        "__compat": {
+          "description": "memory.fill",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/fill",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemoryfillx",
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "78"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multi_memory": {
+          "__compat": {
+            "description": "multi-memory",
+            "spec_url": "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/memory_grow.json
+++ b/webassembly/instructions/memory_grow.json
@@ -1,0 +1,82 @@
+{
+  "webassembly": {
+    "instructions": {
+      "memory_grow": {
+        "__compat": {
+          "description": "memory.grow",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/grow",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemorygrowx",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multi_memory": {
+          "__compat": {
+            "description": "multi-memory",
+            "spec_url": "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/memory_load.json
+++ b/webassembly/instructions/memory_load.json
@@ -1,0 +1,82 @@
+{
+  "webassembly": {
+    "instructions": {
+      "memory_load": {
+        "__compat": {
+          "description": "memory.load",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/load",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#memory-instructions%E2%91%A8",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multi_memory": {
+          "__compat": {
+            "description": "multi-memory",
+            "spec_url": "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/memory_size.json
+++ b/webassembly/instructions/memory_size.json
@@ -1,0 +1,82 @@
+{
+  "webassembly": {
+    "instructions": {
+      "memory_size": {
+        "__compat": {
+          "description": "memory.size",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/size",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemorysizex",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multi_memory": {
+          "__compat": {
+            "description": "multi-memory",
+            "spec_url": "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/memory_store.json
+++ b/webassembly/instructions/memory_store.json
@@ -1,0 +1,82 @@
+{
+  "webassembly": {
+    "instructions": {
+      "memory_store": {
+        "__compat": {
+          "description": "memory.store",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/store",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#memory-instructions%E2%91%A8",
+          "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
+            "chrome": {
+              "version_added": "57"
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
+            "firefox": {
+              "version_added": "52"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "11"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "multi_memory": {
+          "__compat": {
+            "description": "multi-memory",
+            "spec_url": "https://github.com/WebAssembly/multi-memory/blob/main/proposals/multi-memory/Overview.md",
+            "support": {
+              "chrome": {
+                "version_added": "120"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "125"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all [Wasm memory instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Memory).

Each of these has:

- A main data point equivalent to "original" support data (e.g. same as webassembly.api.memory) or webassembly.bulk-memory-operations, depending on when it was first supported.
- A sub-data point for multi-memory, equivalent to the data for webassembly.multiMemory.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
