### PR TITLE
Remove masonry keys

### DIFF
--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -164,27 +164,24 @@
         },
         "masonry": {
           "__compat": {
-            "spec_url": "https://drafts.csswg.org/css-grid-3/#grid-lanes-model",
             "tags": [
               "web-features:masonry"
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/40128480"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": false
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
-                "impl_url": "https://webkit.org/b/248287"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -192,9 +189,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },

--- a/css/properties/grid-template-columns.json
+++ b/css/properties/grid-template-columns.json
@@ -162,39 +162,6 @@
             }
           }
         },
-        "masonry": {
-          "__compat": {
-            "tags": [
-              "web-features:masonry"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "max-content": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content",

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -165,14 +165,12 @@
         "masonry": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Guides/Grid_layout/Masonry_layout",
-            "spec_url": "https://drafts.csswg.org/css-grid-3/#grid-lanes-model",
             "tags": [
               "web-features:masonry"
             ],
             "support": {
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/40128480"
+                "version_added": false
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -184,8 +182,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview",
-                "impl_url": "https://webkit.org/b/248287"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -193,9 +190,9 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
-              "standard_track": true,
-              "deprecated": false
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": true
             }
           }
         },

--- a/css/properties/grid-template-rows.json
+++ b/css/properties/grid-template-rows.json
@@ -162,40 +162,6 @@
             }
           }
         },
-        "masonry": {
-          "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/CSS/Guides/Grid_layout/Masonry_layout",
-            "tags": [
-              "web-features:masonry"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "preview"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": true
-            }
-          }
-        },
         "max-content": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-grid-2/#valdef-grid-template-columns-max-content",


### PR DESCRIPTION
#### Summary

It seems like masonry is not really a thing anymore and it never shipped in browsers. Remove it as is an all-false, deprecated and non-standard feature.

Fix https://github.com/mdn/browser-compat-data/issues/29953

#### Related issues

https://github.com/web-platform-dx/web-features/pull/4225