### PR TITLE
Add api.VideoFrame.copyTo.format_property subfeature

### DIFF
--- a/api/VideoFrame.json
+++ b/api/VideoFrame.json
@@ -451,6 +451,41 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "format_property": {
+          "__compat": {
+            "description": "`format` property",
+            "spec_url": "https://w3c.github.io/webcodecs/#dom-videoframecopytooptions-format",
+            "tags": [
+              "web-features:webcodecs"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "127"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "130"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "displayHeight": {


### PR DESCRIPTION
#### Summary

Adds a `format_property` subfeature under `api.VideoFrame.copyTo` for YUV-to-RGB conversion via `VideoFrameCopyToOptions.format`.

Support versions from [#24147](https://github.com/mdn/browser-compat-data/issues/24147):

- Chrome / Chrome Android: 127 ([ChromeStatus](https://chromestatus.com/feature/4668827056209920))
- Firefox / Firefox Android: 130 ([Bug 1902115](https://bugzilla.mozilla.org/show_bug.cgi?id=1902115))
- Safari: not supported (`VideoFrameCopyToOptions` in WebKit still only exposes `rect` / `layout`)

#### Test results and supporting details

- Spec: https://w3c.github.io/webcodecs/#dom-videoframecopytooptions-format / https://github.com/w3c/webcodecs/pull/754
- `npm run lint -- api/VideoFrame.json` passed locally

#### Related issues

Fixes #24147