### PR TITLE
Add deprecated HTMLBodyElement.onorientationchange

### DIFF
--- a/api/HTMLBodyElement.json
+++ b/api/HTMLBodyElement.json
@@ -213,6 +213,49 @@
           }
         }
       },
+      "orientationchange_event": {
+        "__compat": {
+          "description": "`orientationchange` event",
+          "spec_url": "https://compat.spec.whatwg.org/#windoworientation-interface",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": {
+              "version_added": "18"
+            },
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": {
+              "version_added": "44"
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": {
+              "version_added": "≤14"
+            },
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": {
+              "version_added": "≤3"
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": true
+          }
+        }
+      },
       "text": {
         "__compat": {
           "spec_url": "https://html.spec.whatwg.org/multipage/obsolete.html#dom-body-text",


### PR DESCRIPTION
#### Summary

Per the compat standard https://compat.spec.whatwg.org/#windoworientation-interface `HTMLBodyElement` also has an `orientationchange` event.

#### Test results and supporting details

Same as https://developer.mozilla.org/en-US/docs/Web/API/Window/orientationchange_event#browser_compatibility

#### Related issues

None.
