### PR TITLE
Firefox 155 ships CSS progress()

### DIFF
--- a/css/types/progress.json
+++ b/css/types/progress.json
@@ -16,8 +16,15 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1975530"
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "layout.css.progress-function.enabled",
+                  "value_to_set": "true"
+                }
+              ],
+              "impl_url": "https://bugzil.la/2047015"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/css/types/progress.json
+++ b/css/types/progress.json
@@ -16,15 +16,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "154",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "layout.css.progress-function.enabled",
-                  "value_to_set": "true"
-                }
-              ],
-              "impl_url": "https://bugzil.la/2047015"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Added version added & Flag for `progress()` CSS function in Firefox

#### Test results and supporting details

- Tested in the following with this [CodePen](https://codepen.io/editor/CodeRedDigital/pen/019ff13f-e379-7afb-9b2f-fbe9e4e57ad2):
  - Firefox Nightly 155.0a1 - no flag
  - Firefox Developer Edition 154.0b10 - with flag
  - Firefox Beta 154.0b10 - with flag 
  - Firefox Developer Edition 155.0b1 - no flag
  - Firefox Beta 155.0b1 - no flag 

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/45198)