### PR TITLE
docs: note contenteditable canvas cursor limitations

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -303,14 +303,16 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1"
+              "version_added": "1",
+              "notes": "When a `<canvas>` element is at the end of a `<p>` inside a `contenteditable` element, the cursor cannot be moved behind the canvas or the canvas deleted with Backspace. See [bug 389067061](https://crbug.com/389067061)."
             },
             "chrome_android": "mirror",
             "edge": {
               "version_added": "12"
             },
             "firefox": {
-              "version_added": "3"
+              "version_added": "3",
+              "notes": "When a `<canvas>` element is at the end of a `<p>` inside a `contenteditable` element, the cursor cannot be moved behind the canvas or the canvas deleted with Backspace. See [bug 873883](https://bugzil.la/873883)."
             },
             "firefox_android": "mirror",
             "ie": {


### PR DESCRIPTION
## Summary

- document the `<canvas>` caret and deletion limitation at the end of a `<p>` inside `contenteditable` for Chrome
- document the same limitation for Firefox
- link the related Chromium and Firefox bug reports

Fixes #11509