### PR TITLE
Updates for Firefox Nightly 20-07-2026

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -481,7 +481,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -516,7 +516,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -55,7 +55,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCIceCandidatePair.json
+++ b/api/RTCIceCandidatePair.json
@@ -1,0 +1,100 @@
+{
+  "api": {
+    "RTCIceCandidatePair": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePair",
+        "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidatepair",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "preview"
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "local": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePair/local",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidatepair-local",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "remote": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePair/remote",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidatepair-remote",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -277,7 +277,7 @@
               }
             ],
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -353,7 +353,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
### Summary

Updates from a Collector run (v10.20.4) in today's Firefox Nightly.

#### Test results and supporting details

api.Element.animate.options_rangeEnd_parameter: https://bugzilla.mozilla.org/show_bug.cgi?id=1810248
api.Element.animate.options_rangeStart_parameter: https://bugzilla.mozilla.org/show_bug.cgi?id=1810248

RTCIceTransport selected candidate pair API: https://bugzilla.mozilla.org/show_bug.cgi?id=2019332

#### Related issues

None.