### PR TITLE
Add granular data for Wasm SIMD conversion instructions

### DIFF
--- a/webassembly/instructions/convert_i32x4_s.json
+++ b/webassembly/instructions/convert_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "convert_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/convert_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/convert_i32x4_u.json
+++ b/webassembly/instructions/convert_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "convert_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/convert_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/convert_low_i32x4_s.json
+++ b/webassembly/instructions/convert_low_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "convert_low_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/convert_low_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/convert_low_i32x4_u.json
+++ b/webassembly/instructions/convert_low_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "convert_low_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/convert_low_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/demote_f64x2_zero.json
+++ b/webassembly/instructions/demote_f64x2_zero.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "demote_f64x2_zero": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/demote_f64x2_zero",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_high_i16x8_s.json
+++ b/webassembly/instructions/extend_high_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_high_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_high_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_high_i16x8_u.json
+++ b/webassembly/instructions/extend_high_i16x8_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_high_i16x8_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_high_i16x8_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_high_i32x4_s.json
+++ b/webassembly/instructions/extend_high_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_high_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_high_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_high_i32x4_u.json
+++ b/webassembly/instructions/extend_high_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_high_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_high_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_high_i8x16_s.json
+++ b/webassembly/instructions/extend_high_i8x16_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_high_i8x16_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_high_i8x16_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_high_i8x16_u.json
+++ b/webassembly/instructions/extend_high_i8x16_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_high_i8x16_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_high_i8x16_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_low_i16x8_s.json
+++ b/webassembly/instructions/extend_low_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_low_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_low_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_low_i16x8_u.json
+++ b/webassembly/instructions/extend_low_i16x8_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_low_i16x8_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_low_i16x8_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_low_i32x4_s.json
+++ b/webassembly/instructions/extend_low_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_low_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_low_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_low_i32x4_u.json
+++ b/webassembly/instructions/extend_low_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_low_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_low_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_low_i8x16_s.json
+++ b/webassembly/instructions/extend_low_i8x16_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_low_i8x16_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_low_i8x16_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend_low_i8x16_u.json
+++ b/webassembly/instructions/extend_low_i8x16_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend_low_i8x16_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/extend_low_i8x16_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/narrow_i16x8_s.json
+++ b/webassembly/instructions/narrow_i16x8_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "narrow_i16x8_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/narrow_i16x8_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/narrow_i16x8_u.json
+++ b/webassembly/instructions/narrow_i16x8_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "narrow_i16x8_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/narrow_i16x8_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/narrow_i32x4_s.json
+++ b/webassembly/instructions/narrow_i32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "narrow_i32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/narrow_i32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/narrow_i32x4_u.json
+++ b/webassembly/instructions/narrow_i32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "narrow_i32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/narrow_i32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/promote_low_f32x4.json
+++ b/webassembly/instructions/promote_low_f32x4.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "promote_low_f32x4": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/promote_low_f32x4",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/replace_lane.json
+++ b/webassembly/instructions/replace_lane.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "replace_lane": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/replace_lane",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/shuffle.json
+++ b/webassembly/instructions/shuffle.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "shuffle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/shuffle",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/splat.json
+++ b/webassembly/instructions/splat.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "splat": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/splat",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/swizzle.json
+++ b/webassembly/instructions/swizzle.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "swizzle": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/swizzle",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f32x4_s.json
+++ b/webassembly/instructions/trunc_sat_f32x4_s.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f32x4_s": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/trunc_sat_f32x4_s",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f32x4_u.json
+++ b/webassembly/instructions/trunc_sat_f32x4_u.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f32x4_u": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/trunc_sat_f32x4_u",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f64x2_s_zero.json
+++ b/webassembly/instructions/trunc_sat_f64x2_s_zero.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f64x2_s_zero": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/trunc_sat_f64x2_s_zero",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f64x2_u_zero.json
+++ b/webassembly/instructions/trunc_sat_f64x2_u_zero.json
@@ -1,0 +1,38 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f64x2_u_zero": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/SIMD/conversion/trunc_sat_f64x2_u_zero",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#vector-instructions%E2%91%A8",
+          "support": {
+            "chrome": {
+              "version_added": "91"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "89"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all [Wasm SIMD conversion instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/SIMD/conversion).

All of these were added as part of the fixed-width SIMD proposal, so I've given them the same data as webassembly.fixed-width-SIMD.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
