### PR TITLE
api.FontFaceSet: mark Firefox iterator methods as partial

### DIFF
--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -267,7 +267,7 @@
             "firefox": {
               "version_added": "41",
               "partial_implementation": true,
-              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. Iterating the `FontFaceSet` directly and `forEach()` are unaffected. See [bug 1311198](https://bugzil.la/1311198)."
+              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. See [bug 1311198](https://bugzil.la/1311198)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -374,7 +374,7 @@
             "firefox": {
               "version_added": "41",
               "partial_implementation": true,
-              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. Iterating the `FontFaceSet` directly and `forEach()` are unaffected. See [bug 1311198](https://bugzil.la/1311198)."
+              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. See [bug 1311198](https://bugzil.la/1311198)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -671,7 +671,7 @@
             "firefox": {
               "version_added": "41",
               "partial_implementation": true,
-              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. Iterating the `FontFaceSet` directly and `forEach()` are unaffected. See [bug 1311198](https://bugzil.la/1311198)."
+              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. See [bug 1311198](https://bugzil.la/1311198)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/FontFaceSet.json
+++ b/api/FontFaceSet.json
@@ -265,7 +265,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "41"
+              "version_added": "41",
+              "partial_implementation": true,
+              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. Iterating the `FontFaceSet` directly and `forEach()` are unaffected. See [bug 1311198](https://bugzil.la/1311198)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -370,7 +372,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "41"
+              "version_added": "41",
+              "partial_implementation": true,
+              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. Iterating the `FontFaceSet` directly and `forEach()` are unaffected. See [bug 1311198](https://bugzil.la/1311198)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -665,7 +669,9 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "41"
+              "version_added": "41",
+              "partial_implementation": true,
+              "notes": "The returned iterator object has a `next()` method but does not implement `Symbol.iterator`, so it cannot be used with `for...of` or spread syntax. Iterating the `FontFaceSet` directly and `forEach()` are unaffected. See [bug 1311198](https://bugzil.la/1311198)."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

Marks `api.FontFaceSet.values`, `.keys`, and `.entries` as `partial_implementation` in Firefox. The methods exist and return an object with a working `next()`, but that object does not implement `Symbol.iterator`, so spread syntax and `for...of` throw. The Firefox `version_added` value is unchanged; this has been the behavior since the feature shipped.

`api.FontFaceSet.@@iterator` and `.forEach` were tested and work correctly, so they are left unchanged.

#### Test results and supporting details

Tested on <https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/values> (13 loaded font faces at time of testing; `document.fonts.size === 13` in both browsers), Firefox 153.0.1 vs Chrome 151:
| check | Firefox 153.0.1 | Chrome 151 |
| --- | --- | --- |
| `values()` constructor | `Object` | `Iterator` |
| `values()[Symbol.iterator]` | `undefined` | `function` |
| `values().next()` | `{done: false, value: FontFace}` | `{done: false, value: FontFace}` |
| `[...values()]` | throws `values() is not iterable` | 13 |
| `[...keys()]` | throws `keys() is not iterable` | 13 |
| `[...entries()]` | throws `entries() is not iterable` | 13 |
| `for...of` over the set | 13 | 13 |
| `Array.from(set)` | 13 | 13 |
| `forEach()` | 13 | 13 |

Tracked upstream in [bug 1311198](https://bugzil.la/1311198) (open, `webcompat:platform-bug`), with [1729089](https://bugzil.la/1729089), [1729997](https://bugzil.la/1729997), and [1780657](https://bugzil.la/1780657) filed as duplicates. It has caused observable site breakage — see [bug 1831949](https://bugzil.la/1831949).

Thanks to @jjspace for the report and the bug links.

#### Related issues

Fixes #28106