### PR TITLE
Chrome 152 supports `referenceTarget` and `shadowRootReferenceTarget` unflagged

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -2866,14 +2866,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "133",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "152"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/api/HTMLTemplateElement.json
+++ b/api/HTMLTemplateElement.json
@@ -251,14 +251,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "133",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/ShadowRoot.json
+++ b/api/ShadowRoot.json
@@ -721,14 +721,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "133",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features",
-                  "value_to_set": "true"
-                }
-              ]
+              "version_added": "152"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -223,14 +223,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "133",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "true"
-                  }
-                ]
+                "version_added": "152"
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Chrome 152 supports referenceTarget unflagged

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

https://wpt.fyi/results/shadow-dom/reference-target/tentative/reference-target-basics.html?label=master&label=stable&aligned&q=reference%20target

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://chromestatus.com/feature/5188237101891584

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
