### PR TITLE
Chrome Android supports MediaDevices.devicechange_event

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -58,7 +58,7 @@
               "version_added": "57"
             },
             "chrome_android": {
-              "version_added": false
+              "version_added": "132"
             },
             "edge": {
               "version_added": "12"


### PR DESCRIPTION
#### Summary

Chrome Android supports MediaDevices.devicechange_event

#### Test results and supporting details

Discovered by the Collector (v10.20.5).

See the last I2S comment: https://groups.google.com/a/chromium.org/g/blink-dev/c/s-w44wOMzqs/m/_GezWJ9dAgAJ
https://chromiumdash.appspot.com/commits?commit=64a722a077f22fd130051caa0daefc71073db5e4&platform=Android

#### Related issues

None.
