### PR TITLE
Add "stale-if-error" support details to Cache-Control

### DIFF
--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -80,6 +80,37 @@
             }
           }
         },
+        "stale-if-error": {
+          "__compat": {
+            "spec_url": "https://httpwg.org/specs/rfc5861.html#n-the-stale-if-error-cache-control-extension",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "stale-while-revalidate": {
           "__compat": {
             "spec_url": "https://httpwg.org/specs/rfc5861.html#n-the-stale-while-revalidate-cache-control-extension",
@@ -102,41 +133,6 @@
               },
               "safari": {
                 "version_added": "14"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "stale-if-error": {
-          "__compat": {
-            "spec_url": "https://httpwg.org/specs/rfc5861.html#n-the-stale-if-error-cache-control-extension",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": {
-                "version_added": false
-              },
-              "opera_android": {
-                "version_added": false
-              },
-              "safari": {
-                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/http/headers/Cache-Control.json
+++ b/http/headers/Cache-Control.json
@@ -114,6 +114,41 @@
               "deprecated": false
             }
           }
+        },
+        "stale-if-error": {
+          "__compat": {
+            "spec_url": "https://httpwg.org/specs/rfc5861.html#n-the-stale-if-error-cache-control-extension",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": {
+                "version_added": false
+              },
+              "opera_android": {
+                "version_added": false
+              },
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add information about the widespread lack of support for `stale-if-error` Cache-Control header directive.
Documentation extensively describes this directive, even though not a single browser supports it, and the documentation does not mention this detail at all.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1547587
https://issues.chromium.org/issues/329541436

<!-- #### Related issues -->

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
