### PR TITLE
Add granular data for Wasm SIMD arithmetic instructions

### DIFF
--- a/webassembly/instructions/add_sat_s.json
+++ b/webassembly/instructions/add_sat_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "add_sat_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/add_sat_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/add_sat_u.json
+++ b/webassembly/instructions/add_sat_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "add_sat_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/add_sat_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/avgr_u.json
+++ b/webassembly/instructions/avgr_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "avgr_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/avgr_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/dot_i16x8_s.json
+++ b/webassembly/instructions/dot_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "dot_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/dot_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extadd_pairwise_i16x8_s.json
+++ b/webassembly/instructions/extadd_pairwise_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extadd_pairwise_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extadd_pairwise_i16x8_u.json
+++ b/webassembly/instructions/extadd_pairwise_i16x8_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extadd_pairwise_i16x8_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i16x8_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extadd_pairwise_i8x16_s.json
+++ b/webassembly/instructions/extadd_pairwise_i8x16_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extadd_pairwise_i8x16_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i8x16_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extadd_pairwise_i8x16_u.json
+++ b/webassembly/instructions/extadd_pairwise_i8x16_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extadd_pairwise_i8x16_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extadd_pairwise_i8x16_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_high_i16x8_s.json
+++ b/webassembly/instructions/extmul_high_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_high_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_high_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_high_i16x8_u.json
+++ b/webassembly/instructions/extmul_high_i16x8_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_high_i16x8_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_high_i16x8_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_high_i32x4_s.json
+++ b/webassembly/instructions/extmul_high_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_high_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_high_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_high_i32x4_u.json
+++ b/webassembly/instructions/extmul_high_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_high_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_high_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_high_i8x16_s.json
+++ b/webassembly/instructions/extmul_high_i8x16_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_high_i8x16_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_high_i8x16_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_high_i8x16_u.json
+++ b/webassembly/instructions/extmul_high_i8x16_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_high_i8x16_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_high_i8x16_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_low_i16x8_s.json
+++ b/webassembly/instructions/extmul_low_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_low_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_low_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_low_i16x8_u.json
+++ b/webassembly/instructions/extmul_low_i16x8_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_low_i16x8_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_low_i16x8_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_low_i32x4_s.json
+++ b/webassembly/instructions/extmul_low_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_low_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_low_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_low_i32x4_u.json
+++ b/webassembly/instructions/extmul_low_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_low_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_low_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_low_i8x16_s.json
+++ b/webassembly/instructions/extmul_low_i8x16_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_low_i8x16_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_low_i8x16_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extmul_low_i8x16_u.json
+++ b/webassembly/instructions/extmul_low_i8x16_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extmul_low_i8x16_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/extmul_low_i8x16_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/max_s.json
+++ b/webassembly/instructions/max_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "max_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/max_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/max_u.json
+++ b/webassembly/instructions/max_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "max_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/max_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/min_s.json
+++ b/webassembly/instructions/min_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "min_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/min_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/min_u.json
+++ b/webassembly/instructions/min_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "min_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/min_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/pmax.json
+++ b/webassembly/instructions/pmax.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "pmax": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/pmax",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/pmin.json
+++ b/webassembly/instructions/pmin.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "pmin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/pmin",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/q15mulr_sat_s.json
+++ b/webassembly/instructions/q15mulr_sat_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "q15mulr_sat_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/q15mulr_sat_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/sub_sat_s.json
+++ b/webassembly/instructions/sub_sat_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "sub_sat_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/sub_sat_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/sub_sat_u.json
+++ b/webassembly/instructions/sub_sat_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "sub_sat_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/arithmetic/sub_sat_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all [Wasm SIMD arithmetic instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/arithmetic).

All of these were added as part of the fixed-width SIMD proposal, so I've given them the same data as webassembly.fixed-width-SIMD.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
