### PR TITLE
Firefox 155 ships CSS alpha()

### DIFF
--- a/css/types/color.json
+++ b/css/types/color.json
@@ -57,7 +57,15 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "preview"
+                "version_added": "154",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.alpha-color-function.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/2047437"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",

--- a/css/types/color.json
+++ b/css/types/color.json
@@ -57,15 +57,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "154",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.alpha-color-function.enabled",
-                    "value_to_set": "true"
-                  }
-                ],
-                "impl_url": "https://bugzil.la/2047437"
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
#### Summary

- Added version added & Flag for `alpha()` CSS function in Firefox

#### Test results and supporting details

- Tested in the following with this [CodePen](https://codepen.io/editor/CodeRedDigital/pen/01a01041-1aad-7b2b-a271-6fb2c2bc9cc9):
  - Firefox Nightly 155.0a1 - no flag
  - Firefox Developer Edition 154.0b10 - with flag
  - Firefox Beta 154.0b10 - with flag 
  - Firefox Developer Edition 155.0b1 - no flag
  - Firefox Beta 155.0b1 - no flag 

#### Related issues

- [Firefox Release PR](https://github.com/mdn/content/pull/45219)
