### PR TITLE
Add granular data for Wasm SIMD bitwise instructions

### DIFF
--- a/webassembly/instructions/all_true.json
+++ b/webassembly/instructions/all_true.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "all_true": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/bitwise/all_true",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/andnot.json
+++ b/webassembly/instructions/andnot.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "andnot": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/bitwise/andnot",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/any_true.json
+++ b/webassembly/instructions/any_true.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "any_true": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/bitwise/any_true",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/bitmask.json
+++ b/webassembly/instructions/bitmask.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "bitmask": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/bitwise/bitmask",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/bitselect.json
+++ b/webassembly/instructions/bitselect.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "bitselect": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/bitwise/bitselect",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/not.json
+++ b/webassembly/instructions/not.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "not": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/bitwise/not",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all [Wasm SIMD bitwise instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/bitwise).

All of these were added as part of the fixed-width SIMD proposal, so I've given them the same data as webassembly.fixed-width-SIMD.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
