### PR TITLE
`css.properties.position-anchor`: Chrome 151 has `normal` initial value

### DIFF
--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -11,7 +11,11 @@
           "support": {
             "chrome": [
               {
+                "version_added": "151"
+              },
+              {
                 "version_added": "144",
+                "version_removed": "151",
                 "partial_implementation": true,
                 "notes": "The initial value is `none` instead of `normal` (see [bug 501399489](https://crbug.com/501399489))."
               },


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 151 supports `anchor-position: normal` as the initial value.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

- Chrome status: https://chromestatus.com/feature/5351959625334784
- UA stylesheet change: https://chromiumdash.appspot.com/commit/06472b7e663b26c886ef62634bbeceeaa3a308fe
- Test results: https://wpt.fyi/results/css/css-anchor-position/position-anchor-basics.html?label=experimental&label=master&aligned


<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

As ever, https://github.com/web-platform-dx/web-features/issues/3558.

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
