### PR TITLE
Add hgroup implicit role compatibility data

### DIFF
--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -48,7 +48,7 @@
         },
         "implicit_group_role": {
           "__compat": {
-            "description": "Has an implicit `role="group"`",
+            "description": "Has an implicit `role='group'`",
             "spec_url": "https://w3c.github.io/html-aam/#el-hgroup",
             "tags": [
               "web-features:hgroup"

--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -45,6 +45,42 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "implicit_group_role": {
+          "__compat": {
+            "description": "Has an implicit `group` role.",
+            "spec_url": "https://w3c.github.io/html-aam/#el-hgroup",
+            "tags": [
+              "web-features:hgroup"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "113"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "124"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/253595"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/html/elements/hgroup.json
+++ b/html/elements/hgroup.json
@@ -48,7 +48,7 @@
         },
         "implicit_group_role": {
           "__compat": {
-            "description": "Has an implicit `group` role.",
+            "description": "Has an implicit `role="group"`",
             "spec_url": "https://w3c.github.io/html-aam/#el-hgroup",
             "tags": [
               "web-features:hgroup"


### PR DESCRIPTION
#### Summary

Add a behavioral subfeature for the `<hgroup>` element's implicit `group` role, including the Chrome and Firefox adoption versions and Safari's current lack of support.

#### Test results and supporting details

- `npm test` (315 tests passed)
- Chrome implementation and release: https://chromiumdash.appspot.com/commit/db0d05b836904e1c6e60bf35263e9b9773524118
- Firefox implementation: https://bugzilla.mozilla.org/show_bug.cgi?id=1821156
- Safari tracking bug: https://webkit.org/b/253595
- HTML Accessibility API Mappings: https://w3c.github.io/html-aam/#el-hgroup

#### Related issues

Fixes #23663
