### PR TITLE
FF154 RTCDtlsTransport error event

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -55,7 +55,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
FF154 adds support for the [`error` event](https://developer.mozilla.org/en-US/docs/Web/API/RTCDtlsTransport/error_event) on `RTCDtlsTransport` in https://bugzilla.mozilla.org/show_bug.cgi?id=1805447. This adds the sub feature.

Also tested in https://collector.openwebdocs.org/tests/api/RTCDtlsTransport/error_event

Related docs work can be tracked in https://github.com/mdn/content/issues/44835