### PR TITLE
Update Chrome version support for popover hint

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2476,11 +2476,11 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "150"
+                  "version_added": "151"
                 },
                 {
                   "version_added": "133",
-                  "version_removed": "150",
+                  "version_removed": "151",
                   "partial_implementation": true,
                   "notes": "Implements an older version of the specification with inconsistent behaviors. See [bug 499019927](https://crbug.com/499019927)."
                 }

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -1102,11 +1102,11 @@
             "support": {
               "chrome": [
                 {
-                  "version_added": "150"
+                  "version_added": "151"
                 },
                 {
                   "version_added": "133",
-                  "version_removed": "150",
+                  "version_removed": "151",
                   "partial_implementation": true,
                   "notes": "Implements an older version of the specification with inconsistent behaviors. See [bug 499019927](https://crbug.com/499019927)."
                 }


### PR DESCRIPTION
Ref: https://github.com/whatwg/html/pull/12345#issuecomment-4963441189