### PR TITLE
fix(api): Samsung Internet NavigatorUAData support

### DIFF
--- a/api/NavigatorUAData.json
+++ b/api/NavigatorUAData.json
@@ -28,7 +28,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": {
-            "version_added": false
+            "version_added": "23.0"
           },
           "webview_android": {
             "version_added": false,
@@ -70,7 +70,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "23.0"
             },
             "webview_android": {
               "version_added": false
@@ -113,7 +113,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "23.0"
             },
             "webview_android": {
               "version_added": false
@@ -155,7 +155,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "23.0"
             },
             "webview_android": {
               "version_added": false
@@ -197,7 +197,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "23.0"
             },
             "webview_android": {
               "version_added": false
@@ -239,7 +239,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": {
-              "version_added": false
+              "version_added": "23.0"
             },
             "webview_android": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Update the Samsung Internet compatibility data for `NavigatorUAData` and its members to reflect support starting with Samsung Internet 23.0.

#### Test results and supporting details

- Updated all six `samsunginternet_android` support statements in `api/NavigatorUAData.json` from `version_added: false` to `version_added: "23.0"`.
- Verified the change with direct testing reported in #29774, which found no support in Samsung Internet 22 and support in 23.0.
- `git diff --check` passes.
- BCD lint passes with 0 errors.
- All 315 unit tests pass.

#### Related issues

Fixes #29774