### PR TITLE
Bun 1.4.0 added Temporal, Iterator helpers, textStream and ReadableStream.from

### DIFF
--- a/api/ReadableStream.json
+++ b/api/ReadableStream.json
@@ -153,6 +153,9 @@
             "web-features:readablestream-from"
           ],
           "support": {
+            "bun": {
+              "version_added": "1.4.0"
+            },
             "chrome": {
               "version_added": false
             },

--- a/api/Request.json
+++ b/api/Request.json
@@ -940,6 +940,9 @@
               "web-features:fetch"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.3.7"
+              },
               "chrome": {
                 "version_added": "64"
               },
@@ -2022,6 +2025,9 @@
         "__compat": {
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-textstream",
           "support": {
+            "bun": {
+              "version_added": "1.4.0"
+            },
             "chrome": {
               "version_added": "151"
             },

--- a/api/Response.json
+++ b/api/Response.json
@@ -1035,6 +1035,9 @@
         "__compat": {
           "spec_url": "https://fetch.spec.whatwg.org/#dom-body-textstream",
           "support": {
+            "bun": {
+              "version_added": "1.4.0"
+            },
             "chrome": {
               "version_added": "151"
             },

--- a/api/WritableStreamDefaultController.json
+++ b/api/WritableStreamDefaultController.json
@@ -107,6 +107,9 @@
             "web-features:streams"
           ],
           "support": {
+            "bun": {
+              "version_added": "1.4.0"
+            },
             "chrome": {
               "version_added": "98"
             },

--- a/browsers/bun.json
+++ b/browsers/bun.json
@@ -832,9 +832,16 @@
         "1.3.14": {
           "release_date": "2026-05-13",
           "release_notes": "https://bun.com/blog/release-notes/bun-v1.3.14",
-          "status": "current",
+          "status": "retired",
           "engine": "WebKit",
           "engine_version": "625.1.16"
+        },
+        "1.4.0": {
+          "release_date": "2026-08-20",
+          "release_notes": "https://bun.com/blog/release-notes/bun-v1.4.0",
+          "status": "current",
+          "engine": "WebKit",
+          "engine_version": "626.1.4"
         }
       }
     }

--- a/javascript/builtins/Date.json
+++ b/javascript/builtins/Date.json
@@ -3210,6 +3210,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -97,6 +97,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/chunks",
             "spec_url": "https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.chunks",
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": false
               },
@@ -133,7 +136,7 @@
             ],
             "support": {
               "bun": {
-                "version_added": false
+                "version_added": "1.3.7"
               },
               "chrome": {
                 "version_added": "146"
@@ -524,7 +527,7 @@
             "spec_url": "https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes",
             "support": {
               "bun": {
-                "version_added": false
+                "version_added": "1.4.0"
               },
               "chrome": {
                 "version_added": false
@@ -564,6 +567,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/join",
             "spec_url": "https://tc39.es/proposal-iterator-join/#sec-iterator.prototype.join",
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": false
               },
@@ -846,6 +852,9 @@
             "mdn_url": "https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Iterator/windows",
             "spec_url": "https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.windows",
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": false
               },
@@ -882,7 +891,7 @@
             ],
             "support": {
               "bun": {
-                "version_added": false
+                "version_added": "1.4.0"
               },
               "chrome": {
                 "version_added": false,
@@ -928,7 +937,7 @@
             ],
             "support": {
               "bun": {
-                "version_added": false
+                "version_added": "1.4.0"
               },
               "chrome": {
                 "version_added": false,

--- a/javascript/builtins/Temporal.json
+++ b/javascript/builtins/Temporal.json
@@ -10,6 +10,9 @@
             "web-features:temporal"
           ],
           "support": {
+            "bun": {
+              "version_added": "1.4.0"
+            },
             "chrome": {
               "version_added": "144"
             },

--- a/javascript/builtins/Temporal/Duration.json
+++ b/javascript/builtins/Temporal/Duration.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -52,6 +55,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -94,6 +100,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -136,6 +145,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -178,6 +190,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -220,6 +235,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -262,6 +280,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -304,6 +325,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -346,6 +370,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -388,6 +415,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -430,6 +460,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -472,6 +505,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -514,6 +550,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -556,6 +595,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -598,6 +640,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -640,6 +685,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -682,6 +730,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -724,6 +775,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -766,6 +820,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -808,6 +865,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -850,6 +910,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -892,6 +955,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -934,6 +1000,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -976,6 +1045,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1018,6 +1090,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1060,6 +1135,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1102,6 +1180,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/Instant.json
+++ b/javascript/builtins/Temporal/Instant.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -52,6 +55,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": false,
                   "impl_url": "https://crbug.com/401065166"
@@ -95,6 +101,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -137,6 +146,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -179,6 +191,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -221,6 +236,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -263,6 +281,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -305,6 +326,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -347,6 +371,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -389,6 +416,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -431,6 +461,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -473,6 +506,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -515,6 +551,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -557,6 +596,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -599,6 +641,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -641,6 +686,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -683,6 +731,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -725,6 +776,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -767,6 +821,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/Now.json
+++ b/javascript/builtins/Temporal/Now.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -51,6 +54,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -93,6 +99,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -135,6 +144,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -177,6 +189,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -219,6 +234,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -261,6 +279,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/PlainDate.json
+++ b/javascript/builtins/Temporal/PlainDate.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -95,6 +98,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -137,6 +143,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -179,6 +188,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -221,6 +233,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -263,6 +278,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -305,6 +323,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -347,6 +368,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -389,6 +413,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -431,6 +458,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -473,6 +503,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -515,6 +548,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -557,6 +593,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -599,6 +638,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -641,6 +683,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -683,6 +728,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -725,6 +773,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -767,6 +818,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -809,6 +863,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -851,6 +908,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -893,6 +953,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -935,6 +998,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -977,6 +1043,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1019,6 +1088,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1061,6 +1133,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1103,6 +1178,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1145,6 +1223,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1187,6 +1268,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1229,6 +1313,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1271,6 +1358,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1313,6 +1403,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1355,6 +1448,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1399,6 +1495,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1441,6 +1540,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/PlainDateTime.json
+++ b/javascript/builtins/Temporal/PlainDateTime.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -95,6 +98,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -137,6 +143,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -179,6 +188,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -221,6 +233,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -263,6 +278,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -305,6 +323,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -347,6 +368,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -389,6 +413,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -431,6 +458,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -473,6 +503,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -515,6 +548,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -557,6 +593,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -599,6 +638,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -641,6 +683,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -683,6 +728,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -725,6 +773,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -767,6 +818,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -809,6 +863,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -851,6 +908,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -893,6 +953,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -935,6 +998,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -977,6 +1043,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1019,6 +1088,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1061,6 +1133,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1103,6 +1178,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1145,6 +1223,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1187,6 +1268,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1229,6 +1313,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1271,6 +1358,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1313,6 +1403,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1355,6 +1448,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1397,6 +1493,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1439,6 +1538,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1481,6 +1583,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1523,6 +1628,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1565,6 +1673,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1607,6 +1718,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1651,6 +1765,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1693,6 +1810,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1735,6 +1855,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/PlainMonthDay.json
+++ b/javascript/builtins/Temporal/PlainMonthDay.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -95,6 +98,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -137,6 +143,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -179,6 +188,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -221,6 +233,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -263,6 +278,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -305,6 +323,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -347,6 +368,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -389,6 +413,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -431,6 +458,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -473,6 +503,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -515,6 +548,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/PlainTime.json
+++ b/javascript/builtins/Temporal/PlainTime.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -52,6 +55,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -94,6 +100,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -136,6 +145,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -178,6 +190,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -220,6 +235,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -262,6 +280,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -304,6 +325,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -346,6 +370,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -388,6 +415,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -430,6 +460,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -472,6 +505,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -514,6 +550,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -556,6 +595,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -598,6 +640,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -640,6 +685,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -682,6 +730,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -724,6 +775,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -766,6 +820,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -808,6 +865,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -850,6 +910,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/PlainYearMonth.json
+++ b/javascript/builtins/Temporal/PlainYearMonth.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -95,6 +98,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -137,6 +143,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -179,6 +188,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -221,6 +233,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -263,6 +278,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -305,6 +323,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -347,6 +368,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -389,6 +413,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -431,6 +458,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -473,6 +503,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -515,6 +548,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -557,6 +593,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -599,6 +638,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -641,6 +683,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -683,6 +728,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -725,6 +773,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -767,6 +818,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -809,6 +863,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -851,6 +908,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -893,6 +953,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -935,6 +998,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -977,6 +1043,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1019,6 +1088,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/javascript/builtins/Temporal/ZonedDateTime.json
+++ b/javascript/builtins/Temporal/ZonedDateTime.json
@@ -10,6 +10,9 @@
               "web-features:temporal"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -52,6 +55,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": false,
                   "impl_url": "https://crbug.com/401065166"
@@ -95,6 +101,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -137,6 +146,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -179,6 +191,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -221,6 +236,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -263,6 +281,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -305,6 +326,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -347,6 +371,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -389,6 +416,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -431,6 +461,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -473,6 +506,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -515,6 +551,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -557,6 +596,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -599,6 +641,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -641,6 +686,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -683,6 +731,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -725,6 +776,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -767,6 +821,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -809,6 +866,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -851,6 +911,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -893,6 +956,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -935,6 +1001,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -977,6 +1046,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1019,6 +1091,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1061,6 +1136,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1103,6 +1181,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1145,6 +1226,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1187,6 +1271,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1229,6 +1316,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1271,6 +1361,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1313,6 +1406,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1355,6 +1451,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1397,6 +1496,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1439,6 +1541,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1481,6 +1586,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1523,6 +1631,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1565,6 +1676,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1607,6 +1721,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1649,6 +1766,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1691,6 +1811,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1733,6 +1856,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1775,6 +1901,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1817,6 +1946,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1859,6 +1991,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1901,6 +2036,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1943,6 +2081,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -1985,6 +2126,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -2029,6 +2173,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -2071,6 +2218,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -2113,6 +2263,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },
@@ -2155,6 +2308,9 @@
                 "web-features:temporal"
               ],
               "support": {
+                "bun": {
+                  "version_added": "1.4.0"
+                },
                 "chrome": {
                   "version_added": "144"
                 },

--- a/webassembly/api/Exception.json
+++ b/webassembly/api/Exception.json
@@ -225,6 +225,9 @@
               "web-features:wasm-exception-handling"
             ],
             "support": {
+              "bun": {
+                "version_added": "1.4.0"
+              },
               "chrome": {
                 "version_added": "95"
               },

--- a/webassembly/api/Memory.json
+++ b/webassembly/api/Memory.json
@@ -235,6 +235,9 @@
           "__compat": {
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-tofixedlengthbuffer",
             "support": {
+              "bun": {
+                "version_added": "1.2.22"
+              },
               "chrome": {
                 "version_added": "144"
               },
@@ -266,6 +269,9 @@
           "__compat": {
             "spec_url": "https://webassembly.github.io/spec/js-api/#dom-memory-toresizablebuffer",
             "support": {
+              "bun": {
+                "version_added": "1.2.22"
+              },
               "chrome": {
                 "version_added": "144"
               },


### PR DESCRIPTION
Bun 1.4.0 shipped recently which enabled Temporal by default among a few other modern features! :tada:

This PR also fixes some older incorrect entries - `Iterator.concat()` and `Request` `cache: "only-if-cached"` landed in 1.3.7, and `WebAssembly.Memory` `toResizableBuffer()` / `toFixedLengthBuffer()` in 1.2.22.

Generated with mdn-bcd-collector's `update-bcd` from runtime-compat runs of the collector tests (v10.20.7) on Bun 1.2.0, 1.2.5, 1.2.10, 1.2.15, 1.2.20 to 1.2.23, 1.3.0, 1.3.1, 1.3.3, 1.3.5 to 1.3.7, 1.3.14 and 1.4.0, then checked each version boundary by hand on the release binaries.
