### PR TITLE
Don't use `next` as basis for generating regular releases

### DIFF
--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -71,11 +71,11 @@ export const fetchMain = () => {
 };
 
 /**
- * Get the latest Git tag
+ * Get the latest Git tag (excluding `next`)
  * @returns {string} The latest Git tag
  */
 export const getLatestTag = () =>
-  spawn('git', ['describe', '--abbrev=0', '--tags']);
+  spawn('git', ['describe', '--abbrev=0', '--tags', '--exclude=next']);
 
 /**
  * Get the date of a specified ref


### PR DESCRIPTION
I _think_ this will fix the problem of the release PR workflow doing diffs against `next` (which are more up-to-date than the previous normal release), but I haven't tested it.