### PR TITLE
Update new-password autocomplete support data

### DIFF
--- a/html/elements/form.json
+++ b/html/elements/form.json
@@ -164,19 +164,19 @@
               "spec_url": "https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password",
               "support": {
                 "chrome": {
-                  "version_added": false
+                  "version_added": "69"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "67"
+                  "version_added": "69"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "10"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Update support data for the `autocomplete="new-password"` value in Chrome, Firefox, and Safari.

#### Test results and supporting details

- `npm test` (315 tests passed)
- Chrome implementation: https://github.com/chromium/chromium/commit/4703e86794f4fe564f5c7918576aa439a3c36c46
- Firefox implementation: https://bugzilla.mozilla.org/show_bug.cgi?id=1548381
- Safari implementation: https://github.com/WebKit/WebKit/commit/f4982c32c7ce28b80d7a515b4824d8e6aad175a0
- Specification: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-autocomplete-new-password

#### Related issues

Fixes #23318
