### PR TITLE
Add `_static` suffixes for `Uint8Array` static methods

### DIFF
--- a/javascript/builtins/Uint8Array.json
+++ b/javascript/builtins/Uint8Array.json
@@ -218,7 +218,7 @@
             }
           }
         },
-        "fromBase64": {
+        "fromBase64_static": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromBase64",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.frombase64",
@@ -262,7 +262,7 @@
             }
           }
         },
-        "fromHex": {
+        "fromHex_static": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/fromHex",
             "spec_url": "https://tc39.es/ecma262/multipage/indexed-collections.html#sec-uint8array.fromhex",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

The `Uint8Array` static methods don't have `_static` suffixes, as required by the data guideline.

#### Test results and supporting details

This contributed to an error downstream, where the description for the web-features entry was written incorrectly. It wasn't caught because the misnaming of the keys didn't make it obvious these were, in fact, static.

See the [static API data guideline](https://github.com/mdn/browser-compat-data/blob/main/docs/data-guidelines/api.md#static-api-members).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Via https://github.com/web-platform-dx/web-features/issues/3740 and https://github.com/web-platform-dx/web-features/pull/4243.

See https://github.com/web-platform-dx/web-features/pull/4254 for web-features description changes related to this.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
