### PR TITLE
Firefox Android also removed RTCDataChannel.reliable

### DIFF
--- a/api/RTCDataChannel.json
+++ b/api/RTCDataChannel.json
@@ -835,7 +835,8 @@
               "version_removed": "142"
             },
             "firefox_android": {
-              "version_added": "24"
+              "version_added": "24",
+              "version_removed": "142"
             },
             "oculus": "mirror",
             "opera": "mirror",


### PR DESCRIPTION
#### Summary

Firefox Android also removed RTCDataChannel.reliable

#### Test results and supporting details

Found by the Collector (v10.20.5).

#### Related issues

None.