### PR TITLE
FF154 RTCStatsReport certificate stats

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -1216,7 +1216,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -1251,7 +1251,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1287,7 +1287,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1323,7 +1323,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1359,7 +1359,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1380,6 +1380,41 @@
             }
           }
         },
+        "issuerCertificateId": {
+          "__compat": {
+            "description": "`issuerCertificateId` in 'certificate' stats",
+            "spec_url": "https://w3c.github.io/webrtc-stats/#dom-rtccertificatestats-issuercertificateid",
+            "tags": [
+              "web-features:webrtc-stats"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "154"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "timestamp": {
           "__compat": {
             "description": "`timestamp` in 'certificate' stats",
@@ -1395,7 +1430,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -1431,7 +1466,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF154 supports the WebRTC `certificate` stats in https://bugzilla.mozilla.org/show_bug.cgi?id=2019333.

This updates the features, and adds `issuerCertificateId` which was not previously supported by anyone.

Note these were not caught in #30116.

Related docs work can be tracked in https://github.com/mdn/content/issues/44837