### PR TITLE
Chrome 150 @supports named-feature()

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -153,6 +153,41 @@
             }
           }
         },
+        "named-feature": {
+          "__compat": {
+            "description": "`named-feature()`",
+            "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-supports-named-feature-fn",
+            "tags": [
+              "web-features:supports"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "selector": {
           "__compat": {
             "description": "`selector()`",

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -157,9 +157,6 @@
           "__compat": {
             "description": "`named-feature()`",
             "spec_url": "https://drafts.csswg.org/css-conditional-5/#typedef-supports-named-feature-fn",
-            "tags": [
-              "web-features:supports"
-            ],
             "support": {
               "chrome": {
                 "version_added": "150"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 150 adds support for the [`@supports`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@supports) at-rule [`named-feature()`](https://drafts.csswg.org/css-conditional-5/#typedef-supports-named-feature-fn) function; see https://chromestatus.com/feature/5153932394102784.

This PR adds a data point for the new function.

As an FYI, currently only one feature is supported — [`anchor-position-follows-transforms`](https://drafts.csswg.org/css-conditional-5/#anchor-position-follows-transforms). I wasn't sure if it was necessary to add a subfeature for that feature, given that only one is currently supported. Happy to add it if wished.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
