### PR TITLE
Animation.commitStyles auto-fill in Chrome 144 and Safari 26.2

### DIFF
--- a/api/Animation.json
+++ b/api/Animation.json
@@ -187,7 +187,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "144"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -199,7 +199,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": false
+                "version_added": "26.2"
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",
@@ -207,7 +207,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
Looking at [the tests](https://wpt.fyi/results/web-animations/interfaces/Animation/commitStyles.html?label=experimental&label=master&aligned), this became supported but no one updated BCD 😢 