### PR TITLE
FF155 RTCStatsReport selectedCandidatePairChanges in transport stats

### DIFF
--- a/api/RTCStatsReport.json
+++ b/api/RTCStatsReport.json
@@ -8966,7 +8966,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "155"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
FF155 adds support for [`RTCTransportStats.selectedCandidatePairChanges`](https://developer.mozilla.org/en-US/docs/Web/API/RTCTransportStats/selectedCandidatePairChanges) in https://bugzilla.mozilla.org/show_bug.cgi?id=2055911

This updates the subfeature. 

Related docs work can be tracked in https://github.com/mdn/content/issues/45185