### PR TITLE
Chrome 150 zoom property animatable

### DIFF
--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -45,7 +45,7 @@
         },
         "is_animatable": {
           "__compat": {
-            "description": "Animatable and transitionable",
+            "description": "`@keyframe` animatable and transitionable",
             "spec_url": "https://drafts.csswg.org/css-viewport/#zoom-property:~:text=by%20computed%20value%20type",
             "support": {
               "chrome": {

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -43,6 +43,38 @@
             "deprecated": false
           }
         },
+        "is_animatable": {
+          "__compat": {
+            "description": "Animatable and transitionable",
+            "spec_url": "https://drafts.csswg.org/css-viewport/#zoom-property:~:text=by%20computed%20value%20type",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "126"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "reset": {
           "__compat": {
             "description": "The `reset` value",
@@ -76,38 +108,6 @@
               "experimental": false,
               "standard_track": false,
               "deprecated": true
-            }
-          }
-        },
-        "zoom_animatable": {
-          "__compat": {
-            "description": "Animatable `zoom`",
-            "spec_url": "https://drafts.csswg.org/css-viewport/#zoom-property:~:text=by%20computed%20value%20type",
-            "support": {
-              "chrome": {
-                "version_added": "150"
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": "126"
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
             }
           }
         }

--- a/css/properties/zoom.json
+++ b/css/properties/zoom.json
@@ -78,6 +78,38 @@
               "deprecated": true
             }
           }
+        },
+        "zoom_animatable": {
+          "__compat": {
+            "description": "Animatable `zoom`",
+            "spec_url": "https://drafts.csswg.org/css-viewport/#zoom-property:~:text=by%20computed%20value%20type",
+            "support": {
+              "chrome": {
+                "version_added": "150"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "126"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

From Chrome 150 onwards, the [`zoom`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/zoom) CSS property is animatable; see https://chromestatus.com/feature/5183671737909248.

The [spec](https://drafts.csswg.org/css-viewport/#zoom-property) has been updated so that `zoom` is now marked as animated by computed value type.

This PR adds a new data point for animatable zoom.

From what I can tell (see https://bugzilla.mozilla.org/show_bug.cgi?id=1917602), Firefox has always supported animatable `zoom`, so I've marked it as supporting this data point from version 126 - when it was first supported.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
