### PR TITLE
Correct Chrome locale note for `word-break: auto-phrase`

### DIFF
--- a/css/properties/word-break.json
+++ b/css/properties/word-break.json
@@ -57,7 +57,7 @@
             "support": {
               "chrome": {
                 "version_added": "119",
-                "notes": "This value is only applicable if `lang=\"ja\"` is specified. This value has no effect on other locales."
+                "notes": "In Chrome, this value affects text whose content language resolves to Japanese (`ja`) or Korean (`ko`). Japanese uses an ML-based phrase-breaking engine, while Korean uses ICU's non-ML phrase-breaking path. For other locales, it behaves as `normal`."
               },
               "chrome_android": "mirror",
               "edge": "mirror",


### PR DESCRIPTION
#### Summary

Correct the Chrome support note for `word-break: auto-phrase` to include Korean (`ko`) as well as Japanese (`ja`).

The updated note distinguishes Chrome's ML-based Japanese phrase-breaking engine from ICU's non-ML Korean phrase-breaking path, and clarifies that unsupported locales behave as `normal`.

#### Test results and supporting details

- `npm test` passes.
- Runtime behavior was verified with identical `lang="ko"` elements in Google Chrome 152.0.7977.65 on macOS 26.4.1. Changing only `word-break` produced different Korean break opportunities for `normal` and `auto-phrase`.
- The Chrome 119 ICU revision already contains the source comment that phrase breaking supports Japanese and Korean, while `MlBreakEngine` supports only Japanese. I did not independently run Chrome 119.

Supporting sources:

- [Current ICU CJK break-engine implementation](https://github.com/unicode-org/icu/blob/main/icu4c/source/common/dictbe.cpp#L1266-L1270)
- [ICU revision vendored by Chrome 119](https://chromium.googlesource.com/chromium/deps/icu/+/a622de35ac311c5ad390a7af80724634e5dc61ed/source/common/dictbe.cpp#1266)
- [Chrome 119 Blink integration](https://chromium.googlesource.com/chromium/src/+/refs/tags/119.0.6045.105/third_party/blink/renderer/core/layout/ng/inline/ng_line_breaker.cc#3545)
- [BudouX Korean support rationale](https://github.com/google/budoux#korean-support): Korean generally uses spaces between words, so it recommends `word-break: keep-all` for the common goal of preventing intra-word line breaks rather than an ML-based segmenter.
- [CSS Text specification](https://drafts.csswg.org/css-text-4/#valdef-word-break-auto-phrase)

The full reproduction and rationale are documented in the related issue.

#### Related issues

Fixes #30359