### PR TITLE
Add Firefox enumerateDevices focus note

### DIFF
--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -107,7 +107,7 @@
                 "version_added": "116",
                 "notes": [
                   "`enumerateDevices()` enumerates both input and output devices. Previously only input devices were returned.",
-                  "The promise returned by `enumerateDevices()` only resolves when the document has system focus. See [bug 1818588](https://bugzil.la/1818588)."
+                  "The promise returned by `enumerateDevices()` only resolves when the document has focus. See [bug 1818588](https://bugzil.la/1818588)."
                 ]
               },
               {

--- a/api/MediaDevices.json
+++ b/api/MediaDevices.json
@@ -105,7 +105,10 @@
             "firefox": [
               {
                 "version_added": "116",
-                "notes": "`enumerateDevices()` enumerates both input and output devices. Previously only input devices were returned."
+                "notes": [
+                  "`enumerateDevices()` enumerates both input and output devices. Previously only input devices were returned.",
+                  "The promise returned by `enumerateDevices()` only resolves when the document has system focus. See [bug 1818588](https://bugzil.la/1818588)."
+                ]
               },
               {
                 "version_added": "39",


### PR DESCRIPTION
#### Summary

Adds a Firefox note that `enumerateDevices()` only resolves when the document has focus.

#### Test results and supporting details

- `node lint/lint.js api/MediaDevices.json`
- `node node_modules/prettier/bin/prettier.cjs --check api/MediaDevices.json`
- `node node_modules/typescript/bin/tsc --noEmit`
- `node --test --test-reporter=spec --test-isolation=none lint/linter/test-notes.test.js`
- [Mozilla bug 1818588](https://bugzil.la/1818588)

#### Related issues

Fixes #21106