### PR TITLE
`css.types.anchor*`: add behavioral subfeatures for animations

### DIFF
--- a/css/types/anchor-size.json
+++ b/css/types/anchor-size.json
@@ -73,6 +73,39 @@
               "deprecated": false
             }
           }
+        },
+        "is_transitionable": {
+          "__compat": {
+            "description": "Transitionable and animatable when setting inset properties",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos:~:text=transitions%20or%20animations%20of%20a%20property%20using%20an%20anchor%20function%20will%20work%20%22as%20expected%22",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1924226"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/anchor-size.json
+++ b/css/types/anchor-size.json
@@ -77,7 +77,7 @@
         "is_transitionable": {
           "__compat": {
             "description": "Transitionable and animatable when setting inset properties",
-            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos:~:text=transitions%20or%20animations%20of%20a%20property%20using%20an%20anchor%20function%20will%20work%20%22as%20expected%22",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-size-resolution",
             "support": {
               "chrome": {
                 "version_added": "125"

--- a/css/types/anchor.json
+++ b/css/types/anchor.json
@@ -35,6 +35,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "is_transitionable": {
+          "__compat": {
+            "description": "Transitionable and animatable when setting inset properties",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos:~:text=transitions%20or%20animations%20of%20a%20property%20using%20an%20anchor%20function%20will%20work%20%22as%20expected%22",
+            "support": {
+              "chrome": {
+                "version_added": "125"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false,
+                "impl_url": "https://bugzil.la/1924226"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/types/anchor.json
+++ b/css/types/anchor.json
@@ -39,7 +39,7 @@
         "is_transitionable": {
           "__compat": {
             "description": "Transitionable and animatable when setting inset properties",
-            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-pos:~:text=transitions%20or%20animations%20of%20a%20property%20using%20an%20anchor%20function%20will%20work%20%22as%20expected%22",
+            "spec_url": "https://drafts.csswg.org/css-anchor-position-1/#anchor-resolution",
             "support": {
               "chrome": {
                 "version_added": "125"


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add behavioral subfeatures for animating the CSS `anchor()` and `anchor-size()` functions on inset properties.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Note [this spec text](https://drafts.csswg.org/css-anchor-position-1/#resolvable-anchor-function:~:text=transitions%20or%20animations%20of%20a%20property%20using%20an%20anchor%20function%20will%20work%20%22as%20expected%22):

> Note: This means that [transitions](https://www.w3.org/TR/css-transitions-1/#transitions) or [animations](https://www.w3.org/TR/web-animations-1/#concept-animation) of a property using an [anchor function](https://drafts.csswg.org/css-anchor-position-1/#anchor-functions) will work "as expected" for all sorts of possible changes: the [anchor box](https://drafts.csswg.org/css-anchor-position-1/#anchor-box) moving, [anchor elements](https://drafts.csswg.org/css-anchor-position-1/#anchor-element) being added or removed from the document, the [anchor-name](https://drafts.csswg.org/css-anchor-position-1/#propdef-anchor-name) property being changed on anchors, etc.

I reconfirmed the bug reported in https://github.com/mdn/browser-compat-data/issues/28805 with the [test case](https://codepen.io/jaffathecake/pen/PwzGrzw?editors=1100) linked there.

As suggested by Claas in https://github.com/mdn/browser-compat-data/issues/28805#issuecomment-3749158598, I modeled this after `is_transitionable` subfeatures used elsewhere.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Closes https://github.com/mdn/browser-compat-data/issues/28805
- Inspired by https://github.com/web-platform-dx/web-features/issues/3558#issuecomment-5358733231
- [Firefox bug 1924226](https://bugzilla.mozilla.org/show_bug.cgi?id=1924226 "Handle animation of `anchor()` / interleaved styling of anchor-positioned elements")

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
