### PR TITLE
Add granular data for Wasm table and variable instructions

### DIFF
--- a/webassembly/instructions/global_get.json
+++ b/webassembly/instructions/global_get.json
@@ -4,6 +4,7 @@
       "global_get": {
         "__compat": {
           "description": "global.get",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.get",
           "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#variable-instructions①",
           "support": {
             "chrome": {

--- a/webassembly/instructions/local.json
+++ b/webassembly/instructions/local.json
@@ -1,26 +1,36 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "local": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/local",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#variable-instructions①",
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
-              "version_added": "69"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
             "firefox": {
-              "version_added": "62"
+              "version_added": "52"
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/local_get.json
+++ b/webassembly/instructions/local_get.json
@@ -1,26 +1,37 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "local_get": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "local.get",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/local.get",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#variable-instructions①",
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
-              "version_added": "69"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
             "firefox": {
-              "version_added": "62"
+              "version_added": "52"
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/local_set.json
+++ b/webassembly/instructions/local_set.json
@@ -1,26 +1,37 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "local_set": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "local.set",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/local.set",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#variable-instructions①",
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
-              "version_added": "69"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
             "firefox": {
-              "version_added": "62"
+              "version_added": "52"
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/local_tee.json
+++ b/webassembly/instructions/local_tee.json
@@ -1,26 +1,37 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "local_tee": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "local.tee",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/local.tee",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#variable-instructions①",
           "support": {
+            "bun": {
+              "version_added": "1.0.0"
+            },
             "chrome": {
-              "version_added": "69"
+              "version_added": "57"
             },
             "chrome_android": "mirror",
-            "edge": "mirror",
+            "deno": {
+              "version_added": "1.0"
+            },
+            "edge": {
+              "version_added": "16"
+            },
             "firefox": {
-              "version_added": "62"
+              "version_added": "52"
             },
             "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": "8.0.0"
+            },
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "11"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/table_fill.json
+++ b/webassembly/instructions/table_fill.json
@@ -1,26 +1,26 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "table_fill": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "table.fill",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Table/fill",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftablefillx",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "96"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "62"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/table_get.json
+++ b/webassembly/instructions/table_get.json
@@ -1,26 +1,26 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "table_get": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "table.get",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Table/get",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftablegetx",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "96"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "62"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/table_grow.json
+++ b/webassembly/instructions/table_grow.json
@@ -1,26 +1,26 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "table_grow": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "table.grow",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Table/grow",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftablegrowx",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "96"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "62"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/table_set.json
+++ b/webassembly/instructions/table_set.json
@@ -1,26 +1,26 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "table_set": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "table.set",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Table/set",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftablesetx",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "96"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "62"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/webassembly/instructions/table_size.json
+++ b/webassembly/instructions/table_size.json
@@ -1,26 +1,26 @@
 {
   "webassembly": {
     "instructions": {
-      "global_set": {
+      "table_size": {
         "__compat": {
-          "description": "global.set",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Variables/global.set",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions①",
+          "description": "table.size",
+          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Table/size",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftablesizex",
           "support": {
             "chrome": {
-              "version_added": "69"
+              "version_added": "96"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "62"
+              "version_added": "79"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "13.1"
+              "version_added": "15.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR is part of my work to make sure all Wasm pages have working BCD and display it properly in their "Specifications" and "Browser compatibility" sections.

In particular, this PR adds granular data for all Wasm [table instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Table) and [variable instructions](https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Variables).

The table pages were originally displaying the data for webassembly.reference-types, so I duplicated that data for these data points.

The global variable pages already had data.

The local variables have been supported since the start, so I gave them the same "original" data as seen at webassembly.api.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
