### PR TITLE
Mark api.HTMLAllCollection as deprecated

### DIFF
--- a/api/HTMLAllCollection.json
+++ b/api/HTMLAllCollection.json
@@ -37,7 +37,7 @@
         "status": {
           "experimental": false,
           "standard_track": true,
-          "deprecated": false
+          "deprecated": true
         }
       },
       "item": {
@@ -77,7 +77,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -118,7 +118,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       },
@@ -159,7 +159,7 @@
           "status": {
             "experimental": false,
             "standard_track": true,
-            "deprecated": false
+            "deprecated": true
           }
         }
       }


### PR DESCRIPTION
#### Summary

Mark `api.HTMLAllCollection` (and `item` / `length` / `namedItem`) as deprecated so it matches `Document.all` and the MDN page.

#### Test results and supporting details

- `api.Document.all` is already `deprecated: true` (spec: https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-all)
- MDN already treats the interface as deprecated: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAllCollection
- annevk on https://github.com/whatwg/html/issues/9298#issuecomment-1552660266: the API is deprecated, just can't be removed
- Same status pattern as `HTMLMarqueeElement`

#### Related issues

Fixes #30340
