### PR TITLE
Firefox/Android supports viewport-fit

### DIFF
--- a/html/elements/meta/name/viewport/viewport-fit.json
+++ b/html/elements/meta/name/viewport/viewport-fit.json
@@ -20,7 +20,9 @@
                   "firefox": {
                     "version_added": false
                   },
-                  "firefox_android": "mirror",
+                  "firefox_android": {
+                    "version_added": "79"
+                  },
                   "oculus": "mirror",
                   "opera": "mirror",
                   "opera_android": "mirror",
@@ -55,7 +57,9 @@
                     "firefox": {
                       "version_added": false
                     },
-                    "firefox_android": "mirror",
+                    "firefox_android": {
+                      "version_added": "79"
+                    },
                     "oculus": "mirror",
                     "opera": "mirror",
                     "opera_android": "mirror",
@@ -91,7 +95,9 @@
                     "firefox": {
                       "version_added": false
                     },
-                    "firefox_android": "mirror",
+                    "firefox_android": {
+                      "version_added": "79"
+                    },
                     "oculus": "mirror",
                     "opera": "mirror",
                     "opera_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 79+ for Android supports `viewport-fit`.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1574307

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

https://bugzilla.mozilla.org/show_bug.cgi?id=1574307

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
