### PR TITLE
Updates for Firefox 155 beta

### DIFF
--- a/api/CSSFontFaceDescriptors.json
+++ b/api/CSSFontFaceDescriptors.json
@@ -413,7 +413,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -428,7 +428,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -695,7 +695,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -710,7 +710,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/SVGAElement.json
+++ b/api/SVGAElement.json
@@ -93,7 +93,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -127,7 +127,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -161,7 +161,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -312,7 +312,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -346,7 +346,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -380,7 +380,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -451,7 +451,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -485,7 +485,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -623,7 +623,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -740,7 +740,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false

--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -571,7 +571,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -586,7 +586,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -768,7 +768,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -783,7 +783,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -799,7 +799,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": {
               "version_added": false
@@ -1001,7 +1001,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",

--- a/api/WebTransportDatagramDuplexStream.json
+++ b/api/WebTransportDatagramDuplexStream.json
@@ -98,7 +98,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -113,7 +113,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WebTransportDatagramsWritable.json
+++ b/api/WebTransportDatagramsWritable.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "155"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -26,7 +26,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -57,7 +57,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -74,7 +74,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -89,7 +89,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WebTransportSendGroup.json
+++ b/api/WebTransportSendGroup.json
@@ -11,7 +11,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "155"
           },
           "firefox_android": "mirror",
           "oculus": "mirror",
@@ -26,7 +26,7 @@
           "webview_ios": "mirror"
         },
         "status": {
-          "experimental": true,
+          "experimental": false,
           "standard_track": true,
           "deprecated": false
         }
@@ -42,7 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -57,7 +57,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/api/WebTransportSendStream.json
+++ b/api/WebTransportSendStream.json
@@ -141,7 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -156,7 +156,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }

--- a/css/properties/font-width.json
+++ b/css/properties/font-width.json
@@ -15,7 +15,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": false
+              "version_added": "155"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -30,7 +30,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -48,7 +48,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -63,7 +63,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -82,7 +82,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -97,7 +97,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -116,7 +116,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -131,7 +131,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -150,7 +150,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -165,7 +165,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -184,7 +184,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -199,7 +199,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -216,7 +216,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -231,7 +231,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -250,7 +250,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -265,7 +265,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -284,7 +284,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -299,7 +299,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -318,7 +318,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -333,7 +333,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -352,7 +352,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -367,7 +367,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }

--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -13,6 +13,7 @@
             "edge": "mirror",
             "firefox": {
               "version_added": "153",
+              "version_removed": "155",
               "partial_implementation": true,
               "notes": "The `@supports selector(::-webkit-scrollbar)` returns `true` but this pseudo-element cannot be used to style scrollbars. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
             },

--- a/css/types/attr.json
+++ b/css/types/attr.json
@@ -61,14 +61,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "150",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.attr.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -175,14 +168,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": "149",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "layout.css.attr.enabled",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -198,7 +184,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -218,14 +204,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -241,7 +220,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -262,14 +241,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -285,7 +257,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -306,14 +278,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -329,7 +294,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -350,14 +315,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -373,7 +331,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -394,14 +352,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -417,7 +368,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -438,14 +389,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -461,7 +405,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -482,14 +426,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -505,7 +442,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -526,14 +463,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -549,7 +479,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -570,14 +500,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -593,7 +516,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -614,14 +537,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -637,7 +553,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -658,14 +574,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -681,7 +590,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -702,14 +611,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -725,7 +627,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -746,14 +648,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -769,7 +664,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }
@@ -790,14 +685,7 @@
                 "chrome_android": "mirror",
                 "edge": "mirror",
                 "firefox": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "layout.css.attr.enabled",
-                      "value_to_set": "true"
-                    }
-                  ]
+                  "version_added": "155"
                 },
                 "firefox_android": "mirror",
                 "oculus": "mirror",
@@ -813,7 +701,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/javascript/builtins/Promise.json
+++ b/javascript/builtins/Promise.json
@@ -146,6 +146,37 @@
             }
           }
         },
+        "allKeyed": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-await-dictionary/#sec-promise.allkeyed",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "allSettled": {
           "__compat": {
             "description": "`allSettled()`",
@@ -187,6 +218,37 @@
             },
             "status": {
               "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "allSettledKeyed": {
+          "__compat": {
+            "spec_url": "https://tc39.es/proposal-await-dictionary/#sec-promise.allsettledkeyed",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.20.6) found new features shipping in Firefox 155 beta1 which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Firefox Nightly only, it is not considered here.

With this PR, BCD considers the following features as shipping in Firefox 155 (**bold** features are new keys in BCD).

- api.CSSFontFaceDescriptors.font-width
- api.CSSFontFaceDescriptors.fontWidth
- api.SVGAElement.hash
- api.SVGAElement.host
- api.SVGAElement.hostname
- api.SVGAElement.origin
- api.SVGAElement.password
- api.SVGAElement.pathname
- api.SVGAElement.port
- api.SVGAElement.protocol
- api.SVGAElement.search
- api.SVGAElement.username
- api.WebTransport.createSendGroup
- api.WebTransport.draining
- api.WebTransport.exportKeyingMaterial
- api.WebTransport.protocol
- api.WebTransportDatagramDuplexStream.createWritable
- api.WebTransportDatagramsWritable
- api.WebTransportDatagramsWritable.sendGroup
- api.WebTransportDatagramsWritable.sendOrder
- api.WebTransportSendGroup
- api.WebTransportSendGroup.getStats
- api.WebTransportSendStream.sendGroup
- css.properties.font-width
- css.properties.font-width.condensed
- css.properties.font-width.expanded
- css.properties.font-width.extra-condensed
- css.properties.font-width.extra-expanded
- css.properties.font-width.normal
- css.properties.font-width.percentage
- css.properties.font-width.semi-condensed
- css.properties.font-width.semi-expanded
- css.properties.font-width.ultra-condensed
- css.properties.font-width.ultra-expanded
- css.selectors.-webkit-scrollbar
- css.types.attr.attr-name_accepts_namespaces
- css.types.attr.type_function
- css.types.attr.type_function.angle
- css.types.attr.type_function.color
- css.types.attr.type_function.custom-ident
- css.types.attr.type_function.ident
- css.types.attr.type_function.image
- css.types.attr.type_function.integer
- css.types.attr.type_function.length
- css.types.attr.type_function.length-percentage
- css.types.attr.type_function.number
- css.types.attr.type_function.percentage
- css.types.attr.type_function.resolution
- css.types.attr.type_function.string
- css.types.attr.type_function.time
- css.types.attr.type_function.transform-function
- **javascript.builtins.Promise.allKeyed**
- **javascript.builtins.Promise.allSettledKeyed**

Updated in other PRs:

- api.GPUDevice.createRenderPipeline.dual-source-blending
- api.GPUDevice.createRenderPipelineAsync.dual-source-blending
- api.RTCError.worker_support
- api.RTCError.errorDetail.sctp-failure
- api.RTCErrorEvent.worker_support
- css.types.color.alpha
- css.types.progress

For more Firefox 155 info, see also https://github.com/mdn/mdn/issues/857 and https://www.firefox.com/en-US/firefox/155.0beta/releasenotes/

For the spec_url failures, see https://github.com/w3c/browser-specs/issues/2601