### PR TITLE
fix: update Error.isError compatibility data

### DIFF
--- a/javascript/builtins/Error.json
+++ b/javascript/builtins/Error.json
@@ -399,7 +399,9 @@
             ],
             "support": {
               "bun": {
-                "version_added": "1.1.39"
+                "version_added": "1.1.39",
+                "partial_implementation": true,
+                "notes": "Returns `false` for `DOMException` instances. See [issue 15821](https://github.com/oven-sh/bun/issues/15821)."
               },
               "chrome": {
                 "version_added": "134"
@@ -430,7 +432,7 @@
               "safari": {
                 "version_added": "18.4",
                 "partial_implementation": true,
-                "notes": "Returns `false` for `DOMException` instances."
+                "notes": "Returns `false` for `DOMException` instances. See [bug 292727](https://webkit.org/b/292727)."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Mark Bun as partially supporting `Error.isError()` because it returns `false` for `DOMException` instances, and add a link to WebKit bug 292727 in Safari's existing partial-support note.

#### Test results and supporting details

* `git diff --check` passed.
* `npm test` format and lint checks passed.
* BCD linting passed with `All data passed linting!`.
* Unit tests passed: **315 tests, 315 passed, 0 failed**.
* The Bun behavior is documented in [[oven-sh/bun#15821](https://github.com/oven-sh/bun/issues/15821)](https://github.com/oven-sh/bun/issues/15821).
* The Safari/WebKit issue is documented in [[WebKit bug 292727](https://webkit.org/b/292727)](https://webkit.org/b/292727).

#### Related issues

Fixes #28300