### PR TITLE
FF154  rtcp prop in object for RTCRtpReceiver.getParameters(), RTCRtpSender.{get|set}Parameters()

### DIFF
--- a/api/RTCRtpReceiver.json
+++ b/api/RTCRtpReceiver.json
@@ -478,9 +478,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
+              "firefox": [
+                {
+                  "version_added": "154"
+                },
+                {
+                  "version_added": "128",
+                  "version_removed": "154",
+                  "partial_implementation": true,
+                  "notes": "The property is defined but not implemented/used."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -342,11 +342,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "The property is defined but not implemented/used."
-              },
+              "firefox": [
+                {
+                  "version_added": "154"
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "154",
+                  "partial_implementation": true,
+                  "notes": "The property is defined but not implemented/used."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
@@ -1025,11 +1031,17 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": {
-                "version_added": "46",
-                "partial_implementation": true,
-                "notes": "The property is defined but not implemented/used."
-              },
+              "firefox": [
+                {
+                  "version_added": "154"
+                },
+                {
+                  "version_added": "46",
+                  "version_removed": "154",
+                  "partial_implementation": true,
+                  "notes": "The property is defined but not implemented/used."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
FF154 adds support for get/set the `rtcp` property in the object set/returned from [`RTCRtpReceiver.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpReceiver/getParameters), [`RTCRtpSender.getParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/getParameters) and [`RTCRtpSender.setParameters()`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters) in https://bugzilla.mozilla.org/show_bug.cgi?id=1584318

This adds feature info.

Related docs work can be tracked in https://github.com/mdn/content/issues/44834