### PR TITLE
Fix Firefox support for Document.startViewTransition updateCallback

### DIFF
--- a/api/Document.json
+++ b/api/Document.json
@@ -8850,21 +8850,9 @@
               },
               "chrome_android": "mirror",
               "edge": "mirror",
-              "firefox": [
-                {
-                  "version_added": "preview"
-                },
-                {
-                  "version_added": "140",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "dom.viewTransitions.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
-                }
-              ],
+              "firefox": {
+                "version_added": "144"
+              },
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",


### PR DESCRIPTION
#### Summary

Update the Firefox compatibility data for the `Document.startViewTransition()` `updateCallback` parameter. Firefox support is available from Firefox 144 without requiring the `dom.viewTransitions.enabled` preference, so the outdated preview and preference-gated entries are replaced with `version_added: "144"`.

#### Test results and supporting details

* `npm run lint` — passed with all data passing linting.
* `git diff --check` — passed with no whitespace errors.
* `npm test` — formatting and linting passed; the unittest step could not run on Windows because the package script uses Unix-style `NODE_ENV=test` syntax.
* Firefox 144 support was confirmed in BrowserStack and the related Mozilla issue/release information.

#### Related issues

Fixes #29455
