### PR TITLE
Chrome 153 ships <camera> and <microphone>

### DIFF
--- a/api/HTMLCameraElement.json
+++ b/api/HTMLCameraElement.json
@@ -1,0 +1,224 @@
+{
+  "api": {
+    "HTMLCameraElement": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement",
+        "support": {
+          "chrome": {
+            "version_added": "153"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "description": "`cancel` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement-oncancel",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement-error",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "`error` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement-onerror",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setConstraints": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement-setconstraints",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "track": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement-track",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "track_event": {
+        "__compat": {
+          "description": "`track` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlcameraelement-ontrack",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLMicrophoneElement.json
+++ b/api/HTMLMicrophoneElement.json
@@ -1,0 +1,224 @@
+{
+  "api": {
+    "HTMLMicrophoneElement": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement",
+        "support": {
+          "chrome": {
+            "version_added": "153"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "description": "`cancel` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement-oncancel",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement-error",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "`error` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement-onerror",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setConstraints": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement-setconstraints",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "track": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement-track",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "track_event": {
+        "__compat": {
+          "description": "`track` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlmicrophoneelement-ontrack",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/camera.json
+++ b/html/elements/camera.json
@@ -1,0 +1,37 @@
+{
+  "html": {
+    "elements": {
+      "camera": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#the-camera-html-element",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/microphone.json
+++ b/html/elements/microphone.json
@@ -1,0 +1,37 @@
+{
+  "html": {
+    "elements": {
+      "microphone": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#the-microphone-html-element",
+          "support": {
+            "chrome": {
+              "version_added": "153"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Chrome 153 ships `<camera>` and `<microphone>`.

spec_urls fail until we have a new xref on Wednesday.

#### Test results and supporting details

See https://chromestatus.com/feature/5153829504024576

#### Related issues

Follow-up to https://github.com/mdn/browser-compat-data/pull/30300