### PR TITLE
docs: note Firefox MutationRecord.target nullability

### DIFF
--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -17,7 +17,7 @@
           },
           "firefox": {
             "version_added": "14",
-            "notes": "The `target` property can be `null` to prevent crashes in case of Gecko garbage collection or cycle collection bugs."
+            "notes": "The `target` property can be `null` to prevent crashes in case of Gecko garbage collection or cycle collection bugs. See [bug 896272](https://bugzil.la/896272)."
           },
           "firefox_android": "mirror",
           "ie": {

--- a/api/MutationRecord.json
+++ b/api/MutationRecord.json
@@ -16,7 +16,8 @@
             "version_added": "12"
           },
           "firefox": {
-            "version_added": "14"
+            "version_added": "14",
+            "notes": "The `target` property can be `null` to prevent crashes in case of Gecko garbage collection or cycle collection bugs."
           },
           "firefox_android": "mirror",
           "ie": {


### PR DESCRIPTION
#### Summary

Add a Firefox-specific compatibility note documenting that `MutationRecord.target` can be `null` in Gecko.

#### Test results and supporting details

* `npm run lint` ✅
* Full test suite: `315` tests passed, `0` failed ✅
* `git diff --check` ✅
* Only `api/MutationRecord.json` was modified.

The note documents Gecko's implementation behavior described in [[Mozilla Bug 896272](https://bugzilla.mozilla.org/show_bug.cgi?id=896272)](https://bugzilla.mozilla.org/show_bug.cgi?id=896272).

#### Related issues

Fixes #24698