### PR TITLE
fix: update Safari mask-mode compatibility

### DIFF
--- a/css/properties/mask-mode.json
+++ b/css/properties/mask-mode.json
@@ -22,7 +22,9 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "15.4"
+              "version_added": "15.4",
+              "partial_implementation": true,
+              "notes": "When the mask source is an SVG &lt;mask&gt; element, Safari incorrectly uses an alpha mask instead of a luminance mask. This causes `mask-mode: match-source` to behave incorrectly. See https://webkit.org/b/282530."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -89,7 +91,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "15.4"
+                "version_added": "15.4",
+                "partial_implementation": true,
+                "notes": "`mask-mode: luminance` does not always have the expected effect. See https://webkit.org/b/282530."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Update Safari compatibility data for `mask-mode` to reflect its partial implementation. Safari incorrectly uses an alpha mask instead of a luminance mask for SVG `<mask>` sources, and `mask-mode: luminance` does not always produce the expected effect.

#### Test results and supporting details

- `npm run lint` — passed
- `npm test` — formatting, linting, and TypeScript checks passed; unit tests could not run because the package script uses Unix-style `NODE_ENV=test`, which is not recognized by Windows PowerShell.
- `git diff --check` — passed
- Prettier and lint fixer passed during commit

#### Related issues

- Fixes [mdn/browser-compat-data#26632](https://github.com/mdn/browser-compat-data/issues/26632)
- References [WebKit Bug #282530](https://webkit.org/b/282530)