### PR TITLE
fix(api): update Navigator.serviceWorker Firefox note

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -5056,7 +5056,7 @@
             },
             "firefox": {
               "version_added": "44",
-              "notes": "In Firefox private windows, the `serviceWorker` object is `undefined`. See [bug 1320796](https://bugzil.la/1320796)."
+              "notes": "Before Firefox 139, the `serviceWorker` object is `undefined` in private windows. See [bug 1320796](https://bugzil.la/1320796)."
             },
             "firefox_android": "mirror",
             "nodejs": {


### PR DESCRIPTION
#### Summary

Update the Firefox compatibility note for `Navigator.serviceWorker` to reflect that private-window support was added in Firefox 139.

The note now applies only to Firefox versions before 139, as requested in #29366.

#### Test results and supporting details

- `git diff --check` passed.
- `python -m json.tool api/Navigator.json` passed.
- Format and BCD lint passed.
- Pre-push hooks passed lint, TypeScript, ESLint, and Prettier.
- The unittest stage could not start on Windows because the repository script uses Unix-style `NODE_ENV=test` syntax.

#### Related issues

Closes #29366