### PR TITLE
added extra value for line-clamp and support

### DIFF
--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -139,7 +139,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "preview"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -27,10 +27,21 @@
             ],
             "chrome_android": "mirror",
             "edge": "mirror",
-            "firefox": {
-              "prefix": "-webkit-",
-              "version_added": "68"
-            },
+            "firefox": [
+              {
+                "prefix": "-webkit-",
+                "version_added": "68"
+              },
+              {
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.line-clamp.enabled"
+                  }
+                ]
+              }
+            ],
             "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
@@ -77,7 +88,13 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.line-clamp.enabled"
+                  }
+                ]
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -122,7 +139,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -157,6 +174,41 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "68"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "string": {
+          "__compat": {
+            "description": "`<string>`",
+            "spec_url": "https://drafts.csswg.org/css-values-4/#string-value",
+            "tags": [
+              "web-features:line-clamp"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Added `<string>` value for `line-clamp` CSS property
- Updated Firefox support
- Updated Safari support for `no-ellipsis` value

#### Test results and supporting details

- Tested with [this CodePen}(https://codepen.io/editor/CodeRedDigital/pen/019fa94d-bfe3-7700-8314-85b7ae276e3b) in the following Browsers:
  - Chrome 150.0.7871.187 - with Experimental Web Platform features enabled
  - Safari Technical Preview ~~245~~ 249
  - Firefox Beta 154 with `layout.css.line-clamp.enabled` set to true

#### Related issues

- [Content PR](https://github.com/mdn/content/pull/45007)
- [Firefox Release PR](https://github.com/mdn/content/pull/45008)