### PR TITLE
Chrome 151 ships the <usermedia> element

### DIFF
--- a/api/HTMLUserMediaElement.json
+++ b/api/HTMLUserMediaElement.json
@@ -1,0 +1,224 @@
+{
+  "api": {
+    "HTMLUserMediaElement": {
+      "__compat": {
+        "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement",
+        "support": {
+          "chrome": {
+            "version_added": "151"
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": true,
+          "deprecated": false
+        }
+      },
+      "cancel_event": {
+        "__compat": {
+          "description": "`cancel` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement-oncancel",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement-error",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "error_event": {
+        "__compat": {
+          "description": "`error` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement-onerror",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "setConstraints": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement-setconstraints",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stream": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement-stream",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
+      "stream_event": {
+        "__compat": {
+          "description": "`stream` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-htmlusermediaelement-onstream",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/usermedia.json
+++ b/html/elements/usermedia.json
@@ -1,0 +1,37 @@
+{
+  "html": {
+    "elements": {
+      "usermedia": {
+        "__compat": {
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#the-usermedia-html-element",
+          "support": {
+            "chrome": {
+              "version_added": "151"
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

This is part of https://w3c.github.io/mediacapture-extensions/ which only now has become part of browser-specs and is therefore now visible in our tooling.

See https://developer.chrome.com/blog/usermedia-html-element

#### Test results and supporting details

https://chromestatus.com/feature/4926233538330624

#### Related issues

The build fails but should be solved once we get the new xref package (tomorrow).