### PR TITLE
Update Safari iOS WebGL extensions support

### DIFF
--- a/api/EXT_texture_compression_bptc.json
+++ b/api/EXT_texture_compression_bptc.json
@@ -35,9 +35,7 @@
           "safari": {
             "version_added": "16"
           },
-          "safari_ios": {
-            "version_added": false
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": false
           },

--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -33,9 +33,7 @@
           "safari": {
             "version_added": "14.1"
           },
-          "safari_ios": {
-            "version_added": false
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": {
             "version_added": false
           },

--- a/api/WEBGL_compressed_texture_s3tc.json
+++ b/api/WEBGL_compressed_texture_s3tc.json
@@ -46,9 +46,7 @@
           "safari": {
             "version_added": "8"
           },
-          "safari_ios": {
-            "version_added": false
-          },
+          "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
           "webview_ios": "mirror"


### PR DESCRIPTION
#### Summary

Mark some WebGL extensions as supported in Safari on iOS. Found by the Collector project (v10.20.4).

#### Test results and supporting details

I have not found hints that suggest these aren't also supported on iOS.

#### Related issues

None.