### PR TITLE
Add css.types.color.from_currentcolor for relative color origin

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -388,6 +388,41 @@
             }
           }
         },
+        "from_currentcolor": {
+          "__compat": {
+            "description": "`from currentColor` relative color syntax",
+            "spec_url": "https://drafts.csswg.org/css-color-5/#relative-colors",
+            "tags": [
+              "web-features:relative-color"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "131"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "133"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "18"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "hsl": {
           "__compat": {
             "description": "`hsl()` (HSL color model)",


### PR DESCRIPTION
#### Summary

Relative color syntax can use `currentColor` as the origin (`rgb(from currentColor r g b)` and friends). That shipped later than RCS itself, so it needs its own row.

#### Test results and supporting details

- Chrome 131: [Chrome 131 release notes](https://developer.chrome.com/release-notes/131)
- Firefox 133: https://bugzilla.mozilla.org/show_bug.cgi?id=1890972 (and the note on #22933)
- Safari 18: [WebKit features in Safari 18.0](https://webkit.org/blog/15865/webkit-features-in-safari-18-0/)

#### Related issues

Fixes #22933
