### PR TITLE
Improve spec link for `DOMContentLoaded` event

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -93,7 +93,7 @@
         "__compat": {
           "description": "`DOMContentLoaded` event",
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Document/DOMContentLoaded_event",
-          "spec_url": "https://html.spec.whatwg.org/multipage/parsing.html#stop-parsing",
+          "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-domcontentloaded",
           "tags": [
             "web-features:dom"
           ],


### PR DESCRIPTION
Point to the section intended for web developers instead of the browser implementation details. Same justification as #10090 