### PR TITLE
Updates for Firefox Nightly, 05-08-2026

### DIFF
--- a/api/AudioSession.json
+++ b/api/AudioSession.json
@@ -14,8 +14,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false,
-            "impl_url": "https://bugzil.la/1921506"
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -35,6 +34,73 @@
           "deprecated": false
         }
       },
+      "state": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/audio-session/#dom-audiosession-state",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "statechange_event": {
+        "__compat": {
+          "description": "`statechange` event",
+          "spec_url": "https://w3c.github.io/audio-session/#dom-audiosession-onstatechange",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "type": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AudioSession/type",
@@ -49,7 +115,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/Element.json
+++ b/api/Element.json
@@ -481,7 +481,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -516,7 +516,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -349,8 +349,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1921506"
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "nodejs": {

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -82,6 +82,108 @@
           }
         }
       },
+      "hash": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/hash",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "host": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/host",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "hostname": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/hostname",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "href": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/href",
@@ -199,6 +301,108 @@
           }
         }
       },
+      "origin": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/origin",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "password": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/password",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "pathname": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/pathname",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "ping": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/ping",
@@ -231,6 +435,74 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "port": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/port",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "protocol": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/protocol",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }
@@ -340,6 +612,40 @@
           }
         }
       },
+      "search": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/search",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "target": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/target",
@@ -418,6 +724,40 @@
           },
           "status": {
             "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "username": {
+        "__compat": {
+          "mdn_url": "https://developer.mozilla.org/docs/Web/API/SVGAElement/username",
+          "spec_url": "https://w3c.github.io/svgwg/svg2-draft/linking.html#InterfaceSVGAElement",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -571,7 +571,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -768,7 +768,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -776,6 +776,39 @@
             "opera_android": "mirror",
             "safari": {
               "version_added": "26.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "exportKeyingMaterial": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/webtransport/#dom-webtransport-exportkeyingmaterial",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview"
+            },
+            "firefox_android": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -968,7 +1001,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -98,7 +98,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WebTransportDatagramsWritable.json
+++ b/api/WebTransportDatagramsWritable.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -74,7 +74,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WebTransportSendGroup.json
+++ b/api/WebTransportSendGroup.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": false
+            "version_added": "preview"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WebTransportSendStream.json
+++ b/api/WebTransportSendStream.json
@@ -141,7 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "preview"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
### Summary

Updates from a Collector run (v10.20.6) in today's Firefox Nightly.

#### Test results and supporting details

##### Audio session

See https://bugzilla.mozilla.org/show_bug.cgi?id=2055710

api.AudioSession
api.AudioSession.state
api.AudioSession.statechange_event
api.AudioSession.type
api.Navigator.audioSession

##### Animation ranges

See https://bugzilla.mozilla.org/show_bug.cgi?id=2006262

api.Element.animate.options_rangeEnd_parameter
api.Element.animate.options_rangeStart_parameter

##### SVGAElement

See https://bugzilla.mozilla.org/show_bug.cgi?id=2058578

api.SVGAElement.hash
api.SVGAElement.host
api.SVGAElement.hostname
api.SVGAElement.origin
api.SVGAElement.password
api.SVGAElement.pathname
api.SVGAElement.port
api.SVGAElement.protocol
api.SVGAElement.search
api.SVGAElement.username

##### WebTransport

See https://bugzilla.mozilla.org/show_bug.cgi?id=2007200, https://bugzilla.mozilla.org/show_bug.cgi?id=2007174, https://bugzilla.mozilla.org/show_bug.cgi?id=2007165, https://bugzilla.mozilla.org/show_bug.cgi?id=2007160

api.WebTransport.createSendGroup
api.WebTransport.draining
api.WebTransport.exportKeyingMaterial
api.WebTransport.protocol
api.WebTransportDatagramDuplexStream.createWritable
api.WebTransportDatagramsWritable
api.WebTransportDatagramsWritable.sendGroup
api.WebTransportDatagramsWritable.sendOrder
api.WebTransportSendGroup
api.WebTransportSendGroup.getStats
api.WebTransportSendStream.sendGroup

#### Related issues

None.