### PR TITLE
Update/correct Chrome extension data

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -206,7 +206,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/getBadgeTextColor",
             "support": {
               "chrome": {
-                "version_added": "109"
+                "version_added": "110"
               },
               "edge": "mirror",
               "firefox": {
@@ -681,7 +681,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeTextColor",
             "support": {
               "chrome": {
-                "version_added": "109"
+                "version_added": "110"
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/scripting.json
+++ b/webextensions/api/scripting.json
@@ -498,7 +498,7 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/removeCSS",
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": "90"
               },
               "edge": "mirror",
               "firefox": {
@@ -516,7 +516,7 @@
             "__compat": {
               "support": {
                 "chrome": {
-                  "version_added": "88"
+                  "version_added": "90"
                 },
                 "edge": "mirror",
                 "firefox": {


### PR DESCRIPTION
#### Summary

Found a couple of minor inconsistencies 

#### Test results and supporting details

[scripting.removeCSS](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/scripting/removeCSS) does not appear in the [scripting.idl for M88](https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/4324/chrome/common/extensions/api/scripting.idl), it does not show up until [M90](https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/4430/chrome/common/extensions/api/scripting.idl).

[action.setBadgeTextColor](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeTextColor) was `dev` [channel only in 109](https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/5414/chrome/common/extensions/api/_api_features.json#79), and did not reach stable until [110](https://chromium.googlesource.com/chromium/src/+/refs/branch-heads/5481/chrome/common/extensions/api/_api_features.json)