### PR TITLE
Edge also ships getSecurePaymentConfirmationCapabilities

### DIFF
--- a/api/PaymentRequest.json
+++ b/api/PaymentRequest.json
@@ -260,9 +260,7 @@
               "version_added": "148"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": false
-            },
+            "edge": "mirror",
             "firefox": {
               "version_added": false
             },


### PR DESCRIPTION
#### Summary

Microsoft Edge also supports `api.PaymentRequest.getSecurePaymentConfirmationCapabilities_static`

#### Test results and supporting details

Collector 10.20.5.

#### Related issues

None. I see no hints why it wouldn't be supported as well.