### PR TITLE
fix(api): add Firefox alternative animationend event name

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -664,6 +664,10 @@
                 "version_added": "51"
               },
               {
+                "alternative_name": "onwebkitanimationend",
+                "version_added": "51"
+              },
+              {
                 "version_added": "5",
                 "version_removed": "51",
                 "partial_implementation": true,


### PR DESCRIPTION
#### Summary

Add Firefox compatibility data for the `onwebkitanimationend` alternative event-handler name, which has been supported since Firefox 51.

#### Test results and supporting details

* `git diff --check` passed.
* Prettier passed.
* ESLint passed with no errors.
* Unit tests passed: **338 passed, 0 failed**.
* Added `alternative_name: "onwebkitanimationend"` to `api/Element.json`.
* Supporting source: Mozilla Bug 911987, which documents the Firefox 51 implementation.

#### Related issues

Fixes #12484
