### PR TITLE
FF154 RTCStatsReport more transport stats

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -8462,7 +8462,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8498,7 +8498,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8786,7 +8786,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8822,7 +8822,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8837,7 +8837,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -8858,7 +8858,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -8873,7 +8873,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -8894,7 +8894,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF154 supports the following additional `transport` stats https://bugzilla.mozilla.org/show_bug.cgi?id=2019349 and https://bugzilla.mozilla.org/show_bug.cgi?id=2019333: `remoteCertificateId`, `localCertificateId`, `packetsSent`, `packetsReceived`, `bytesSent`, and `bytesReceived`.

This updates the features.
Note these were not caught in #30116.

Related docs work can be tracked in https://github.com/mdn/content/issues/44837