### PR TITLE
Bug 2059526 Addition of theme property backgrounds_area

### DIFF
--- a/webextensions/manifest/theme.json
+++ b/webextensions/manifest/theme.json
@@ -1001,6 +1001,27 @@
               }
             }
           },
+          "backgrounds_area": {
+            "__compat": {
+              "support": {
+                "chrome": {
+                  "version_added": false
+                },
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "156"
+                },
+                "firefox_android": {
+                  "version_added": false
+                },
+                "opera": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror"
+              }
+            }
+          },
           "color_scheme": {
             "__compat": {
               "support": {


### PR DESCRIPTION
#### Summary

This change addresses the updates made in [Bug 2059526](https://bugzilla.mozilla.org/show_bug.cgi?id=2059526) Add a way for extensions to determine the background position for nova (in the window background, or in the toolbox).

#### Related issues

Corresponding changes to the MDN content are included in PR https://github.com/mdn/content/pull/45362.
