### PR TITLE
Add WebRTC scalabilityMode compatibility data

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -933,7 +933,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "17"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -941,7 +941,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -911,6 +911,41 @@
               "standard_track": true,
               "deprecated": false
             }
+          },
+          "scalabilityMode": {
+            "__compat": {
+              "description": "`init.sendEncodings[].scalabilityMode` parameter",
+              "spec_url": "https://w3c.github.io/webrtc-svc/#dom-rtcrtpencodingparameters-scalabilitymode",
+              "tags": [
+                "web-features:webrtc"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "111"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
           }
         },
         "init_streams_parameter": {

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -964,7 +964,7 @@
                 "opera": "mirror",
                 "opera_android": "mirror",
                 "safari": {
-                  "version_added": false
+                  "version_added": "17"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -972,7 +972,7 @@
                 "webview_ios": "mirror"
               },
               "status": {
-                "experimental": true,
+                "experimental": false,
                 "standard_track": true,
                 "deprecated": false
               }

--- a/api/RTCRtpSender.json
+++ b/api/RTCRtpSender.json
@@ -943,6 +943,41 @@
               }
             }
           },
+          "scalabilityMode": {
+            "__compat": {
+              "description": "`parameters.encodings.scalabilityMode` parameter",
+              "spec_url": "https://w3c.github.io/webrtc-svc/#dom-rtcrtpencodingparameters-scalabilitymode",
+              "tags": [
+                "web-features:webrtc"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "111"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "scaleResolutionDownBy": {
             "__compat": {
               "description": "`parameters.encodings.scaleResolutionDownBy` parameter",


### PR DESCRIPTION
#### Summary

Add compatibility data for the `RTCRtpEncodingParameters.scalabilityMode` parameter used by WebRTC SVC.

The new data covers both API paths where the parameter can be provided:
- `RTCRtpSender.setParameters()` via `parameters.encodings`
- `RTCPeerConnection.addTransceiver()` via `init.sendEncodings`

#### Test results and supporting details

- `npm run format` passed.
- BCD linting passed with no errors.
- The test suite passed: 338 tests passed, 0 failed.
- `git diff --check` passed.
- Chrome support is recorded from version 111 based on the WebRTC SVC implementation.
- Firefox and Safari are recorded as unsupported for this specific encoding parameter.

Supporting specification:
https://w3c.github.io/webrtc-svc/#dom-rtcrtpencodingparameters-scalabilitymode

#### Related issues

Fixes #25720