### PR TITLE
fix(api): note Safari iOS UIEvent.detail behavior

### DIFF
--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -117,7 +117,11 @@
             "safari": {
               "version_added": "1"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "1",
+              "partial_implementation": true,
+              "notes": "Does not increment on subsequent clicks. See [bug 298652](https://webkit.org/b/298652)."
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"

--- a/api/UIEvent.json
+++ b/api/UIEvent.json
@@ -119,8 +119,7 @@
             },
             "safari_ios": {
               "version_added": "1",
-              "partial_implementation": true,
-              "notes": "Does not increment on subsequent clicks. See [bug 298652](https://webkit.org/b/298652)."
+              "notes": "For `click` events, the value does not increment on subsequent clicks. See [bug 298652](https://webkit.org/b/298652)."
             },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
#### Summary

Mark Safari iOS support for `UIEvent.detail` as partial and document that the value does not increment on subsequent clicks.

#### Test results and supporting details

- `npm test` (315 tests passed)
- [WebKit bug 298652](https://webkit.org/b/298652)

#### Related issues

Fixes #27528
