### PR TITLE
fix(api): note Firefox pdfViewerEnabled behavior

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2917,7 +2917,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "99"
+              "version_added": "99",
+              "notes": "Returns `true` even if Firefox is configured to open PDFs in external applications. See [bug 1821747](https://bugzil.la/1821747)."
             },
             "firefox_android": "mirror",
             "nodejs": {


### PR DESCRIPTION
#### Summary

Add a note to the Firefox `Navigator.pdfViewerEnabled` support statement explaining that it remains `true` when Firefox is configured to open PDFs in external applications.

#### Test results and supporting details

- `npm test` (315 tests passed)
- `npm run lint -- api/Navigator.json`
- [Firefox bug 1821747](https://bugzil.la/1821747)

#### Related issues

Fixes #22952