### PR TITLE
Permissions-Policy: clipboard-read/write

### DIFF
--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "88"
+              "version_added": "85"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -381,6 +381,66 @@
             "status": {
               "experimental": true,
               "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "clipboard-read": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "clipboard-write": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "85"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }
@@ -843,7 +903,6 @@
         },
         "language-model": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/language-model",
             "spec_url": "https://webmachinelearning.github.io/prompt-api/#permissions-policy",
             "support": {
               "chrome": {

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -903,6 +903,7 @@
         },
         "language-model": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/language-model",
             "spec_url": "https://webmachinelearning.github.io/prompt-api/#permissions-policy",
             "support": {
               "chrome": {


### PR DESCRIPTION
The compat data is missing information on the the Permissions-Policy directive `clipboard-read` and `clipboard-write`. These were added in Chrome 85 (assuming you trust Chrome status:L https://chromestatus.com/feature/5767075295395840). This adds both features.

Note, the story is a little complicated. Only chrome implemented these and other vendors are opposed. These were removed from the spec without consensus from Chrome, who have no intention of removing them (see discussions such as https://chromestatus.com/feature/5767075295395840).

My take is that we follow specs. So I have marked as non-standard. 

Related docs work discussion https://github.com/mdn/content/issues/45162
