### PR TITLE
Chrome 149 user action pseudo-class top-layer boundary

### DIFF
--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -95,6 +95,39 @@
               "deprecated": false
             }
           }
+        },
+        "top-layer_ancestor_matching_boundary": {
+          "__compat": {
+            "description": "Observes [top-layer ancestor matching boundary](https://developer.mozilla.org/docs/Web/CSS/Reference/Selectors/Pseudo-classes#top-layer_ancestor_matching_boundary) behavior",
+            "spec_url": "https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2025235"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/active.json
+++ b/css/selectors/active.json
@@ -99,7 +99,7 @@
         "top-layer_ancestor_matching_boundary": {
           "__compat": {
             "description": "Observes [top-layer ancestor matching boundary](https://developer.mozilla.org/docs/Web/CSS/Reference/Selectors/Pseudo-classes#top-layer_ancestor_matching_boundary) behavior",
-            "spec_url": "https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
+            "spec_url": "https://drafts.csswg.org/selectors/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
             "support": {
               "chrome": {
                 "version_added": "149"

--- a/css/selectors/focus-within.json
+++ b/css/selectors/focus-within.json
@@ -35,6 +35,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "top-layer_ancestor_matching_boundary": {
+          "__compat": {
+            "description": "Observes [top-layer ancestor matching boundary](https://developer.mozilla.org/docs/Web/CSS/Reference/Selectors/Pseudo-classes#top-layer_ancestor_matching_boundary) behavior",
+            "spec_url": "https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2025235"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/focus-within.json
+++ b/css/selectors/focus-within.json
@@ -39,7 +39,7 @@
         "top-layer_ancestor_matching_boundary": {
           "__compat": {
             "description": "Observes [top-layer ancestor matching boundary](https://developer.mozilla.org/docs/Web/CSS/Reference/Selectors/Pseudo-classes#top-layer_ancestor_matching_boundary) behavior",
-            "spec_url": "https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
+            "spec_url": "https://drafts.csswg.org/selectors/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
             "support": {
               "chrome": {
                 "version_added": "149"

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -153,6 +153,39 @@
               "deprecated": false
             }
           }
+        },
+        "top-layer_ancestor_matching_boundary": {
+          "__compat": {
+            "description": "Observes [top-layer ancestor matching boundary](https://developer.mozilla.org/docs/Web/CSS/Reference/Selectors/Pseudo-classes#top-layer_ancestor_matching_boundary) behavior",
+            "spec_url": "https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
+            "support": {
+              "chrome": {
+                "version_added": "149"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/2025235"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/selectors/hover.json
+++ b/css/selectors/hover.json
@@ -157,7 +157,7 @@
         "top-layer_ancestor_matching_boundary": {
           "__compat": {
             "description": "Observes [top-layer ancestor matching boundary](https://developer.mozilla.org/docs/Web/CSS/Reference/Selectors/Pseudo-classes#top-layer_ancestor_matching_boundary) behavior",
-            "spec_url": "https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
+            "spec_url": "https://drafts.csswg.org/selectors/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element",
             "support": {
               "chrome": {
                 "version_added": "149"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 149 adds [User Action pseudo-class top-layer matching boundary behavior](https://www.w3.org/TR/selectors-4/#useraction-pseudos:~:text=they%20also%20match%20on%20the%20element%E2%80%99s%20flat%20tree%20ancestors%2C%20up%20to%20and%20including%20the%20first%20top%20layer%20element): see https://chromestatus.com/feature/6296574159355904.

This PR adds a sub-data point to the `:hover`, `:active`, and `:focus-within` data to cover this.

This is a recreation of the original PR at https://github.com/mdn/browser-compat-data/pull/29960, which was closed before merging because I had to nuke my fork and start over.

The related content update has just been merged: https://github.com/mdn/content/pull/44615

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
