### PR TITLE
fix(gentypes): support spawn on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "c8": "~12.0.0",
         "cli-progress": "^3.12.0",
         "compare-versions": "~6.1.0",
+        "cross-spawn": "^7.0.6",
         "deep-diff": "~1.0.2",
         "diff": "^9.0.0",
         "es-main": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "c8": "~12.0.0",
     "cli-progress": "^3.12.0",
     "compare-versions": "~6.1.0",
+    "cross-spawn": "^7.0.6",
     "deep-diff": "~1.0.2",
     "diff": "^9.0.0",
     "es-main": "~1.4.0",

--- a/utils/spawn.js
+++ b/utils/spawn.js
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import spawn from 'cross-spawn';
 
 /** @import {SpawnSyncOptionsWithStringEncoding} from 'node:child_process' */
 
@@ -10,7 +10,7 @@ import { spawnSync } from 'node:child_process';
  * @returns {string} The output from the command
  */
 export default (command, args, opts) => {
-  const result = spawnSync(command, args, {
+  const result = spawn.sync(command, args, {
     ...opts,
     encoding: 'utf8',
     shell: false,


### PR DESCRIPTION
#### Summary

Fix Windows command spawning during the installation/build toolchain.

On Windows, `utils/spawn.js` used Node's native `spawnSync()` with `shell: false`, which could not resolve npm's `.cmd` executables such as `tsc`, causing `npm install`/`npm ci` to fail with `spawnSync tsc ENOENT`.

This changes the shared spawn utility to use `cross-spawn`, which correctly handles Windows command resolution while preserving the existing non-shell behavior.

#### Test results and supporting details

* Reproduced the original `spawnSync tsc ENOENT` failure on Windows.
* Verified `npm run gentypes` succeeds after the fix.
* Verified the unit test suite: **315 passed, 0 failed**.
* Verified a clean `npm ci` installation succeeds on Windows.
* Verified the clean install successfully runs:

  * `npm run gentypes`
  * `npm run build`
* Verified `git diff --check` passes.
* Pre-commit/pre-push checks passed: lint, ESLint, TypeScript, and Prettier.

#### Related issues

Closes #29405
