### PR TITLE
Add granular data for Wasm non-trapping float-to-int conversion instructions

### DIFF
--- a/webassembly/instructions/trunc_sat_f32_s.json
+++ b/webassembly/instructions/trunc_sat_f32_s.json
@@ -1,0 +1,42 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f32_s": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A8",
+          "tags": [
+            "web-features:wasm-non-trapping-float-to-int"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f32_u.json
+++ b/webassembly/instructions/trunc_sat_f32_u.json
@@ -1,0 +1,42 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f32_u": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A8",
+          "tags": [
+            "web-features:wasm-non-trapping-float-to-int"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f64_s.json
+++ b/webassembly/instructions/trunc_sat_f64_s.json
@@ -1,0 +1,42 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f64_s": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A8",
+          "tags": [
+            "web-features:wasm-non-trapping-float-to-int"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/trunc_sat_f64_u.json
+++ b/webassembly/instructions/trunc_sat_f64_u.json
@@ -1,0 +1,42 @@
+{
+  "webassembly": {
+    "instructions": {
+      "trunc_sat_f64_u": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A8",
+          "tags": [
+            "web-features:wasm-non-trapping-float-to-int"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "64"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds granular compat data for the Wasm instructions related to the [Non-trapping Float-to-int Conversions](https://github.com/WebAssembly/spec/blob/main/proposals/nontrapping-float-to-int-conversion/Overview.md):

- `trunc_sat_f32_s`
- `trunc_sat_f32_u`
- `trunc_sat_f64_s`
- `trunc_sat_f64_u`

I've given them the same data as the existing webassembly.non-trapping-float-to-int-conversions entry.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
