### PR TITLE
Update text-box support

### DIFF
--- a/css/properties/text-box-edge.json
+++ b/css/properties/text-box-edge.json
@@ -40,7 +40,7 @@
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-line-fit-edge-alphabetic",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -105,7 +105,7 @@
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-line-fit-edge-cap",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -136,7 +136,7 @@
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-line-fit-edge-ex",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/text-box-edge.json
+++ b/css/properties/text-box-edge.json
@@ -179,7 +179,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.2"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -210,7 +210,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.2"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/text-box-edge.json
+++ b/css/properties/text-box-edge.json
@@ -52,7 +52,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/properties/text-box-trim.json
+++ b/css/properties/text-box-trim.json
@@ -35,6 +35,40 @@
             "deprecated": false
           }
         },
+        "inline_elements": {
+          "__compat": {
+            "description": "Works on inline elements",
+            "spec_url": "https://drafts.csswg.org/css-inline-3/#text-box-trim",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "154"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.5",
+                "partial_implementation": true,
+                "notes": "Fails in vertical writing modes."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-text-box-trim-none",

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -40,7 +40,7 @@
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-line-fit-edge-alphabetic",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -102,7 +102,7 @@
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-line-fit-edge-cap",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -133,7 +133,7 @@
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-line-fit-edge-ex",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "133"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -221,6 +221,40 @@
             }
           }
         },
+        "inline_elements": {
+          "__compat": {
+            "description": "Works on inline elements",
+            "spec_url": "https://drafts.csswg.org/css-inline-3/#propdef-text-box-trim",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "154"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.5",
+                "partial_implementation": true,
+                "notes": "Fails in vertical writing modes."
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-inline-3/#valdef-text-box-trim-none",

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -176,7 +176,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.2"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -207,7 +207,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "18.2"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/text-box.json
+++ b/css/properties/text-box.json
@@ -52,7 +52,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "18.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -60,7 +60,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
I dug through https://wpt.fyi/results/css/css-inline/text-box-trim and made the following updates:

- Chrome has supported a lot of the key values of `text-box` from 133
- Safari support was incorrect in multiple places
- Added a sub-feature for "inline" support

`text-box` works pretty differently on inline elements, and support in Chrome and Safari is absent/partial. However, I think most developers will be using this on block level elements, so my gut feeling is that it isn't right to mark Chrome or Safari as 'partial' for the feature overall.