### PR TITLE
Remove dependabot cooldown for web-features, xref, inventory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: daily
       time: "11:00"
+    cooldown:
+      exclude:
+        - "@webref/xref"
+        - "@ddbeck/mdn-content-inventory"
+        - "web-features"
     groups:
       npm:
         update-types:


### PR DESCRIPTION
#### Summary

We need these data dependencies to be as fresh as possible.

#### Test results and supporting details

The ddbeck inventory is 3 days old, for example.

#### Related issues

Also added this to the Collector.