### PR TITLE
FF153 CSS basic shapes allow closest-/farthest-corner values

### DIFF
--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -104,6 +104,70 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "closest-corner_value": {
+            "__compat": {
+              "description": "`closest-corner` value",
+              "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-closest-corner",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "farthest-corner_value": {
+            "__compat": {
+              "description": "`farthest-corner` value",
+              "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-farthest-corner",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "ellipse": {
@@ -139,6 +203,70 @@
               "experimental": false,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "closest-corner_value": {
+            "__compat": {
+              "description": "`closest-corner` value",
+              "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-closest-corner",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "farthest-corner_value": {
+            "__compat": {
+              "description": "`farthest-corner` value",
+              "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-farthest-corner",
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "18.4"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },

--- a/css/types/basic-shape.json
+++ b/css/types/basic-shape.json
@@ -105,9 +105,8 @@
               "deprecated": false
             }
           },
-          "closest-corner_value": {
+          "closest-corner": {
             "__compat": {
-              "description": "`closest-corner` value",
               "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-closest-corner",
               "support": {
                 "chrome": {
@@ -137,9 +136,8 @@
               }
             }
           },
-          "farthest-corner_value": {
+          "farthest-corner": {
             "__compat": {
-              "description": "`farthest-corner` value",
               "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-farthest-corner",
               "support": {
                 "chrome": {
@@ -205,9 +203,8 @@
               "deprecated": false
             }
           },
-          "closest-corner_value": {
+          "closest-corner": {
             "__compat": {
-              "description": "`closest-corner` value",
               "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-closest-corner",
               "support": {
                 "chrome": {
@@ -237,9 +234,8 @@
               }
             }
           },
-          "farthest-corner_value": {
+          "farthest-corner": {
             "__compat": {
-              "description": "`farthest-corner` value",
               "spec_url": "https://drafts.csswg.org/css-images-3/#valdef-radial-extent-farthest-corner",
               "support": {
                 "chrome": {


### PR DESCRIPTION
FF153 adds support for the `farthest-corner` and `closest-corner` radius values for [`ellipse()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/basic-shape/ellipse) and [`circle()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/basic-shape/circle) in Nightly in https://bugzilla.mozilla.org/show_bug.cgi?id=2037673

Browserstack testing using https://wpt.live/css/css-masking/clip-path/clip-path-ellipse-closest-farthest-corner.html and similar tests also show this is not supported in Chrome, but is supported in Safari 18.4 (but not 17).

This updates the features.

Related docs work can be tracked in https://github.com/mdn/content/issues/44459

