### PR TITLE
fix(api): remove obsolete ElementInternals Safari impl URL

### DIFF
--- a/api/ElementInternals.json
+++ b/api/ElementInternals.json
@@ -21,8 +21,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "16.4",
-            "impl_url": "https://webkit.org/b/197960"
+            "version_added": "16.4"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",


### PR DESCRIPTION
### Summary

Remove the obsolete Safari `impl_url` from `ElementInternals` compatibility data.

### Motivation

`ElementInternals` is fully supported in Safari 16.4, so the WebKit bug URL should not be attached as an implementation URL.

Fixes #26631