### PR TITLE
`api.EXT_texture_compression_rgtc`: set Safari iOS to 18.5

### DIFF
--- a/api/EXT_texture_compression_rgtc.json
+++ b/api/EXT_texture_compression_rgtc.json
@@ -33,7 +33,9 @@
           "safari": {
             "version_added": "14.1"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "18.5"
+          },
           "samsunginternet_android": {
             "version_added": false
           },


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is a more conservative take on https://github.com/mdn/browser-compat-data/pull/30113.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Testing on Browser Stack could not confirm iOS support before iOS 18.5. It might be hardware limitation or a true lack of support. I don't know, so I'm taking the worst-case value. If someone has more information, then I'd expect to see that in a follow up PR in the future.

Also, a contributor from Apple didn't set `mirror` previously, in https://github.com/mdn/browser-compat-data/pull/10129.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Kicked off by https://github.com/web-platform-dx/web-features/pull/4228/
- https://github.com/mdn/browser-compat-data/pull/10129
- https://github.com/mdn/browser-compat-data/pull/30113

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
