### PR TITLE
fix(api): note Chrome optional chaining defect

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -15,7 +15,8 @@
               "version_added": "1.0.0"
             },
             "chrome": {
-              "version_added": "80"
+              "version_added": "80",
+              "notes": "A call with a non-final spread argument in an optional chain fails in Chrome 80 through 90. See <https://crbug.com/42201552>."
             },
             "chrome_android": "mirror",
             "deno": {

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -16,7 +16,7 @@
             },
             "chrome": {
               "version_added": "80",
-              "notes": "A call with a non-final spread argument in an optional chain fails in Chrome 80 through 90. See <https://crbug.com/42201552>."
+              "notes": "A call with a non-final spread argument in an optional chain fails in Chrome 80 through 90. See [bug 42201552](https://crbug.com/42201552)." 
             },
             "chrome_android": "mirror",
             "deno": {

--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -16,7 +16,7 @@
             },
             "chrome": {
               "version_added": "80",
-              "notes": "A call with a non-final spread argument in an optional chain fails in Chrome 80 through 90. See [bug 42201552](https://crbug.com/42201552)." 
+              "notes": "A call with a non-final spread argument in an optional chain fails in Chrome 80 through 90. See [bug 42201552](https://crbug.com/42201552)."
             },
             "chrome_android": "mirror",
             "deno": {


### PR DESCRIPTION
#### Summary

Add a compatibility note for the Chrome 80–90 bug affecting optional chaining calls with a non-final spread argument.

#### Test results and supporting details

- `git diff --check`
- `npm run lint`
- Both pass for the change.
- Reference: https://crbug.com/42201552

#### Related

Fixes #29270