### PR TITLE
Exclude "next" tags in release notes script

### DIFF
--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -75,7 +75,7 @@ export const fetchMain = () => {
  * @returns {string} The latest Git tag
  */
 export const getLatestTag = () =>
-  spawn('git', ['describe', '--abbrev=0', '--tags']);
+  spawn('git', ['describe', '--abbrev=0', '--tags', '--exclude=next']);
 
 /**
  * Get the date of a specified ref


### PR DESCRIPTION
#### Summary

Seems like we didn't notice for a while but the release notes are either empty (see [8.0.12](https://github.com/mdn/browser-compat-data/pull/30236)), or incomplete.

#### Test results and supporting details

I got the exclude argument from https://git-scm.com/docs/git-describe

#### Related issues

None, I think.