### PR TITLE
Firefox 154 adds a time picker for `datetime-local` inputs

### DIFF
--- a/html/elements/input/datetime-local.json
+++ b/html/elements/input/datetime-local.json
@@ -18,10 +18,16 @@
               "edge": {
                 "version_added": "12"
               },
-              "firefox": {
-                "version_added": "93",
-                "notes": "Only displays a date picker without a time picker, see [bug 1726107](https://bugzil.la/1726107) and [bug 1726108](https://bugzil.la/1726108)."
-              },
+              "firefox": [
+                {
+                  "version_added": "154"
+                },
+                {
+                  "version_added": "93",
+                  "version_removed": "154",
+                  "notes": "Only displays a date picker without a time picker, see [bug 1726107](https://bugzil.la/1726107) and [bug 1726108](https://bugzil.la/1726108)."
+                }
+              ],
               "firefox_android": "mirror",
               "oculus": "mirror",
               "opera": {


### PR DESCRIPTION
#### Summary

Updates Firefox support for `<input type="datetime-local">` to record the time picker UI added in Firefox 154.

The existing note is now limited to Firefox 93–153 using separate support statements.

#### Test results and supporting details

- Confirmed the modified file parses as valid JSON.
- `git diff --check` passes.
- [Firefox 154 release notes](https://www.firefox.com/en-US/firefox/154.0/releasenotes/)
  
  > Added a time picker user interface to `<input type="time">` and `<input type="datetime-local">`, making selecting a time more accessible and intuitive.
- [Firefox bug 1726107](https://bugzil.la/1726107)
- [Firefox bug 1726108](https://bugzil.la/1726108)

#### Related issues

None.
