### PR TITLE
Fix WebView support for PublicKeyCredential

### DIFF
--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -197,7 +197,10 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
+            "webview_android": {
+              "version_added": "131",
+              "notes": "Conditional mediation (autofill integration) is not supported; `isConditionalMediationAvailable()` returns `false`."
+            },
             "webview_ios": "mirror"
           },
           "status": {

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -199,7 +199,8 @@
             "samsunginternet_android": "mirror",
             "webview_android": {
               "version_added": "131",
-              "notes": "Conditional mediation (autofill integration) is not supported; `isConditionalMediationAvailable()` returns `false`."
+              "partial_implementation": true,
+              "notes": "Conditional mediation (autofill integration) is not supported; `isConditionalMediationAvailable()` always returns `false`."
             },
             "webview_ios": "mirror"
           },

--- a/api/PublicKeyCredential.json
+++ b/api/PublicKeyCredential.json
@@ -40,9 +40,7 @@
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
-          "webview_android": {
-            "version_added": false
-          },
+          "webview_android": "mirror",
           "webview_ios": "mirror"
         },
         "status": {
@@ -76,9 +74,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -114,9 +110,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -167,9 +161,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -205,9 +197,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -258,9 +248,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -296,9 +284,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -334,9 +320,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -386,9 +370,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -438,9 +420,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -476,9 +456,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -514,9 +492,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -552,9 +528,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {
@@ -590,9 +564,7 @@
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
+            "webview_android": "mirror",
             "webview_ios": "mirror"
           },
           "status": {


### PR DESCRIPTION
#### Summary

Update `PublicKeyCredential` compatibility data to reflect Android WebView support.

Android WebView supports the `PublicKeyCredential` API and its listed members since WebView support was enabled in M131. This updates the `webview_android` entries from `version_added: false` to `"mirror"` so they correctly follow Chrome for Android compatibility data.

This addresses #29452.

#### Test results and supporting details

- `git diff --check`
- `npm run lint`

All data passed linting with 0 errors and 0 warnings.

The remaining `HTMLMediaElement.seekToNextFrame` obsolete message is an existing informational lint result unrelated to this change.

Supporting information:
- https://developer.android.com/identity/sign-in/credential-manager-webview
- https://github.com/mdn/browser-compat-data/issues/29452

#### Related issues

Fixes #29452