### PR TITLE
fix(css): mark Safari 26 scope support as partial

### DIFF
--- a/css/at-rules/scope.json
+++ b/css/at-rules/scope.json
@@ -22,9 +22,21 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "17.4"
-            },
+            "safari": [
+              {
+                "version_added": "26.4"
+              },
+              {
+                "version_added": "26",
+                "version_removed": "26.4",
+                "partial_implementation": true,
+                "notes": "CSS rules within `@scope` are not applied to `<input>` and `<textarea>` elements."
+              },
+              {
+                "version_added": "17.4",
+                "version_removed": "26"
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
#### Summary

Update Safari compatibility data for `@scope` to reflect the regression in Safari 26.0–26.3.

Safari 26.0–26.3 did not apply CSS rules inside `@scope` to elements such as `<input>` and `<textarea>`. Safari 26.4 fixed this issue, so these versions are now marked as partial support.

#### Test results and supporting details

- `npm run lint`
- `npm run format`
- `git diff --check`

The change is based on WebKit bug 305369 and the Safari 26.4 release notes.

#### Related issues

Fixes #29259