### PR TITLE
fix(css): mark Safari SVG mask support as partial

### DIFF
--- a/css/properties/mask-image.json
+++ b/css/properties/mask-image.json
@@ -141,7 +141,9 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "4"
+                "version_added": "4",
+                "partial_implementation": true,
+                "notes": "Does not support referencing an SVG `<mask>` element from a non-SVG element."
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",


### PR DESCRIPTION
#### Summary

Update Safari compatibility data for the `mask-image` `svg_masks` subfeature to reflect its partial implementation. Safari does not support referencing an SVG `<mask>` element from a non-SVG element.

#### Test results and supporting details

* `npx prettier --check css/properties/mask-image.json` — passed
* `npm run lint -- css/properties/mask-image.json` — passed
* Unit tests — 315 passed, 0 failed
* `git diff --check` — passed

#### Related issues

Fixes #26358
