### PR TITLE
Add data points for Wasm bulk memory operations

### DIFF
--- a/webassembly/definitions/data.json
+++ b/webassembly/definitions/data.json
@@ -1,0 +1,40 @@
+{
+  "webassembly": {
+    "definitions": {
+      "data": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#data-segments%E2%91%A0",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/definitions/elem.json
+++ b/webassembly/definitions/elem.json
@@ -1,0 +1,40 @@
+{
+  "webassembly": {
+    "definitions": {
+      "elem": {
+        "__compat": {
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#element-segments%E2%91%A0",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/data_drop.json
+++ b/webassembly/instructions/data_drop.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "instructions": {
+      "data_drop": {
+        "__compat": {
+          "description": "data.drop",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfdatadropx%E2%91%A0",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/elem_drop.json
+++ b/webassembly/instructions/elem_drop.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "instructions": {
+      "elem_drop": {
+        "__compat": {
+          "description": "elem.drop",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsfelemdropx%E2%91%A0",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/memory_copy.json
+++ b/webassembly/instructions/memory_copy.json
@@ -6,6 +6,9 @@
           "description": "memory.copy",
           "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/copy",
           "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemorycopyx_1x_2",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
           "support": {
             "chrome": {
               "version_added": "75"

--- a/webassembly/instructions/memory_init.json
+++ b/webassembly/instructions/memory_init.json
@@ -1,11 +1,10 @@
 {
   "webassembly": {
     "instructions": {
-      "memory_fill": {
+      "memory_init": {
         "__compat": {
-          "description": "memory.fill",
-          "mdn_url": "https://developer.mozilla.org/docs/WebAssembly/Reference/Memory/fill",
-          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemoryfillx",
+          "description": "memory.init",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-memorymathsfmemoryinitxy",
           "tags": [
             "web-features:wasm-bulk-memory"
           ],

--- a/webassembly/instructions/table_copy.json
+++ b/webassembly/instructions/table_copy.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "instructions": {
+      "table_copy": {
+        "__compat": {
+          "description": "table.copy",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftablecopyxy",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/webassembly/instructions/table_init.json
+++ b/webassembly/instructions/table_init.json
@@ -1,0 +1,41 @@
+{
+  "webassembly": {
+    "instructions": {
+      "table_init": {
+        "__compat": {
+          "description": "table.init",
+          "spec_url": "https://webassembly.github.io/spec/core/bikeshed/#-hrefsyntax-instr-tablemathsftableinitxy",
+          "tags": [
+            "web-features:wasm-bulk-memory"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "75"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "79"
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "15.1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

This PR adds data points for any Wasm bulk memory operation features that were missing; see https://github.com/mdn/content/pull/44296/ for a list.

I've given each one the same data as webassembly.bulk-memory-operations, except that the Firefox version has been changed to 79, as per a discovery @caugner made in https://github.com/mdn/browser-compat-data/pull/30072.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
