### PR TITLE
[API] Firefox 135 deprecated navigator.doNotTrack in favor of navigator.globalPrivacyControl

### DIFF
--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -1278,7 +1278,8 @@
               "version_added": "9",
               "notes": [
                 "In Firefox, `navigator.doNotTrack` returns `\"unspecified\"` instead of `null`.",
-                "Before Firefox 32, `navigator.doNotTrack` would report values of `\"yes\"` and `\"no\"` rather than `\"1\"` and `\"0\"`."
+                "Before Firefox 32, `navigator.doNotTrack` would report values of `\"yes\"` and `\"no\"` rather than `\"1\"` and `\"0\"`.",
+                "Starting with Firefox 135, `navigator.doNotTrack` always reports value of `\"unspecified\"`."
               ]
             },
             "firefox_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 135 removed support for changing `navigator.doNotTrack` and it always returns `"unspecified"`. Sites should use `navigator.globalPrivacyControl` instead.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

 - Firefox 135 release notes https://www.firefox.com/en-US/firefox/135.0/releasenotes/#note-790647
 - Mozilla KB https://support.mozilla.org/en-US/kb/how-do-i-turn-do-not-track-feature
 - Set preference in Firefox settings. Open any site on Firefox 135+ (e.g., I used current 153) and query `navigator.doNotTrack` (always `"unspecified"`) and `navigator.globalPrivacyControl` (changes based on browser setting).
<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

#30243 
#30081
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
