### PR TITLE
FF155 WebGPU: dual-source blending

### DIFF
--- a/api/GPUDevice.json
+++ b/api/GPUDevice.json
@@ -1299,9 +1299,11 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1314,7 +1316,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -1659,9 +1661,11 @@
               },
               "edge": "mirror",
               "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": {
                 "version_added": false
               },
-              "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",
@@ -1674,7 +1678,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF155 supports the [dual-source blending](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedFeatures#available_features) feature in https://bugzilla.mozilla.org/show_bug.cgi?id=1924328

This adds the feature for Firefox desktop (FF android doesn't support the parent feature).

Related docs work can be tracked in https://github.com/mdn/content/issues/45176