### PR TITLE
Updates for Safari TP 249

### DIFF
--- a/api/CSSFunctionDeclarations.json
+++ b/api/CSSFunctionDeclarations.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSFunctionDescriptors.json
+++ b/api/CSSFunctionDescriptors.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CSSFunctionRule.json
+++ b/api/CSSFunctionRule.json
@@ -21,7 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": false
+            "version_added": "preview"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -55,7 +55,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -90,7 +90,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -125,7 +125,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/GPUAdapterInfo.json
+++ b/api/GPUAdapterInfo.json
@@ -347,7 +347,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -402,7 +402,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/at-rules/function.json
+++ b/css/at-rules/function.json
@@ -23,7 +23,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -57,7 +57,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/white-space-trim.json
+++ b/css/properties/white-space-trim.json
@@ -1,0 +1,171 @@
+{
+  "css": {
+    "properties": {
+      "white-space-trim": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-text-4/#propdef-white-space-trim",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "discard-after": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-trim-discard-after",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "discard-before": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-trim-discard-before",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "discard-inner": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-trim-discard-inner",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#white-space-trim",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/css/properties/wrap-inside.json
+++ b/css/properties/wrap-inside.json
@@ -1,13 +1,9 @@
 {
   "css": {
     "properties": {
-      "text-decoration-inset": {
+      "wrap-inside": {
         "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Reference/Properties/text-decoration-inset",
-          "spec_url": "https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-inset",
-          "tags": [
-            "web-features:text-decoration"
-          ],
+          "spec_url": "https://drafts.csswg.org/css-text-4/#propdef-wrap-inside",
           "support": {
             "chrome": {
               "version_added": false
@@ -15,7 +11,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "146"
+              "version_added": false
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -24,7 +20,9 @@
             "safari": {
               "version_added": "preview"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": false
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -37,10 +35,7 @@
         },
         "auto": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-inset-auto",
-            "tags": [
-              "web-features:text-decoration"
-            ],
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-wrap-inside-auto",
             "support": {
               "chrome": {
                 "version_added": false
@@ -48,7 +43,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "146"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -57,7 +52,42 @@
               "safari": {
                 "version_added": "preview"
               },
-              "safari_ios": "mirror",
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "avoid": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-wrap-inside-avoid",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",
               "webview_ios": "mirror"

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -29,15 +29,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "preview",
-              "flags": [
-                {
-                  "name": "useTemporal",
-                  "value_to_set": "1",
-                  "type": "runtime_flag"
-                }
-              ],
-              "impl_url": "https://webkit.org/b/223166"
+              "version_added": "preview"
             },
             "safari_ios": {
               "version_added": false

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -155,7 +155,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -659,7 +659,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -785,7 +785,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -869,7 +869,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -953,7 +953,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -156,7 +156,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -702,7 +702,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -29,7 +29,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
@@ -70,7 +70,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -112,7 +112,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -154,7 +154,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -196,7 +196,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -238,7 +238,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -280,7 +280,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -29,7 +29,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
@@ -114,7 +114,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -156,7 +156,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -198,7 +198,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -240,7 +240,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -282,7 +282,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -324,7 +324,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -366,7 +366,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -408,7 +408,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -450,7 +450,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -492,7 +492,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -534,7 +534,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -576,7 +576,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -618,7 +618,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -660,7 +660,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -702,7 +702,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -744,7 +744,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -786,7 +786,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -828,7 +828,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -870,7 +870,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -912,7 +912,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -954,7 +954,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -996,7 +996,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1038,7 +1038,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1080,7 +1080,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1122,7 +1122,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1164,7 +1164,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1206,7 +1206,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1248,7 +1248,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1290,7 +1290,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1332,7 +1332,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1376,7 +1376,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1418,7 +1418,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1460,7 +1460,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -29,7 +29,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
@@ -114,7 +114,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -156,7 +156,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -198,7 +198,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -240,7 +240,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -282,7 +282,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -324,7 +324,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -366,7 +366,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -408,7 +408,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -450,7 +450,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -492,7 +492,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -534,7 +534,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -576,7 +576,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -618,7 +618,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -660,7 +660,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -702,7 +702,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -744,7 +744,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -786,7 +786,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -828,7 +828,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -870,7 +870,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -912,7 +912,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -954,7 +954,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -996,7 +996,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1038,7 +1038,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1080,7 +1080,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1122,7 +1122,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1164,7 +1164,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1206,7 +1206,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1248,7 +1248,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1290,7 +1290,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1332,7 +1332,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1374,7 +1374,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1416,7 +1416,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1458,7 +1458,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1500,7 +1500,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1542,7 +1542,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1584,7 +1584,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1628,7 +1628,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1670,7 +1670,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1712,7 +1712,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1754,7 +1754,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -29,7 +29,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
@@ -114,7 +114,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -156,7 +156,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -198,7 +198,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -240,7 +240,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -282,7 +282,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -324,7 +324,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -366,7 +366,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -408,7 +408,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -450,7 +450,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -492,7 +492,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -534,7 +534,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -701,7 +701,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -29,7 +29,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
@@ -114,7 +114,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -156,7 +156,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -198,7 +198,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -240,7 +240,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -282,7 +282,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -324,7 +324,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -366,7 +366,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -408,7 +408,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -450,7 +450,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -492,7 +492,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -534,7 +534,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -576,7 +576,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -618,7 +618,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -660,7 +660,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -702,7 +702,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -744,7 +744,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -786,7 +786,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -828,7 +828,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -870,7 +870,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -912,7 +912,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -954,7 +954,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -996,7 +996,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1038,7 +1038,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -29,7 +29,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://webkit.org/b/223166"
               },
               "safari_ios": "mirror",
@@ -72,7 +72,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -114,7 +114,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -156,7 +156,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -198,7 +198,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -240,7 +240,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -282,7 +282,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -324,7 +324,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -366,7 +366,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -408,7 +408,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -450,7 +450,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -492,7 +492,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -534,7 +534,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -576,7 +576,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -618,7 +618,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -660,7 +660,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -702,7 +702,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -744,7 +744,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -786,7 +786,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -828,7 +828,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -870,7 +870,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -912,7 +912,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -954,7 +954,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -996,7 +996,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1038,7 +1038,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1080,7 +1080,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1122,7 +1122,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1164,7 +1164,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1206,7 +1206,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1248,7 +1248,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1290,7 +1290,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1332,7 +1332,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1374,7 +1374,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1416,7 +1416,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1458,7 +1458,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1500,7 +1500,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1542,7 +1542,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1584,7 +1584,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1626,7 +1626,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1668,7 +1668,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1710,7 +1710,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1752,7 +1752,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1794,7 +1794,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1836,7 +1836,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1878,7 +1878,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1920,7 +1920,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -1962,7 +1962,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -2006,7 +2006,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -2048,7 +2048,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -2090,7 +2090,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -2132,7 +2132,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",
@@ -2174,7 +2174,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false,
+                  "version_added": "preview",
                   "impl_url": "https://webkit.org/b/223166"
                 },
                 "safari_ios": "mirror",


### PR DESCRIPTION
The https://collector.openwebdocs.org project (v10.20.5) found new features shipping in Safari Technical Preview 249 on macOS 27.0 Beta which was released last week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive.

See also https://webkit.org/blog/18182/release-notes-for-safari-technology-preview-249/

This PR now marks the following features as "preview":

- api.CSSFunctionDeclarations
- api.CSSFunctionDeclarations.style
- api.CSSFunctionDescriptors
- api.CSSFunctionDescriptors.result
- api.CSSFunctionRule
- api.CSSFunctionRule.getParameters
- api.CSSFunctionRule.name
- api.CSSFunctionRule.returnType
- api.GPUAdapterInfo.subgroupMaxSize
- api.GPUAdapterInfo.subgroupMinSize
- css.properties.text-decoration-inset
- css.properties.text-decoration-inset.auto
- css.properties.white-space-trim
- css.properties.white-space-trim.discard-after
- css.properties.white-space-trim.discard-before
- css.properties.white-space-trim.discard-inner
- css.properties.white-space-trim.none
- css.properties.wrap-inside
- css.properties.wrap-inside.auto
- css.properties.wrap-inside.avoid
- javascript.builtins.Temporal.*