### PR TITLE
Safari 16.4 shipped configurationchange event

### DIFF
--- a/api/MediaStreamTrack.json
+++ b/api/MediaStreamTrack.json
@@ -976,6 +976,38 @@
           }
         }
       },
+      "configurationchange_event": {
+        "__compat": {
+          "description": "`configurationchange` event",
+          "spec_url": "https://w3c.github.io/mediacapture-extensions/#dom-mediastreamtrack-onconfigurationchange",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "16.4"
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "contentHint": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/MediaStreamTrack/contentHint",


### PR DESCRIPTION
#### Summary

This was not previously discovered because the spec wasn't part of browser-specs.

#### Test results and supporting details

Seems to be shipped with 16.4, see https://github.com/WebKit/WebKit/commit/78a2a0119f7b892bae066fc5493645185e9a046e#diff-e37a477bd613b5750c49c594fe7be2908c9a2f1c1c870bf381525875bae8f110

No support in other browsers.

#### Related issues

None.