### PR TITLE
[HTTP] Firefox 135 removed HTTP header DNT

### DIFF
--- a/http/headers/DNT.json
+++ b/http/headers/DNT.json
@@ -13,7 +13,8 @@
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "4"
+              "version_added": "4",
+              "version_removed": "135"
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->
Firefox 135 removed support for HTTP header DNT in favor of GPC header.

#### Test results and supporting details

 - Firefox 135 release notes https://www.firefox.com/en-US/firefox/135.0/releasenotes/#note-790647
 - Mozilla KB https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
#30081