### PR TITLE
Fix Safari support for SVGAnimationElement endEvent

### DIFF
--- a/api/SVGAnimationElement.json
+++ b/api/SVGAnimationElement.json
@@ -303,11 +303,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "10",
-              "partial_implementation": true,
-              "notes": "The `onend` event handler property is not supported."
-            },
+            "safari": [
+              {
+                "version_added": "26.5"
+              },
+              {
+                "version_added": "10",
+                "version_removed": "26.5",
+                "partial_implementation": true,
+                "notes": "The `onend` event handler property is not supported."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
#### Summary

Update `SVGAnimationElement.endEvent` compatibility data to reflect full Safari support starting in Safari 26.5.

Safari 10 through 26.4 remains partial because the `onend` event handler property was not supported.

#### Test results and supporting details

- `git diff --check` ✅
- `npm run lint` ✅
- All data passed linting with 0 errors and 0 warnings.

The Safari 26.5 release notes state that the `onend` event handler was added/fixed for `SVGAnimationElement`.

#### Related

Fixes #29758

Note: The related collector test currently checks `onendEvent` instead of `onend` and will require a corresponding update in `openwebdocs/mdn-bcd-collector`.