### PR TITLE
docs: note Safari RSA-OAEP key length limitation

### DIFF
--- a/api/SubtleCrypto.json
+++ b/api/SubtleCrypto.json
@@ -987,7 +987,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "notes": "Throws an `OperationError` for RSA-OAEP keys greater than 4096 bits long."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -1159,7 +1160,8 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "7",
+              "notes": "Throws an `OperationError` for RSA-OAEP keys greater than 4096 bits long."
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",


### PR DESCRIPTION
# Summary

Document Safari's RSA-OAEP key length limitation for `SubtleCrypto.generateKey()` and `SubtleCrypto.importKey()` by noting that `OperationError` is thrown for keys greater than 4096 bits long.

# Test results and supporting details

* `git diff --check` passes.
* Prettier passes.
* ESLint passes with 0 errors.
* Full `npm test` is currently blocked by a local TypeScript error: `types/public.d.ts` is reported as not being a module by `scripts/build/index.js` and `scripts/diff-flat.js`.

# Related issues

Fixes #8752
