### PR TITLE
Fix Chrome support data for MediaStreamTrack.applyConstraints

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -45,7 +45,10 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "59"
+              "version_added": "59",
+              "impl_url": "https://crbug.com/390804131",
+              "partial_implementation": true,
+              "notes": "`echoCancellation` does not always take effect when used with `applyConstraints()`."
             },
             "chrome_android": "mirror",
             "edge": {


### PR DESCRIPTION
#### Summary

Update Chrome compatibility data for `MediaStreamTrack.applyConstraints()` to reflect partial implementation when applying the `echoCancellation` constraint.

#### Test results and supporting details

- `git diff --check` ✅
- `npm run format` ✅
- `npm run lint` ✅
- Unit tests: 338 passed, 0 failed ✅
- Git pre-push checks: TypeScript, ESLint, and Prettier passed ✅
- Chromium issue: https://crbug.com/390804131

#### Related issues

Fixes #25717