### PR TITLE
`css.properties.position-anchor`: Safari 27 has `normal` initial value

### DIFF
--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -45,11 +45,17 @@
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",
-            "safari": {
-              "version_added": "26",
-              "partial_implementation": true,
-              "notes": "The initial value is `auto` instead of `normal` (see [bug 308981](https://webkit.org/b/308981) and [bug 311941](https://webkit.org/b/311941))."
-            },
+            "safari": [
+              {
+                "version_added": "27"
+              },
+              {
+                "version_added": "26",
+                "version_removed": "27",
+                "partial_implementation": true,
+                "notes": "The initial value is `auto` instead of `normal` (see [bug 308981](https://webkit.org/b/308981) and [bug 311941](https://webkit.org/b/311941))."
+              }
+            ],
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Safari 27 has the `position-anchor: normal` initial value.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- Mentioned by the [Safari 27 beta release notes](https://developer.apple.com/documentation/safari-release-notes/safari-27-release-notes#:~:text=172097721)
- I tested this with https://wpt.fyi/results/css/css-anchor-position/position-anchor-basics.html?label=experimental&label=master&aligned

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

As ever for anchor positioning, https://github.com/web-platform-dx/web-features/issues/3558.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
