### PR TITLE
Add granular data for Wasm sign-extension operation instructions

### DIFF
--- a/webassembly/instructions/extend16_s.json
+++ b/webassembly/instructions/extend16_s.json
@@ -1,0 +1,39 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend16_s": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A6",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend32_s.json
+++ b/webassembly/instructions/extend32_s.json
@@ -1,0 +1,39 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend32_s": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A6",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/extend8_s.json
+++ b/webassembly/instructions/extend8_s.json
@@ -1,0 +1,39 @@
+{
+  "webassembly": {
+    "instructions": {
+      "extend8_s": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#numeric-instructions%E2%91%A6",
+          "support": {
+            "chrome": {
+              "version_added": "69"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "18"
+            },
+            "firefox": {
+              "version_added": "62"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "14.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds granular data for the Wasm [sign-extension operation instructions](https://github.com/WebAssembly/spec/blob/main/proposals/sign-extension-ops/Overview.md).

For the support data, I've just copied the data from the existing webassembly.sign-extension-operations data point.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
