### PR TITLE
fix: update SVGElement load event Firefox support

### DIFF
--- a/api/SVGElement.json
+++ b/api/SVGElement.json
@@ -392,11 +392,17 @@
             "edge": {
               "version_added": "12"
             },
-            "firefox": {
-              "alternative_name": "SVGLoad",
-              "version_added": "4",
-              "notes": "See [bug 620002](https://bugzil.la/620002) for implementation status of the standard `load` event."
-            },
+            "firefox": [
+              {
+                "version_added": "83"
+              },
+              {
+                "alternative_name": "SVGLoad",
+                "version_added": "4",
+                "version_removed": "83",
+                "notes": "See [bug 620002](https://bugzil.la/620002) for implementation status of the standard `load` event."
+              }
+            ],
             "firefox_android": "mirror",
             "ie": {
               "version_added": "9"


### PR DESCRIPTION
## Summary

- record standard `load` event support for Firefox starting in 83
- preserve the historical `SVGLoad` alternative name from Firefox 4 through 82
- update compatibility data for `SVGElement.load_event`

Fixes #20831

Parent: #25725

## Evidence

Issue #20831 reports testing the standard `load` event on Firefox 60, 73, 77, 81, and 82 as unsupported, and Firefox 83, 85, and 100 as supported. The same investigation notes that the older `SVGLoad`/`addEventListener()` behavior worked from Firefox 4.

## Validation

- `npm run lint`
- `git diff --check`
- commit hooks: prettier and lint:fix
- push hooks: lint, tsc, eslint, prettier