### PR TITLE
fix(svg): correct SVGTextPathElement Firefox support

### DIFF
--- a/api/SVGTextPathElement.json
+++ b/api/SVGTextPathElement.json
@@ -107,7 +107,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "2"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -184,7 +184,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "2"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -230,7 +230,7 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "20"
+              "version_added": "2"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
### Description

Correct the Firefox compatibility data for `SVGTextPathElement` by changing the `version_added` value from Firefox 20 to Firefox 2 for the `method`, `spacing`, and `startOffset` attributes.

### Motivation

Issue #27275 identified missing/inaccurate compatibility data for `svg.elements.textPath.method`. The issue investigation confirmed that `method` was implemented together with `<textPath>`, `spacing`, and `startOffset`, and that this support shipped in Firefox 2.

This updates the three related attributes to reflect the historical Firefox 2 support.

Fixes #27275.
