### PR TITLE
Add details ToggleEvent compatibility data

### DIFF
--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -2944,6 +2944,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "uses_toggleevent": {
+            "__compat": {
+              "description": "`toggle` event uses the `ToggleEvent` interface",
+              "spec_url": "https://html.spec.whatwg.org/multipage/indices.html#event-toggle",
+              "tags": [
+                "web-features:details"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "119"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "120"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "17.2"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "dialog_elements": {


### PR DESCRIPTION
## Summary

- add compatibility data for `ToggleEvent` usage by the `toggle` event on `<details>` elements
- record support from Chrome 119, Firefox 120, and Safari 17.2

## Test

- `npm test` (315 tests passed)

## Sources

- [Chromium implementation](https://chromiumdash.appspot.com/commit/60fb44f3fd569fe34e39d475b3d55bad3dce26ed)
- [Firefox implementation](https://bugzilla.mozilla.org/show_bug.cgi?id=1817122)
- [WebKit implementation](https://bugs.webkit.org/show_bug.cgi?id=252373)
- [HTML specification](https://html.spec.whatwg.org/multipage/indices.html#event-toggle)

Fixes #23664.
