### PR TITLE
Add a data guideline for HTML constructors

### DIFF
--- a/api/HTMLGeolocationElement.json
+++ b/api/HTMLGeolocationElement.json
@@ -36,44 +36,6 @@
           "deprecated": false
         }
       },
-      "HTMLGeolocationElement": {
-        "__compat": {
-          "description": "`HTMLGeolocationElement()` constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/HTMLGeolocationElement",
-          "spec_url": "https://wicg.github.io/PEPC/geolocation-element.html#dom-htmlgeolocationelement-constructor",
-          "tags": [
-            "web-features:geolocation-element"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": "144"
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": {
-              "version_added": false
-            },
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "autolocate": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLGeolocationElement/autolocate",

--- a/api/HTMLOutputElement.json
+++ b/api/HTMLOutputElement.json
@@ -42,42 +42,6 @@
           "deprecated": false
         }
       },
-      "HTMLOutputElement": {
-        "__compat": {
-          "description": "`HTMLOutputElement()` constructor",
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/HTMLOutputElement",
-          "spec_url": "https://html.spec.whatwg.org/multipage/form-elements.html#htmloutputelement",
-          "tags": [
-            "web-features:output"
-          ],
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": false
-            },
-            "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": "15"
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": true,
-            "standard_track": true,
-            "deprecated": false
-          }
-        }
-      },
       "checkValidity": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLOutputElement/checkValidity",

--- a/docs/data-guidelines/api.md
+++ b/docs/data-guidelines/api.md
@@ -95,7 +95,9 @@ For example, the `ImageData` constructor, `ImageData()`, is represented as `api.
 
 ### HTML element constructors
 
-HTML element constructors get no feature key. In IDL, you can recognize them using the [`[HTMLConstructor]`](https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors) extended attribute.
+Do not create keys for HTML element constructors. In IDL, you can recognize them using the [`[HTMLConstructor]`](https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors) extended attribute.
+
+This guideline was proposed in [#30349](https://github.com/mdn/browser-compat-data/pull/30349/).
 
 ## DOM events (`eventname_event`)
 

--- a/docs/data-guidelines/api.md
+++ b/docs/data-guidelines/api.md
@@ -93,6 +93,10 @@ For example, the `ImageData` constructor, `ImageData()`, is represented as `api.
 }
 ```
 
+### HTML element constructors
+
+HTML element constructors get no feature key. In IDL, you can recognize them using the [`[HTMLConstructor]`](https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors) extended attribute.
+
 ## DOM events (`eventname_event`)
 
 Add DOM events as features of their target interfaces, using the name _eventname_\_event with the description text set to `` `eventname` event ``. If an event can be sent to multiple interfaces, add the event as a feature of each interface that can receive it.


### PR DESCRIPTION
#### Summary

This PR proposes a guideline to formalize what has been happening all along: HTML elements get no key for their constructors. In the past, probably accidentally, two HTML element constructors have been added for HTMLGeolocation and HTMLOutputElement. This PR removes that data.

#### Alternative

The alternative is that all HTML element APIs get their constructor key. I believe they only got their constructors when custom elements were introduced, but I might be wrong. Developers don't use HTML element constructors directly. I think they are only meaningful in the context of custom elements. (Docs written at https://developer.mozilla.org/en-US/docs/Web/API/HTMLGeolocationElement/HTMLGeolocationElement are really weak and don't really illustrate any useful usage imho).

#### Related issues

Unblocks 
- https://github.com/mdn/browser-compat-data/pull/30326
- https://github.com/mdn/browser-compat-data/pull/30316