### PR TITLE
fix(api): update SpeechRecognition.continuous Safari support

### DIFF
--- a/api/SpeechRecognition.json
+++ b/api/SpeechRecognition.json
@@ -468,9 +468,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "14.1"
-            },
+            "safari": [
+              {
+                "version_added": "17"
+              },
+              {
+                "version_added": "14.1",
+                "version_removed": "17",
+                "partial_implementation": true,
+                "notes": "Returns multiple results when set to `false`."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
### Summary

Update `SpeechRecognition.continuous` compatibility data to reflect Safari's partial implementation in versions 14.1 through 16.6, where `continuous` set to `false` could return multiple results. Safari 17 and later have full support following the WebKit fix.

### Test results and supporting details

* `npm run lint` — passed.
* Prettier — passed.
* ESLint — 0 errors.
* Unit tests — 315 passed, 0 failed.
* `git diff --check` — passed.
* Supporting WebKit fix: WebKit bug 252936 / commit `68c30e6`.

### Related issues

Fixes #19084
