### PR TITLE
Edge 137 also supports Wasm EH with exnref feature

### DIFF
--- a/webassembly/exceptionsFinal.json
+++ b/webassembly/exceptionsFinal.json
@@ -12,10 +12,15 @@
             "version_added": "137"
           },
           "chrome_android": "mirror",
-          "edge": {
-            "version_added": "16",
-            "version_removed": "79"
-          },
+          "edge": [
+            {
+              "version_added": "137"
+            },
+            {
+              "version_added": "16",
+              "version_removed": "79"
+            }
+          ],
           "firefox": {
             "version_added": "131"
           },

--- a/webassembly/types/exnref.json
+++ b/webassembly/types/exnref.json
@@ -10,10 +10,15 @@
               "version_added": "137"
             },
             "chrome_android": "mirror",
-            "edge": {
-              "version_added": "16",
-              "version_removed": "79"
-            },
+            "edge": [
+              {
+                "version_added": "137"
+              },
+              {
+                "version_added": "16",
+                "version_removed": "79"
+              }
+            ],
             "firefox": {
               "version_added": "131"
             },


### PR DESCRIPTION
#### Summary

This PR updates and corrects the version values for Microsoft Edge for the `exceptionsFinal` and `exnref` WebAssembly features.

#### Test results and supporting details

Tested locally at https://collector.openwebdocs.org/tests/webassembly/exceptionsFinal with Edge 151.0.4129.107. I assume the behavior is the same on Edge 137 (according to https://github.com/emscripten-core/emscripten/pull/27575#issuecomment-5417889551 there are no known cases where Edge didn't ship a JS or Wasm feature that was on by default in V8).

#### Related issues

See PR #27216 for context.
