### PR TITLE
BrowserCaptureMediaStreamTrack is available on Chrome Android

### DIFF
--- a/api/BrowserCaptureMediaStreamTrack.json
+++ b/api/BrowserCaptureMediaStreamTrack.json
@@ -12,7 +12,7 @@
             "version_added": "104"
           },
           "chrome_android": {
-            "version_added": false
+            "version_added": "121"
           },
           "edge": "mirror",
           "firefox": {
@@ -48,7 +48,7 @@
               "version_added": "104"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "121"
             },
             "edge": "mirror",
             "firefox": {


### PR DESCRIPTION
#### Summary

This interface is exposed on Chrome Android. Discovered thanks to the Collector (v10.20.4).

#### Test results and supporting details

https://chromiumdash.appspot.com/commit/70de5a1e0903dcca28309087bb528c798be108ea
https://source.chromium.org/chromium/chromium/src/+/70de5a1e0903dcca28309087bb528c798be108ea

#### Related issues

None.