### PR TITLE
Add HTML Processing Instruction entry

### DIFF
--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -43,7 +43,7 @@
           "deprecated": false
         }
       },
-      "doc-html": {
+      "doc_html": {
         "__compat": {
           "description": "HTML document support",
           "spec_url": "https://html.spec.whatwg.org/multipage/syntax.html#processing-instructions",

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -43,6 +43,38 @@
           "deprecated": false
         }
       },
+      "doc-html": {
+        "__compat": {
+          "description": "HTML document support",
+          "spec_url": "https://html.spec.whatwg.org/multipage/syntax.html#processing-instructions",
+          "support": {
+            "chrome": {
+              "version_added": "150"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getAttribute": {
         "__compat": {
           "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-getattribute",

--- a/api/ProcessingInstruction.json
+++ b/api/ProcessingInstruction.json
@@ -75,6 +75,50 @@
           }
         }
       },
+      "doc_xml": {
+        "__compat": {
+          "description": "XML document support",
+          "spec_url": "https://dom.spec.whatwg.org/#interface-processinginstruction",
+          "tags": [
+            "web-features:dom"
+          ],
+          "support": {
+            "chrome": {
+              "version_added": "1"
+            },
+            "chrome_android": "mirror",
+            "edge": {
+              "version_added": "12"
+            },
+            "firefox": {
+              "version_added": "1"
+            },
+            "firefox_android": "mirror",
+            "ie": {
+              "version_added": "9"
+            },
+            "oculus": "mirror",
+            "opera": {
+              "version_added": "≤12.1"
+            },
+            "opera_android": {
+              "version_added": "≤12.1"
+            },
+            "safari": {
+              "version_added": "1"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": false,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "getAttribute": {
         "__compat": {
           "spec_url": "https://dom.spec.whatwg.org/#dom-processinginstruction-getattribute",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 150 supports Processing Instructions in HTML documents.

Prior to this they were treated as comments by all browsers [as noted in MDN](https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction) (I'm in the process of updating that too btw!):

> Warning: ProcessingInstruction nodes are only supported in XML documents, not in HTML documents. In these, a process instruction will be considered as a comment and be represented as a [Comment](https://developer.mozilla.org/en-US/docs/Web/API/Comment) object in the tree.

Chrome also added some extra methods (`getAttribute`, `getAttributeNames`...etc) which are [already in BCD](https://developer.mozilla.org/en-US/docs/Web/API/ProcessingInstruction#browser_compatibility) but they are somewhat separate to the support of Processing Instructions in HTML docs, and it may not be obvious to most developers that these are linked. So I think worth adding another entry for that.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://wpt.fyi/results/html/syntax/parsing/html5lib_url.html%3Ffile%3Dprocessing-instructions?label=master&label=experimental&aligned&q=Processing%20Instructions

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromestatus.com/feature/6534495085920256

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
