### PR TITLE
FF155 WebTransport() options_protocols_parameter

### DIFF
--- a/api/WebTransport.json
+++ b/api/WebTransport.json
@@ -163,6 +163,38 @@
             }
           }
         },
+        "options_protocols_parameter": {
+          "__compat": {
+            "description": "`options.protocols` parameter",
+            "spec_url": "https://w3c.github.io/webtransport/#dom-webtransportoptions-protocols",
+            "support": {
+              "chrome": {
+                "version_added": "143"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "26.4"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "options_requireUnreliable_parameter": {
           "__compat": {
             "description": "`options.requireUnreliable` parameter",


### PR DESCRIPTION
FF155 adds support for a `WebTransport` app to specify a list of preferred application-specific protocols in the constructor, and for the server to return its preferred option in `WebTransport.protocol`. 

The  `WebTransport.protocol` entry is present, but the corresponding `options_protocols_parameter` was omitted. This just mirrors  `WebTransport.protocol`  support, since they go together.

PS All these options omit docs links. I didn't add them myself.

Related docs work can be tracked in https://github.com/mdn/content/issues/45302