### PR TITLE
FF155 RTCErrorEvent  `sctp-error` on dedicated workers

### DIFF
--- a/api/RTCError.json
+++ b/api/RTCError.json
@@ -74,6 +74,46 @@
           }
         }
       },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "bun": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "155"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "errorDetail": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCError/errorDetail",

--- a/api/RTCError.json
+++ b/api/RTCError.json
@@ -149,6 +149,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "sctp-failure": {
+          "__compat": {
+            "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCError/errorDetail#sctp-failure",
+            "spec_url": "https://w3c.github.io/webrtc-pc/#dom-rtcerrordetailtype-sctp-failure",
+            "support": {
+              "chrome": {
+                "version_added": "74"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "60"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "15.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "httpRequestStatusCode": {

--- a/api/RTCErrorEvent.json
+++ b/api/RTCErrorEvent.json
@@ -72,6 +72,46 @@
           }
         }
       },
+      "worker_support": {
+        "__compat": {
+          "description": "Available in workers",
+          "support": {
+            "bun": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "155"
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "error": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/RTCErrorEvent/error",


### PR DESCRIPTION
FF155 supports web rtc error events with the `sctp-error` type fired at a data channel with [`RTCError.errorDetail`](https://developer.mozilla.org/en-US/docs/Web/API/RTCError/errorDetail) set to ["sctp-failure"](https://developer.mozilla.org/en-US/docs/Web/API/RTCError/errorDetail#sctp-failure) in https://bugzilla.mozilla.org/show_bug.cgi?id=1814460

I've added that, and indicated this was already supported in Safari and Chrome, mirroring the `errorDtail`. That's a **guess**. It is supported based on https://wpt.fyi/results/webrtc/RTCDataChannel-close.html?label=master&label=experimental&aligned&view=interop&q=label%3Ainterop-2026-webrtc back to around 2023, but can't be sure exactly when it was added.

In addition, the [`RTCErrorEvent`](https://developer.mozilla.org/en-US/docs/Web/API/RTCErrorEvent) and its [`RTCError`](https://developer.mozilla.org/en-US/docs/Web/API/RTCError) property are also supported on dedicated workers as part of this. This is not yet in the spec, but is agreed in  https://github.com/w3c/webrtc-pc/issues/3092. I have added the worker support note, and made the assumption this is ONLY supported in FF. It is marked as non-standard for now.

Related docs work can be tracked in https://github.com/mdn/content/issues/45175