### PR TITLE
Add notes to explain text-flow: ellipsis sometimes behaving as clip

### DIFF
--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -173,7 +173,11 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "9"
+                "version_added": "9",
+                "notes": [
+                  "In textual `<input>` and `<textarea>` elements, behaves as `clip`.",
+                  "In `contenteditable` elements, behaves as `clip` while the element is focused."
+                ]
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/properties/text-overflow.json
+++ b/css/properties/text-overflow.json
@@ -115,14 +115,23 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "1"
+                "version_added": "1",
+                "notes": [
+                  "In `<textarea>` elements, behaves as `clip`.",
+                  "In textual `<input>` elements, behaves as `clip` while the element is focused.",
+                  "From version 149, in `contenteditable` elements, behaves as `clip` while the element is focused."
+                ]
               },
               "chrome_android": "mirror",
               "edge": {
                 "version_added": "12"
               },
               "firefox": {
-                "version_added": "7"
+                "version_added": "7",
+                "notes": [
+                  "In textual `<input>` and `<textarea>` elements, behaves as `clip`.",
+                  "In `contenteditable` elements, behaves as `clip` while the element is focused."
+                ]
               },
               "firefox_android": "mirror",
               "ie": {
@@ -132,7 +141,11 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "1.3"
+                "version_added": "1.3",
+                "notes": [
+                  "In `<textarea>` elements, behaves as `clip`.",
+                  "In textual `<input>` elements, behaves as `clip` while the element is focused."
+                ]
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

As of Chrome 149, the behavior of [`text-overflow: ellipsis`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-overflow#ellipsis) when applied to `contenteditable` elements has changed — it now behaves as `text-overflow: clip` while the elements are focused, to make it so that the text can be scanned and edited. See https://chromestatus.com/feature/5146265241387008.

While I was doing this, I fell down a bit of a rabbit hole and also tested the behavior of other browsers for `ellipsis` and also for string values of `text-overflow`. The notes I've added here describe what I found in my tests.

See https://codepen.io/editor/Chris-Mills/pen/019fd2ca-c668-7925-a7c0-dbce3a12bcfb for my test.

Note that I haven't added notes to say what version most of the various browser behaviors were first observed in. I'm really not sure how to get that information, and I think that, for most of them, it has been like this long enough that the versions aren't really that important. For example, the Firefox notes are true for the last few versions, as are the Safari notes.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
