### PR TITLE
Chrome 148 RTCPeerConnection() constructor alwaysNegotiateDataChannels

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -126,6 +126,41 @@
             "deprecated": false
           }
         },
+        "configuration_alwaysNegotiateDataChannels_parameter": {
+          "__compat": {
+            "description": "`configuration.alwaysNegotiateDataChannels` parameter",
+            "spec_url": "https://w3c.github.io/webrtc-extensions/#dom-rtcconfiguration-alwaysnegotiatedatachannels",
+            "tags": [
+              "web-features:webrtc"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "148"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "configuration_bundlePolicy_parameter": {
           "__compat": {
             "description": "`configuration.bundlePolicy` parameter",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 148 adds support for the [`RTCPeerConnection()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection) [`alwaysNegotiateDataChannels`](https://w3c.github.io/webrtc-extensions/#dom-rtcconfiguration-alwaysnegotiatedatachannels) config option. See https://chromestatus.com/feature/5113419982307328.

This PR adds a data point for the new config option.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
