### PR TITLE
FF155 regular expr buffer boundary assertion

### DIFF
--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -56,6 +56,54 @@
           }
         }
       },
+      "buffer_boundary_assertion": {
+        "__compat": {
+          "description": "Buffer boundary assertion: `\\A`, `\\z`, `\\Z`",
+          "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion",
+          "support": {
+            "bun": {
+              "version_added": false
+            },
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "deno": {
+              "version_added": false
+            },
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "preview",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "javascript.options.experimental.regexp_buffer_boundaries",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "capturing_group": {
         "__compat": {
           "description": "Capturing group: `(...)`",

--- a/javascript/regular_expressions.json
+++ b/javascript/regular_expressions.json
@@ -59,7 +59,7 @@
       "buffer_boundary_assertion": {
         "__compat": {
           "description": "Buffer boundary assertion: `\\A`, `\\z`, `\\Z`",
-          "spec_url": "https://tc39.es/ecma262/multipage/text-processing.html#prod-Assertion",
+          "spec_url": "https://tc39.es/proposal-regexp-buffer-boundaries/#sec-patterns",
           "support": {
             "bun": {
               "version_added": false


### PR DESCRIPTION
FF155 added support for buffer boundary assertions in nightly behind flag `javascript.options.experimental.regexp_buffer_boundaries` in https://bugzilla.mozilla.org/show_bug.cgi?id=2047706

Related docs work can be tracked in https://github.com/mdn/content/issues/45183