### PR TITLE
Add table_cells entry for writing-mode iOS Safari compatibility

### DIFF
--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -473,6 +473,45 @@
             }
           }
         },
+        "table_cells": {
+          "__compat": {
+            "description": "Applies to <th> and <td> elements",
+            "tags": [
+              "web-features:writing-mode"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "48"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "43"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "9"
+              },
+              "safari_ios": {
+                "version_added": "17",
+                "notes": "Not supported on <th> or <td> elements before iOS 17."
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "vertical-lr": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-writing-modes/#valdef-writing-mode-vertical-lr",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -473,9 +473,9 @@
             }
           }
         },
-        "table_cells": {
+        "vertical_oriented_table_cells": {
           "__compat": {
-            "description": "Applies to table cell elements",
+            "description": "Vertically-oriented table cells",
             "support": {
               "chrome": {
                 "version_added": "48"

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -475,7 +475,7 @@
         },
         "table_cells": {
           "__compat": {
-            "description": "Applies to <th> and <td> elements",
+            "description": "Applies to table cell elements",
             "tags": [
               "web-features:writing-mode"
             ],
@@ -499,7 +499,7 @@
               },
               "safari_ios": {
                 "version_added": "17",
-                "notes": "Not supported on <th> or <td> elements before iOS 17."
+                "notes": "Not supported on table cell elements before iOS 17."
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -476,9 +476,6 @@
         "table_cells": {
           "__compat": {
             "description": "Applies to table cell elements",
-            "tags": [
-              "web-features:writing-mode"
-            ],
             "support": {
               "chrome": {
                 "version_added": "48"
@@ -491,6 +488,9 @@
                 "version_added": "43"
               },
               "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
               "oculus": "mirror",
               "opera": "mirror",
               "opera_android": "mirror",

--- a/css/properties/writing-mode.json
+++ b/css/properties/writing-mode.json
@@ -498,8 +498,7 @@
                 "version_added": "9"
               },
               "safari_ios": {
-                "version_added": "17",
-                "notes": "Not supported on table cell elements before iOS 17."
+                "version_added": "17"
               },
               "samsunginternet_android": "mirror",
               "webview_android": "mirror",


### PR DESCRIPTION
Fixes #29241

This PR adds a new compatibility entry documenting that `writing-mode: vertical-*` does not work on `<th>` or `<td>` elements on iOS Safari before version 17.

The current data shows `safari_ios: "mirror"` which incorrectly implies full support from iOS 9+. In reality, table cell elements only received support starting from iOS 17.