### PR TITLE
Chrome 148 linear_indexing WGSL extension

### DIFF
--- a/api/WGSLLanguageFeatures.json
+++ b/api/WGSLLanguageFeatures.json
@@ -108,6 +108,42 @@
           }
         }
       },
+      "extension_linear_indexing": {
+        "__compat": {
+          "description": "`linear_indexing` extension",
+          "spec_url": "https://gpuweb.github.io/gpuweb/wgsl/#language_extension-linear_indexing",
+          "tags": [
+            "web-features:webgpu"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "148",
+              "notes": "Supported on ChromeOS, macOS, Windows, and Linux (Intel Gen12+ GPUs only)."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "extension_packed_4x8_integer_dot_product": {
         "__compat": {
           "description": "`packed_4x8_integer_dot_product` extension",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 148 adds support for the [`linear_indexing`](https://gpuweb.github.io/gpuweb/wgsl/#language_extension-linear_indexing) WGSL extension. See https://chromestatus.com/feature/5071243424432128.

This PR adds a data point for the new feature.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
