### PR TITLE
Fix Chrome Android support for ChapterInformation

### DIFF
--- a/api/ChapterInformation.json
+++ b/api/ChapterInformation.json
@@ -11,7 +11,9 @@
           "chrome": {
             "version_added": "127"
           },
-          "chrome_android": "mirror",
+          "chrome_android": {
+            "version_added": false
+          },
           "edge": "mirror",
           "firefox": {
             "version_added": false
@@ -45,7 +47,9 @@
             "chrome": {
               "version_added": "127"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -80,7 +84,9 @@
             "chrome": {
               "version_added": "127"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false
@@ -115,7 +121,9 @@
             "chrome": {
               "version_added": "127"
             },
-            "chrome_android": "mirror",
+            "chrome_android": {
+              "version_added": false
+            },
             "edge": "mirror",
             "firefox": {
               "version_added": false


### PR DESCRIPTION
#### Summary

Update `api.ChapterInformation` and all subfeatures to correctly mark Chrome for Android as unsupported. Replace the inherited `chrome_android` mirror data with `version_added: false`.

#### Test results and supporting details

* `git diff --check` passed.
* `npm run lint` passed with no errors.
* `npm test` reached the test suite but could not run on Windows because the repository's `NODE_ENV=test` command is not recognized by PowerShell. Existing lint warnings were unrelated to this change.

#### Related issues

Fixes #24737
