### PR TITLE
Updates for Chrome 153 beta

### DIFF
--- a/api/BaseAudioContext.json
+++ b/api/BaseAudioContext.json
@@ -1014,6 +1014,41 @@
           }
         }
       },
+      "renderQuantumSize": {
+        "__compat": {
+          "spec_url": "https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-renderquantumsize",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "sampleRate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/BaseAudioContext/sampleRate",

--- a/api/Document.json
+++ b/api/Document.json
@@ -979,7 +979,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "126"
+              "version_added": "126",
+              "version_removed": "153"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLElement.json
+++ b/api/HTMLElement.json
@@ -297,7 +297,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "152"
+              "version_added": "153"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/HTMLIFrameElement.json
+++ b/api/HTMLIFrameElement.json
@@ -256,7 +256,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "126"
+              "version_added": "126",
+              "version_removed": "153"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/scroll-axis-lock.json
+++ b/css/properties/scroll-axis-lock.json
@@ -1,0 +1,111 @@
+{
+  "css": {
+    "properties": {
+      "scroll-axis-lock": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-overflow-5/#scroll-axis-lock",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "auto": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-5/#valdef-scroll-axis-lock-auto",
+            "support": {
+              "chrome": {
+                "version_added": "153"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-overflow-5/#valdef-scroll-axis-lock-none",
+            "support": {
+              "chrome": {
+                "version_added": "153"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -565,7 +565,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-join/#sec-iterator.prototype.join",
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "153"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -585,7 +585,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -885,8 +885,7 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/465357675"
+                "version_added": "153"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -913,7 +912,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }
@@ -931,8 +930,7 @@
                 "version_added": false
               },
               "chrome": {
-                "version_added": false,
-                "impl_url": "https://crbug.com/465357675"
+                "version_added": "153"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -959,7 +957,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.20.7) found new features shipping in Chromium 153 beta which was released yesterday. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Canary/behind flags, it is not considered here.

Chrome 153 releases on September, 8, 2026. This PR needs to be merged before the BCD release on September 3, 2026.

With this PR, BCD will consider the following features as shipping in Chromium 153 (**bold** features are new keys in BCD).


- **api.BaseAudioContext.renderQuantumSize** ([ref](https://chromium-review.googlesource.com/c/chromium/src/+/8242387))
- api.Document.browsingTopics (removal) ([ref](https://chromestatus.com/feature/5194473869017088))
- api.HTMLElement.autocorrect (152->153) ([ref](https://chromiumdash.appspot.com/commits?commit=25a6eb59d05e8188b8328bc4765c1abbf2c14ae0&platform=Android))
- api.HTMLIFrameElement.browsingTopics (removal) ([ref](https://chromestatus.com/feature/5194473869017088))
- **css.properties.scroll-axis-lock** ([ref](https://chromestatus.com/feature/5908461532610560))
- **css.properties.scroll-axis-lock.auto** ([ref](https://chromestatus.com/feature/5908461532610560))
- **css.properties.scroll-axis-lock.none** ([ref](https://chromestatus.com/feature/5908461532610560))
- javascript.builtins.Iterator.join ([ref](https://chromestatus.com/feature/5095183554314240))
- javascript.builtins.Iterator.zip ([ref](https://chromestatus.com/feature/6249068542164992))
- javascript.builtins.Iterator.zipKeyed ([ref](https://chromestatus.com/feature/6249068542164992))

See also https://developer.chrome.com/blog/chrome-153-beta and https://chromestatus.com/roadmap

**Note**: There are also new capability elements: `<camera>` and `<microphone>`, however, they are not in a spec which is considered by browser-specs, see https://github.com/w3c/browser-specs/issues/1915. I will follow-up on these separately.