### PR TITLE
chore(eslint): resolve and enforce `jsdoc/require-*` ESLint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -114,7 +114,15 @@ export default [
       ],
       'jsdoc/check-param-names': 'error',
       'jsdoc/prefer-import-tag': 'error',
-      'jsdoc/require-description': 'warn',
+      // Kept as a warning until the remaining `@param {*}`/`{any}` types are replaced.
+      'jsdoc/reject-any-type': 'warn',
+      'jsdoc/require-description': 'error',
+      'jsdoc/require-param-description': 'error',
+      'jsdoc/require-param-type': 'error',
+      'jsdoc/require-property-description': 'error',
+      'jsdoc/require-returns-description': 'error',
+      'jsdoc/require-returns-type': 'error',
+      'jsdoc/require-throws-type': 'error',
 
       'jsdoc/require-jsdoc': [
         'warn',

--- a/lint/common/spec-urls-exceptions.js
+++ b/lint/common/spec-urls-exceptions.js
@@ -8,7 +8,7 @@ const __dirname = dirname(__filename);
 export const exceptionListPath = join(__dirname, './spec-urls-exceptions.txt');
 
 /**
- * @returns {Promise<string[]>}
+ * @returns {Promise<string[]>} The list of spec URL exceptions
  */
 export const getSpecURLsExceptions = async () =>
   (await readFile(exceptionListPath, 'utf-8'))

--- a/lint/common/spec-urls-exceptions.js
+++ b/lint/common/spec-urls-exceptions.js
@@ -8,6 +8,7 @@ const __dirname = dirname(__filename);
 export const exceptionListPath = join(__dirname, './spec-urls-exceptions.txt');
 
 /**
+ * Get the list of spec URL exceptions
  * @returns {Promise<string[]>} The list of spec URL exceptions
  */
 export const getSpecURLsExceptions = async () =>

--- a/lint/common/standard-track-exceptions.js
+++ b/lint/common/standard-track-exceptions.js
@@ -21,7 +21,7 @@ export const getStandardTrackExceptions = async () =>
 
 /**
  *
- * @param {Iterable<string>} features
+ * @param {Iterable<string>} features The features to set as exceptions
  */
 export const setStandardTrackExceptions = async (features) => {
   const lines = (await readFile(exceptionListPath, 'utf-8'))

--- a/lint/common/standard-track-exceptions.js
+++ b/lint/common/standard-track-exceptions.js
@@ -11,7 +11,7 @@ export const exceptionListPath = join(
 );
 
 /**
- * @returns {Promise<string[]>}
+ * @returns {Promise<string[]>} The list of standard track exceptions
  */
 export const getStandardTrackExceptions = async () =>
   (await readFile(exceptionListPath, 'utf-8'))

--- a/lint/common/standard-track-exceptions.js
+++ b/lint/common/standard-track-exceptions.js
@@ -11,6 +11,7 @@ export const exceptionListPath = join(
 );
 
 /**
+ * Get the list of standard track exceptions
  * @returns {Promise<string[]>} The list of standard track exceptions
  */
 export const getStandardTrackExceptions = async () =>
@@ -20,7 +21,7 @@ export const getStandardTrackExceptions = async () =>
     .filter((line) => line.length > 0 && !line.startsWith('#'));
 
 /**
- *
+ * Set the list of standard track exceptions
  * @param {Iterable<string>} features The features to set as exceptions
  */
 export const setStandardTrackExceptions = async (features) => {

--- a/lint/fixer/browser-order.js
+++ b/lint/fixer/browser-order.js
@@ -23,7 +23,7 @@ export const orderSupportBlock = (key, value) => {
         /**
          * @param {InternalSupportBlock} result The accumulated support block
          * @param {BrowserName} key The browser name to add
-         * @returns {InternalSupportBlock}
+         * @returns {InternalSupportBlock} The support block with the browser added
          */
         (result, key) => {
           result[key] = value.support[key];

--- a/lint/fixer/browser-order.js
+++ b/lint/fixer/browser-order.js
@@ -21,6 +21,7 @@ export const orderSupportBlock = (key, value) => {
       .sort()
       .reduce(
         /**
+         * Add a browser's support to the ordered support block
          * @param {InternalSupportBlock} result The accumulated support block
          * @param {BrowserName} key The browser name to add
          * @returns {InternalSupportBlock} The support block with the browser added

--- a/lint/fixer/browser-order.js
+++ b/lint/fixer/browser-order.js
@@ -21,8 +21,8 @@ export const orderSupportBlock = (key, value) => {
       .sort()
       .reduce(
         /**
-         * @param {InternalSupportBlock} result
-         * @param {BrowserName} key
+         * @param {InternalSupportBlock} result The accumulated support block
+         * @param {BrowserName} key The browser name to add
          * @returns {InternalSupportBlock}
          */
         (result, key) => {

--- a/lint/fixer/feature-order.js
+++ b/lint/fixer/feature-order.js
@@ -8,7 +8,7 @@ import compareFeatures from '../../scripts/lib/compare-features.js';
 /**
  * Check whether an object contains compat data anywhere in its subtree.
  * @param {object} obj - The object to check
- * @returns {boolean}
+ * @returns {boolean} Whether the object contains compat data
  */
 const hasCompatData = (obj) => {
   if (!obj || typeof obj !== 'object') {

--- a/lint/linter/test-consistency.js
+++ b/lint/linter/test-consistency.js
@@ -19,16 +19,16 @@ import bcd from '../../index.js';
 
 /**
  * @typedef {object} ConsistencyError
- * @property {string[]} path
- * @property {FeatureError[]} errors
+ * @property {string[]} path The path to the feature with the inconsistency
+ * @property {FeatureError[]} errors The consistency errors found for the feature
  */
 
 /**
  * @typedef {object} FeatureError
- * @property {ErrorType} type
- * @property {BrowserName} browser
- * @property {VersionValue} parentValue
- * @property {[string, VersionValue][]} subfeatures
+ * @property {ErrorType} type The type of inconsistency
+ * @property {BrowserName} browser The browser the inconsistency applies to
+ * @property {VersionValue} parentValue The support value of the parent feature
+ * @property {[string, VersionValue][]} subfeatures The subfeatures and their support values that are inconsistent with the parent
  */
 
 /**

--- a/lint/linter/test-descriptions.js
+++ b/lint/linter/test-descriptions.js
@@ -11,10 +11,10 @@ import { validateHTML } from './test-notes.js';
 
 /**
  * @typedef {object} DescriptionError
- * @property {string} path
- * @property {string} ruleName
- * @property {string} actual
- * @property {string} expected
+ * @property {string} path The feature path where the error was found
+ * @property {string} ruleName The name of the rule that was violated
+ * @property {string} actual The actual description
+ * @property {string} expected The expected description
  */
 
 /**

--- a/lint/linter/test-flags.js
+++ b/lint/linter/test-flags.js
@@ -11,8 +11,8 @@ import { compare } from 'compare-versions';
 
 /**
  * @typedef {object} FlagError
- * @property {FlagStatement[]} flagData
- * @property {BrowserName} browser
+ * @property {FlagStatement[]} flagData The irrelevant flag statements found
+ * @property {BrowserName} browser The browser the flag data applies to
  */
 
 /**

--- a/lint/linter/test-links.js
+++ b/lint/linter/test-links.js
@@ -10,11 +10,11 @@ import { IS_WINDOWS, indexToPos, indexToPosRaw } from '../utils.js';
 
 /**
  * @typedef {object} LinkError
- * @property {string} issue
- * @property {[number, number] | [null, null]} pos
- * @property {string} posString
- * @property {string} actual
- * @property {string} [expected]
+ * @property {string} issue The description of the issue
+ * @property {[number, number] | [null, null]} pos The line and column of the issue
+ * @property {string} posString The formatted position of the issue
+ * @property {string} actual The actual link
+ * @property {string} [expected] The expected link
  */
 
 /**

--- a/lint/linter/test-mdn-urls.js
+++ b/lint/linter/test-mdn-urls.js
@@ -12,10 +12,10 @@ import { inventory } from '../../utils/mdn-content-inventory.js';
 
 /**
  * @typedef {object} MDNURLError
- * @property {string} path
- * @property {string} ruleName
- * @property {string} actual
- * @property {string} expected
+ * @property {string} path The feature path where the error was found
+ * @property {string} ruleName The name of the rule that was violated
+ * @property {string} actual The actual MDN URL
+ * @property {string} expected The expected MDN URL
  */
 
 /** @type {Map<string, string>} path → mdn_url, persisted across calls */

--- a/lint/linter/test-mdn-urls.test.js
+++ b/lint/linter/test-mdn-urls.test.js
@@ -23,10 +23,10 @@ const originalRedirects = inventory.redirects;
 
 /**
  * Replace inventory with mock data, restoring originals in afterEach.
- * @param {object} [overrides]
- * @param {Map<string, string>} [overrides.slugs]
- * @param {Map<string, string>} [overrides.slugByPath]
- * @param {Record<string, string>} [overrides.redirects]
+ * @param {object} [overrides] The inventory values to override
+ * @param {Map<string, string>} [overrides.slugs] The mock slugs
+ * @param {Map<string, string>} [overrides.slugByPath] The mock slugs by path
+ * @param {Record<string, string>} [overrides.redirects] The mock redirects
  */
 const mockInventory = (overrides = {}) => {
   inventory.slugs = overrides.slugs ?? new Map();

--- a/lint/linter/test-spec-urls.test.js
+++ b/lint/linter/test-spec-urls.test.js
@@ -14,7 +14,7 @@ import specURLsLinter, { processData } from './test-spec-urls.js';
 /**
  * Build a fake xref lookup that reports the given URLs as valid.
  * @param {string[]} [validURLs] URLs the lookup should treat as existing
- * @returns {(url: string) => object[]}
+ * @returns {(url: string) => object[]} The mock xref lookup function
  */
 const mockLookup =
   (validURLs = []) =>
@@ -27,7 +27,7 @@ const mockLookup =
  * @param {object} [deps] Injected dependencies
  * @param {(url: string) => object[]} [deps.lookup] The mock xref lookup
  * @param {string[]} [deps.exceptions] The host exceptions
- * @returns {LinterMessage[]}
+ * @returns {LinterMessage[]} The logged messages
  */
 const run = (data, { lookup = mockLookup(), exceptions = [] } = {}) => {
   const logger = new Logger('Spec URLs', 'test.feature');

--- a/scripts/build/mirror.js
+++ b/scripts/build/mirror.js
@@ -69,7 +69,7 @@ const matchingSafariVersions = new Map([
  * @param {BrowserName} targetBrowser The browser to mirror to
  * @param {string} sourceVersion The version from the source browser
  * @returns {string | false} The matching browser version, or `false` if no match is found
- * @throws An error when the downstream browser has no upstream
+ * @throws {Error} An error when the downstream browser has no upstream
  */
 export const getMatchingBrowserVersion = (targetBrowser, sourceVersion) => {
   const browserData = bcd.browsers[targetBrowser];

--- a/scripts/build/mirror.test.js
+++ b/scripts/build/mirror.test.js
@@ -174,7 +174,10 @@ describe('mirror', () => {
     });
 
     describe('updateNotes', () => {
-      /** @type {(string) => (string | false)} */
+      /**
+       * Map a version to the next version, or false for the sentinel version
+       * @type {(string) => (string | false)}
+       */
       const versionMapper = (v) => (v === '99' ? false : String(Number(v) + 1));
       const regex = /\bChrome\b/g;
 

--- a/scripts/diff-flat.js
+++ b/scripts/diff-flat.js
@@ -617,7 +617,7 @@ if (esMain(import.meta)) {
       default: DEFAULT_FORMAT,
       choices: /** @type {Readonly<Format[]>} */ (FORMATS),
       /**
-       * @param {string} value
+       * @param {string} value The raw option value
        * @returns {Format}
        */
       coerce: (value) => FORMATS.find((f) => f === value) ?? DEFAULT_FORMAT,

--- a/scripts/diff-flat.js
+++ b/scripts/diff-flat.js
@@ -618,7 +618,7 @@ if (esMain(import.meta)) {
       choices: /** @type {Readonly<Format[]>} */ (FORMATS),
       /**
        * @param {string} value The raw option value
-       * @returns {Format}
+       * @returns {Format} The coerced format
        */
       coerce: (value) => FORMATS.find((f) => f === value) ?? DEFAULT_FORMAT,
     })

--- a/scripts/diff-flat.js
+++ b/scripts/diff-flat.js
@@ -617,6 +617,7 @@ if (esMain(import.meta)) {
       default: DEFAULT_FORMAT,
       choices: /** @type {Readonly<Format[]>} */ (FORMATS),
       /**
+       * Coerce the format option value
        * @param {string} value The raw option value
        * @returns {Format} The coerced format
        */

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -54,11 +54,11 @@ const stringifyChange = (lhs, rhs) =>
 /**
  * Perform mirroring on specified diff statement
  * @param {object} diff - The diff to perform mirroring on
- * @param {InternalSupportStatement} diff.base
- * @param {InternalSupportStatement} diff.head
+ * @param {InternalSupportStatement} diff.base - The support statement of the base side
+ * @param {InternalSupportStatement} diff.head - The support statement of the head side
  * @param {object} contents - The contents to mirror from
- * @param {InternalIdentifier} contents.base
- * @param {InternalIdentifier} contents.head
+ * @param {InternalIdentifier} contents.base - The identifier of the base side
+ * @param {InternalIdentifier} contents.head - The identifier of the head side
  * @param {string[]} path - The feature path to mirror
  * @param {'base' | 'head'} direction - Whether to mirror 'base' or 'head'
  */

--- a/scripts/diff.js
+++ b/scripts/diff.js
@@ -17,14 +17,14 @@ import mirror from './build/mirror.js';
 
 /**
  * @typedef {object} Contents
- * @property {string} base
- * @property {string} head
+ * @property {string} base The file contents at the base commit
+ * @property {string} head The file contents at the head commit
  */
 
 /**
  * @typedef {object} DiffItem
- * @property {string} name
- * @property {string} description
+ * @property {string} name The name of the changed feature
+ * @property {string} description The description of the change
  */
 
 /**

--- a/scripts/lib/git.js
+++ b/scripts/lib/git.js
@@ -5,9 +5,9 @@ import { spawn } from '../../utils/index.js';
 
 /**
  * @typedef {object} Fields
- * @property {string} value
- * @property {string} headPath
- * @property {string} basePath
+ * @property {string} value The status value of the change
+ * @property {string} headPath The file path at the head commit
+ * @property {string} basePath The file path at the base commit
  */
 
 /**

--- a/scripts/release/changes.js
+++ b/scripts/release/changes.js
@@ -3,16 +3,16 @@
 
 /**
  * @typedef {object} FeatureChange
- * @property {string} [mergeCommit]
- * @property {number} number
- * @property {string} url
- * @property {string} feature
+ * @property {string} [mergeCommit] The hash of the merge commit
+ * @property {number} number The pull request number
+ * @property {string} url The pull request URL
+ * @property {string} feature The feature that changed
  */
 
 /**
  * @typedef {object} Changes
- * @property {FeatureChange[]} added
- * @property {FeatureChange[]} removed
+ * @property {FeatureChange[]} added The features that were added
+ * @property {FeatureChange[]} removed The features that were removed
  */
 
 import { styleText } from 'node:util';

--- a/scripts/release/stats.js
+++ b/scripts/release/stats.js
@@ -3,16 +3,16 @@
 
 /**
  * @typedef {object} Stats
- * @property {number} commits
- * @property {number} changed
- * @property {number} insertions
- * @property {number} deletions
- * @property {number} releaseContributors
- * @property {number} totalContributors
- * @property {number} features
- * @property {number} stars
- * @property {string} start
- * @property {string} end
+ * @property {number} commits The number of commits in the release
+ * @property {number} changed The number of changed files
+ * @property {number} insertions The number of inserted lines
+ * @property {number} deletions The number of deleted lines
+ * @property {number} releaseContributors The number of contributors to the release
+ * @property {number} totalContributors The total number of contributors
+ * @property {number} features The number of features
+ * @property {number} stars The number of repository stargazers
+ * @property {string} start The start date of the release period
+ * @property {string} end The end date of the release period
  */
 
 /**

--- a/scripts/statistics.js
+++ b/scripts/statistics.js
@@ -16,9 +16,9 @@ import { getRefDate } from './release/utils.js';
 
 /**
  * @typedef {object} VersionStatsEntry
- * @property {number} all
- * @property {number} exact
- * @property {number} range
+ * @property {number} all The total number of version values
+ * @property {number} exact The number of exact version values
+ * @property {number} range The number of ranged version values
  */
 
 /**

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -235,7 +235,7 @@ if (esMain(import.meta)) {
         (b) => bcd.browsers[b].type !== 'server',
       ),
       /**
-       *
+       * Coerce the browsers option value
        * @param value The raw option value
        * @returns {BrowserName[]} The coerced browser names
        */

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -12,9 +12,9 @@ import bcd from '../index.js';
 
 /**
  * @typedef {object} StatusFilters
- * @property {boolean | undefined} deprecated
- * @property {boolean | undefined} standard_track
- * @property {boolean | undefined} experimental
+ * @property {boolean | undefined} deprecated Whether to filter by the deprecated status
+ * @property {boolean | undefined} standard_track Whether to filter by the standard track status
+ * @property {boolean | undefined} experimental Whether to filter by the experimental status
  */
 
 /**

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -236,7 +236,7 @@ if (esMain(import.meta)) {
       ),
       /**
        * Coerce the browsers option value
-       * @param value The raw option value
+       * @param {string | string[]} value The raw option value
        * @returns {BrowserName[]} The coerced browser names
        */
       coerce: (value) =>

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -236,7 +236,7 @@ if (esMain(import.meta)) {
       ),
       /**
        *
-       * @param value
+       * @param value The raw option value
        * @returns {BrowserName[]}
        */
       coerce: (value) =>

--- a/scripts/traverse.js
+++ b/scripts/traverse.js
@@ -27,7 +27,7 @@ import bcd from '../index.js';
  * @param {string} identifier The identifier of the current object
  * @param {StatusFilters | null} [status] Whether to filter by status flags
  * @yields {string} The feature identifier
- * @returns {IterableIterator<string>}
+ * @returns {IterableIterator<string>} The matching feature identifiers
  */
 export function* iterateFeatures(
   obj,
@@ -237,7 +237,7 @@ if (esMain(import.meta)) {
       /**
        *
        * @param value The raw option value
-       * @returns {BrowserName[]}
+       * @returns {BrowserName[]} The coerced browser names
        */
       coerce: (value) =>
         /** @type {BrowserName[]} */ (

--- a/scripts/update-browser-releases/bun.js
+++ b/scripts/update-browser-releases/bun.js
@@ -5,17 +5,17 @@
 
 /**
  * @typedef {object} BunVersionsResponse
- * @property {string} $note
- * @property {Record<string, BunReleaseInfo>} releases
+ * @property {string} $note A note about the response
+ * @property {Record<string, BunReleaseInfo>} releases The releases keyed by version
  */
 
 /**
  * @typedef {object} BunReleaseInfo
- * @property {'current' | 'retired'} status
- * @property {string} release_date
- * @property {string} release_notes
- * @property {Record<string, string>} [versions]
- * @property {string} [revision]
+ * @property {'current' | 'retired'} status The status of the release
+ * @property {string} release_date The release date
+ * @property {string} release_notes The URL of the release notes
+ * @property {Record<string, string>} [versions] The bundled dependency versions
+ * @property {string} [revision] The revision of the release
  */
 
 import fs from 'node:fs/promises';

--- a/scripts/update-browser-releases/edge.js
+++ b/scripts/update-browser-releases/edge.js
@@ -63,7 +63,7 @@ const getFutureReleaseDate = async (release, releaseScheduleURL) => {
  * @param {string} status The status of the release
  * @param {string | number} version The major version of the release
  * @returns {Promise<string>} The URL of the release notes or the empty string if not found
- * @throws a string in case of error
+ * @throws {string} A string in case of error
  */
 const getReleaseNotesURL = async (status, version) => {
   const url = `https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/${version}`;

--- a/scripts/update-browser-releases/edge.js
+++ b/scripts/update-browser-releases/edge.js
@@ -322,7 +322,7 @@ export const updateEdgeReleases = async (options) => {
 /**
  * Parses a release date from the Edge release table.
  * @param {string} dateText - Release date in the original format.
- * @returns string
+ * @returns {Date} The parsed release date
  */
 export const parseReleaseDate = (dateText) => {
   const months = [

--- a/scripts/update-browser-releases/opera.js
+++ b/scripts/update-browser-releases/opera.js
@@ -5,12 +5,12 @@
 
 /**
  * @typedef {object} Release
- * @property {string} version
- * @property {string} date
- * @property {string} releaseNote
- * @property {'current'} channel
- * @property {'Blink'} engine
- * @property {string} engineVersion
+ * @property {string} version The version number of the release
+ * @property {string} date The release date
+ * @property {string} releaseNote The URL of the release notes
+ * @property {'current'} channel The release channel
+ * @property {'Blink'} engine The name of the engine
+ * @property {string} engineVersion The version of the engine
  */
 
 import fs from 'node:fs/promises';

--- a/scripts/update-browser-releases/safari.js
+++ b/scripts/update-browser-releases/safari.js
@@ -10,11 +10,11 @@ import { newBrowserEntry, updateBrowserEntry } from './utils.js';
 
 /**
  * @typedef {object} Release
- * @property {string} version
- * @property {string} engineVersion
- * @property {'current' | 'beta' | 'retired'} channel
- * @property {string} date
- * @property {string} releaseNote
+ * @property {string} version The version number of the release
+ * @property {string} engineVersion The version of the engine
+ * @property {'current' | 'beta' | 'retired'} channel The release channel
+ * @property {string} date The release date
+ * @property {string} releaseNote The URL of the release notes
  */
 
 /**

--- a/scripts/update-browser-releases/utils.js
+++ b/scripts/update-browser-releases/utils.js
@@ -5,10 +5,10 @@
 
 /**
  * @typedef {object} RSSItem
- * @property {string} title
- * @property {string} pubDate
- * @property {string} description
- * @property {string} link
+ * @property {string} title The title of the RSS item
+ * @property {string} pubDate The publication date of the RSS item
+ * @property {string} description The description of the RSS item
+ * @property {string} link The link of the RSS item
  */
 
 import { styleText } from 'node:util';

--- a/utils/walk.js
+++ b/utils/walk.js
@@ -43,7 +43,7 @@ import query from './query.js';
  * @param {BrowserStatement} data The data to iterate
  * @param {string} [path] The current path
  * @yields {BrowserReleaseWalkOutput} The release info
- * @returns {IterableIterator<BrowserReleaseWalkOutput>}
+ * @returns {IterableIterator<BrowserReleaseWalkOutput>} The browser release walk output
  */
 export function* browserReleaseWalk(data, path) {
   for (const [release, releaseData] of Object.entries(data.releases)) {
@@ -62,7 +62,7 @@ export function* browserReleaseWalk(data, path) {
  * @param {string} [path] The current path
  * @param {number} [depth] The maximum depth to iterate
  * @yields {LowLevelWalkOutput} The feature info
- * @returns {IterableIterator<LowLevelWalkOutput>}
+ * @returns {IterableIterator<LowLevelWalkOutput>} The low-level walk output
  */
 export function* lowLevelWalk(data = bcd, path, depth = Infinity) {
   if (path !== undefined && path !== '__meta') {
@@ -96,7 +96,7 @@ export function* lowLevelWalk(data = bcd, path, depth = Infinity) {
  * @param {string | string[]} [entryPoints] Entry points to iterate
  * @param {InternalDataType} [data] The data to iterate
  * @yields {WalkOutput} The feature info
- * @returns {IterableIterator<WalkOutput>}
+ * @returns {IterableIterator<WalkOutput>} The walk output
  */
 export default function* walk(entryPoints, data = bcd) {
   /** @type {IterableIterator<LowLevelWalkOutput>[]} */

--- a/utils/walk.js
+++ b/utils/walk.js
@@ -16,26 +16,26 @@ import query from './query.js';
 
 /**
  * @typedef {object} BrowserReleaseWalkOutput
- * @property {string} path
- * @property {InternalDataType} data
- * @property {BrowserStatement} browser
- * @property {ReleaseStatement} browserRelease
+ * @property {string} path The path of the current node
+ * @property {InternalDataType} data The data of the current node
+ * @property {BrowserStatement} browser The browser statement of the current node
+ * @property {ReleaseStatement} browserRelease The release statement of the current node
  */
 
 /**
  * @typedef {object} LowLevelWalkOutput
- * @property {string} path
- * @property {InternalDataType} data
- * @property {BrowserStatement} [browser]
- * @property {InternalCompatStatement} [compat]
- * @property {ReleaseStatement} [browserRelease]
+ * @property {string} path The path of the current node
+ * @property {InternalDataType} data The data of the current node
+ * @property {BrowserStatement} [browser] The browser statement of the current node
+ * @property {InternalCompatStatement} [compat] The compat statement of the current node
+ * @property {ReleaseStatement} [browserRelease] The release statement of the current node
  */
 
 /**
  * @typedef {object} WalkOutput
- * @property {string} path
- * @property {InternalDataType} data
- * @property {InternalCompatStatement} compat
+ * @property {string} path The path of the current node
+ * @property {InternalDataType} data The data of the current node
+ * @property {InternalCompatStatement} compat The compat statement of the current node
  */
 
 /**


### PR DESCRIPTION
#### Summary

Fix all fixable `jsdoc/*` ESLint warnings (except `reject-any-type`), then promote the affected rules from warnings to errors so regressions fail linting. Each failing rule is fixed in its own commit, followed by a single commit that flips their severity.

- Descriptions: `require-property-description`, `require-param-description`, `require-returns-description`, `require-description`.
- Types: `require-throws-type`, `require-param-type`, `require-returns-type` (and correct `parseReleaseDate`, which was annotated `@returns string` but returns a `Date`).
- Promotion: the seven rules above are now `'error'`. `reject-any-type` (83 warnings) stays a warning, since replacing `any` with concrete types needs case-by-case judgment.

The motivation is noise reduction and enforcement: these warnings made it hard to spot actual errors in ESLint output, and promoting them to errors keeps the tree clean going forward.

#### Test results and supporting details

`npm run format` (ESLint + Prettier + `tsc --noEmit`) passes with 0 errors. The only remaining `jsdoc/*` warnings are the out-of-scope `reject-any-type` ones.

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
