### PR TITLE
Updates for Safari 27 beta (second run)

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -788,7 +788,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "27"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -1993,7 +1993,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "27"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/GPUSupportedLimits.json
+++ b/api/GPUSupportedLimits.json
@@ -1112,7 +1112,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "26"
+              "version_added": "26",
+              "version_removed": "27"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
This is a follow-up PR to https://github.com/mdn/browser-compat-data/pull/29823

The https://collector.openwebdocs.org project (v10.20.5) found new features shipping in Safari 27 beta (22625.1.24.11.2) on macOS 27.0 Beta (26A5388g).

`ariaNotify` (as found in the first run already) is now also officially mentioned as shipping:
https://developer.apple.com/documentation/safari-release-notes/safari-27-release-notes

The deprecated `maxInterStageShaderComponents` has been removed.

The release notes also say "Added support for the TC39 BigInt Math proposal, exposing Math-equivalent methods on BigInt such as BigInt.pow and BigInt.sqrt. (152472996)" but I can't confirm this. I think it might be behind a (JSC) flag.

@jdatapple, can you review? Am I missing things for the new Safari 27 beta?