### PR TITLE
Updates for Chrome 152 beta

### DIFF
--- a/api/DeviceMotionEvent.json
+++ b/api/DeviceMotionEvent.json
@@ -215,7 +215,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -237,7 +237,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/DeviceOrientationEvent.json
+++ b/api/DeviceOrientationEvent.json
@@ -275,7 +275,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -297,7 +297,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -297,7 +297,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -316,8 +316,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "preview",
-              "impl_url": "https://crbug.com/493315747"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -996,6 +996,37 @@
           }
         }
       },
+      "cpuPerformance": {
+        "__compat": {
+          "spec_url": "https://wicg.github.io/cpu-performance/#dom-navigator-cpuperformance",
+          "support": {
+            "chrome": {
+              "version_added": "152"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "createAuctionNonce": {
         "__compat": {
           "tags": [

--- a/api/PermissionsPolicy.json
+++ b/api/PermissionsPolicy.json
@@ -5,7 +5,7 @@
         "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#permissionspolicy",
         "support": {
           "chrome": {
-            "version_added": "preview"
+            "version_added": "152"
           },
           "chrome_android": "mirror",
           "edge": "mirror",
@@ -35,7 +35,7 @@
           "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicy-allowedfeatures",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -66,7 +66,7 @@
           "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicy-allowsfeature",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -97,7 +97,7 @@
           "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicy-features",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -128,7 +128,7 @@
           "spec_url": "https://w3c.github.io/webappsec-permissions-policy/#dom-permissionspolicy-getallowlistforfeature",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/window-drag.json
+++ b/css/properties/window-drag.json
@@ -6,7 +6,7 @@
           "spec_url": "https://drafts.csswg.org/css-ui-4/#propdef-window-drag",
           "support": {
             "chrome": {
-              "version_added": "preview"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,7 +36,7 @@
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-window-drag-move",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "152"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -67,7 +67,7 @@
             "spec_url": "https://drafts.csswg.org/css-ui-4/#valdef-window-drag-none",
             "support": {
               "chrome": {
-                "version_added": "preview"
+                "version_added": "152"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/selectors/buffering.json
+++ b/css/selectors/buffering.json
@@ -14,7 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/muted.json
+++ b/css/selectors/muted.json
@@ -14,7 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/paused.json
+++ b/css/selectors/paused.json
@@ -14,8 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40748199"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/playing.json
+++ b/css/selectors/playing.json
@@ -14,8 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
-              "impl_url": "https://crbug.com/40748199"
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/seeking.json
+++ b/css/selectors/seeking.json
@@ -14,7 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/stalled.json
+++ b/css/selectors/stalled.json
@@ -14,7 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/selectors/volume-locked.json
+++ b/css/selectors/volume-locked.json
@@ -14,7 +14,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -125,7 +125,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.20.5) found new features shipping in Chromium 152 beta which was released on Friday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Canary/behind flags, it is not considered here.

With this PR, BCD will consider the following 21 features as shipping in Chromium 152 (**bold** features are new keys in BCD).

- api.DeviceMotionEvent.requestPermission_static
- api.DeviceOrientationEvent.requestPermission_static
- api.HTMLElement.autocorrect
- api.HTMLTemplateElement.shadowRootSlotAssignment
- **api.Navigator.cpuPerformance**
- api.PermissionsPolicy
- api.PermissionsPolicy.allowedFeatures
- api.PermissionsPolicy.allowsFeature
- api.PermissionsPolicy.features
- api.PermissionsPolicy.getAllowlistForFeature
- css.properties.window-drag
- css.properties.window-drag.move
- css.properties.window-drag.none
- css.selectors.buffering
- css.selectors.muted
- css.selectors.paused
- css.selectors.playing
- css.selectors.seeking
- css.selectors.stalled
- css.selectors.volume-locked
- html.global_attributes.autocorrect


See also https://developer.chrome.com/blog/chrome-152-beta and https://chromestatus.com/roadmap