### PR TITLE
Update spec URL for animation-duration property

### DIFF
--- a/css/properties/animation-duration.json
+++ b/css/properties/animation-duration.json
@@ -4,7 +4,7 @@
       "animation-duration": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/animation-duration",
-          "spec_url": "https://drafts.csswg.org/css-animations/#animation-duration",
+          "spec_url": "https://drafts.csswg.org/css-animations-2/#animation-duration",
           "tags": [
             "web-features:animations-css"
           ],


### PR DESCRIPTION
the formal syntax comes from animation-2 (see the keyword `auto`), so we should link to that.