### PR TITLE
Updates for Firefox 154 beta

### DIFF
--- a/api/RTCDtlsTransport.json
+++ b/api/RTCDtlsTransport.json
@@ -55,7 +55,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": false
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/RTCIceCandidatePair.json
+++ b/api/RTCIceCandidatePair.json
@@ -1,0 +1,106 @@
+{
+  "api": {
+    "RTCIceCandidatePair": {
+      "__compat": {
+        "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePair",
+        "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidatepair",
+        "support": {
+          "chrome": {
+            "version_added": false
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": "154"
+          },
+          "firefox_android": {
+            "version_added": false
+          },
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "local": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePair/local",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidatepair-local",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "154"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "remote": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCIceCandidatePair/remote",
+          "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcicecandidatepair-remote",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "154"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/RTCIceTransport.json
+++ b/api/RTCIceTransport.json
@@ -277,7 +277,7 @@
               }
             ],
             "firefox": {
-              "version_added": false
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -353,7 +353,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/properties/text-box-edge.json
+++ b/css/properties/text-box-edge.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -45,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -79,7 +79,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -110,7 +110,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -125,7 +125,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -141,7 +141,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -156,7 +156,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -172,7 +172,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -187,7 +187,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -203,7 +203,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -218,7 +218,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -234,7 +234,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/text-box-trim.json
+++ b/css/properties/text-box-trim.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -48,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -82,7 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -116,7 +116,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -150,7 +150,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -45,7 +45,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -76,7 +76,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -107,7 +107,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -122,7 +122,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -138,7 +138,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -153,7 +153,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -169,7 +169,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -184,7 +184,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -200,7 +200,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -215,7 +215,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -231,7 +231,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -265,7 +265,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -296,7 +296,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -327,7 +327,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -358,7 +358,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -389,7 +389,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/types/sibling-count.json
+++ b/css/types/sibling-count.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1953973"
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/types/sibling-index.json
+++ b/css/types/sibling-index.json
@@ -16,8 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/1953973"
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -102,7 +102,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -534,7 +534,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "nodejs": {
@@ -568,7 +568,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -849,7 +849,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.20.4) found new features shipping in Firefox 154   beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following features as shipping in Firefox 154 (**bold** features are new keys in BCD).

- api.RTCDtlsTransport.error_event
- **api.RTCIceCandidatePair**
- **api.RTCIceCandidatePair.local**
- **api.RTCIceCandidatePair.remote**
- api.RTCIceTransport.getSelectedCandidatePair
- api.RTCIceTransport.selectedcandidatepairchange_event
- css.properties.text-box-edge
- css.properties.text-box-edge.alphabetic
- css.properties.text-box-edge.auto
- css.properties.text-box-edge.cap
- css.properties.text-box-edge.ex
- css.properties.text-box-edge.ideographic
- css.properties.text-box-edge.ideographic-ink
- css.properties.text-box-edge.text
- css.properties.text-box-trim
- css.properties.text-box-trim.none
- css.properties.text-box-trim.trim-both
- css.properties.text-box-trim.trim-end
- css.properties.text-box-trim.trim-start
- css.properties.text-box
- css.properties.text-box.alphabetic
- css.properties.text-box.auto
- css.properties.text-box.cap
- css.properties.text-box.ex
- css.properties.text-box.ideographic
- css.properties.text-box.ideographic-ink
- css.properties.text-box.none
- css.properties.text-box.normal
- css.properties.text-box.text
- css.properties.text-box.trim-both
- css.properties.text-box.trim-end
- css.properties.text-box.trim-start
- css.types.sibling-count
- css.types.sibling-index
- javascript.builtins.Iterator.chunks
- javascript.builtins.Iterator.includes
- javascript.builtins.Iterator.join
- javascript.builtins.Iterator.windows

Updated in other PRs:

- webdriver.bidi.browsingContext.domContentLoaded_event.userContext_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.download_parameter
- webdriver.bidi.browsingContext.downloadEnd_event.userContext_parameter
- webdriver.bidi.browsingContext.downloadWillBegin_event.download_parameter
- webdriver.bidi.browsingContext.downloadWillBegin_event.userContext_parameter
- webdriver.bidi.browsingContext.fragmentNavigated_event.userContext_parameter
- webdriver.bidi.browsingContext.historyUpdated_event.userContext_parameter
- webdriver.bidi.browsingContext.load_event.userContext_parameter
- webdriver.bidi.browsingContext.navigationCommitted_event.userContext_parameter
- webdriver.bidi.browsingContext.navigationFailed_event.userContext_parameter
- webdriver.bidi.browsingContext.navigationStarted_event.userContext_parameter
- webdriver.bidi.browsingContext.startScreencast
- webdriver.bidi.browsingContext.startScreencast.context_parameter
- webdriver.bidi.browsingContext.startScreencast.mimeType_parameter
- webdriver.bidi.browsingContext.startScreencast.video_parameter
- webdriver.bidi.browsingContext.stopScreencast
- webdriver.bidi.browsingContext.stopScreencast.screencast_parameter
- webdriver.bidi.browsingContext.userPromptClosed_event.userContext_parameter
- webdriver.bidi.browsingContext.userPromptOpened_event.userContext_parameter
- webdriver.bidi.input.fileDialogOpened_event.userContext_parameter
- webdriver.bidi.network.authRequired_event.userContext_parameter
- webdriver.bidi.network.beforeRequestSent_event.userContext_parameter
- webdriver.bidi.network.fetchError_event.userContext_parameter
- webdriver.bidi.network.responseCompleted_event.userContext_parameter
- webdriver.bidi.network.responseStarted_event.userContext_parameter
- webdriver.bidi.script.realmCreated_event.userContext_parameter

For more Firefox 154 info, see also https://github.com/mdn/mdn/issues/850 and https://www.firefox.com/en-US/firefox/154.0beta/releasenotes/