### PR TITLE
FF153 source phase imports of wasm

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1925,6 +1925,55 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "import_wasm_modules": {
+            "__compat": {
+              "description": "Source phase import of WASM modules",
+              "spec_url": "https://webassembly.github.io/esm-integration/js-api/index.html#esm-integration",
+              "support": {
+                "bun": {
+                  "version_added": false
+                },
+                "chrome": {
+                  "version_added": false
+                },
+                "chrome_android": "mirror",
+                "deno": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "javascript.options.experimental.wasm_esm_integration",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/1997621"
+                },
+                "firefox_android": "mirror",
+                "nodejs": {
+                  "version_added": false
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "service_worker_support": {

--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1929,7 +1929,7 @@
           "import_wasm_modules": {
             "__compat": {
               "description": "Source phase import of WASM modules",
-              "spec_url": "https://webassembly.github.io/esm-integration/js-api/index.html#esm-integration",
+              "spec_url": "https://webassembly.github.io/esm-integration/js-api/#esm-integration",
               "support": {
                 "bun": {
                   "version_added": false


### PR DESCRIPTION
In #30034 I added a subfeature for `import source` syntax. This syntax is designed to allow importing a module as source and then later compile it. There are separate proposals to allow importing of WASM modules and JavaScript modules. 

The problem here is that you might reasonably assume seeing the current feature that you can import all module types. In fact you can import none by default. What this does is add a subfeature for WASM module import which is supported in FF on nightly AND behind a pref. 
I'd have to add a record anyway when this ships.

The spec link here fails CI: https://webassembly.github.io/esm-integration/js-api/index.html#esm-integration

I wanted to check this is the right URL to use before we try get it into browser specs.
The relevant links are https://github.com/tc39/proposal-source-phase-imports , but the bit that will allow this to be used in JS is https://github.com/WebAssembly/esm-integration/tree/master/proposals/esm-integration. I think the link above is the most reasonable place since it it explicitly mentions both cases.

Related docs work can be tracked in https://github.com/mdn/content/issues/44475

