### PR TITLE
Update Chrome 150 support for text-fit property

### DIFF
--- a/css/properties/text-fit.json
+++ b/css/properties/text-fit.json
@@ -34,6 +34,40 @@
             "deprecated": false
           }
         },
+        "consistent": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-5/#valdef-text-fit-consistent",
+            "tags": [
+              "web-features:text-fit"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "grow": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-text-5/#valdef-text-fit-grow",
@@ -71,6 +105,109 @@
         "none": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-text-5/#valdef-text-fit-none",
+            "tags": [
+              "web-features:text-fit"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "per-line": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-5/#valdef-text-fit-per-line",
+            "tags": [
+              "web-features:text-fit"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "per-line-all": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-5/#valdef-text-fit-per-line-all",
+            "tags": [
+              "web-features:text-fit"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "percentage": {
+          "__compat": {
+            "description": "`<percentage>`",
+            "spec_url": "https://drafts.csswg.org/css-text-5/#valdef-text-fit-percentage",
             "tags": [
               "web-features:text-fit"
             ],

--- a/css/properties/text-fit.json
+++ b/css/properties/text-fit.json
@@ -144,7 +144,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "150"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 150 adds support for the CSS [`text-fit`](https://drafts.csswg.org/css-text-5/#text-fit-property) property; see https://chromestatus.com/feature/5104141688635392.

The property already had BCD entries, but some of the available keywords were missing from the list.

This PR adds the missing keywords.

<s>Note that I've included the `per-line` keyword but written the data as unsupported. In my tests, `per-line` didn't seem to work, although including it in the property value doesn't invalidate it. I've asked the Chrome engineering folks what is going on there, and will update it when I find out.</s> -- scratch that, there was a mistake in my interpretation of how `per-line` works. It works fine; updated to say support in Chrome 150.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
