### PR TITLE
Chrome 149 active WebSockets no longer stop pages entering bfcache

### DIFF
--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -409,7 +409,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "125"
+              "version_added": "125",
+              "notes": "From version 149, pages with active WebSockets can enter the bfcache; the WebSocket connections are disconnected upon entry."
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From version 149, Chrome no longer allows active WebSocket connections to block pages from entering the [bfcache](https://developer.mozilla.org/en-US/docs/Web/API/Performance_API/Monitoring_bfcache_blocking_reasons). The WebSocket connections are disconnected upon the page entering the cache, and can be reconnected when the page is navigated to again.

See https://chromestatus.com/feature/5068439115923456.

This PR adds a note to cover this behavior change.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
