### PR TITLE
Chrome 154 install API and <install> element

### DIFF
--- a/api/HTMLInstallElement.json
+++ b/api/HTMLInstallElement.json
@@ -1,0 +1,153 @@
+{
+  "api": {
+    "HTMLInstallElement": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "154",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-app-install-element",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "installresult_event": {
+        "__compat": {
+          "description": "`installresult` event",
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "manifest": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "manifestId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/HTMLInstallElement.json
+++ b/api/HTMLInstallElement.json
@@ -36,9 +36,120 @@
           "deprecated": false
         }
       },
+      "initialPermissionStatus": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "installresult_event": {
         "__compat": {
           "description": "`installresult` event",
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "invalidReason": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "isValid": {
+        "__compat": {
           "support": {
             "chrome": {
               "version_added": "154",
@@ -112,6 +223,43 @@
         }
       },
       "manifestId": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
+      "permissionStatus": {
         "__compat": {
           "support": {
             "chrome": {

--- a/api/HTMLInstallElement.json
+++ b/api/HTMLInstallElement.json
@@ -295,6 +295,44 @@
             "deprecated": false
           }
         }
+      },
+      "validationstatuschange_event": {
+        "__compat": {
+          "description": "`validationstatuschange` event",
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/InstallResultEvent.json
+++ b/api/InstallResultEvent.json
@@ -1,0 +1,78 @@
+{
+  "api": {
+    "InstallResultEvent": {
+      "__compat": {
+        "support": {
+          "chrome": {
+            "version_added": "154",
+            "flags": [
+              {
+                "type": "preference",
+                "name": "#web-app-install-element",
+                "value_to_set": "Enabled"
+              }
+            ]
+          },
+          "chrome_android": "mirror",
+          "edge": "mirror",
+          "firefox": {
+            "version_added": false
+          },
+          "firefox_android": "mirror",
+          "oculus": "mirror",
+          "opera": "mirror",
+          "opera_android": "mirror",
+          "safari": {
+            "version_added": false
+          },
+          "safari_ios": "mirror",
+          "samsunginternet_android": "mirror",
+          "webview_android": "mirror",
+          "webview_ios": "mirror"
+        },
+        "status": {
+          "experimental": true,
+          "standard_track": false,
+          "deprecated": false
+        }
+      },
+      "result": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/InstallResultEvent.json
+++ b/api/InstallResultEvent.json
@@ -36,6 +36,44 @@
           "deprecated": false
         }
       },
+      "InstallResultEvent": {
+        "__compat": {
+          "description": "`InstallResultEvent()` constructor",
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "result": {
         "__compat": {
           "support": {

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2077,7 +2077,7 @@
                   "value_to_set": "Enabled"
                 }
               ],
-              "notes": "Requires absolute URLs for manifests and manifest IDs."
+              "notes": "Requires absolute URLs for `manifest` and `manifestId`."
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Navigator.json
+++ b/api/Navigator.json
@@ -2064,6 +2064,48 @@
           }
         }
       },
+      "install": {
+        "__compat": {
+          "description": "`install()` method",
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-installation-api",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Requires absolute URLs for manifests and manifest IDs."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "nodejs": {
+              "version_added": false
+            },
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "javaEnabled": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/Navigator/javaEnabled",

--- a/html/elements/install.json
+++ b/html/elements/install.json
@@ -1,0 +1,44 @@
+{
+  "html": {
+    "elements": {
+      "install": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-install-element",
+                  "value_to_set": "Enabled"
+                }
+              ],
+              "notes": "Requires absolute URLs for manifests and manifest IDs."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/html/elements/install.json
+++ b/html/elements/install.json
@@ -12,8 +12,7 @@
                   "name": "#web-app-install-element",
                   "value_to_set": "Enabled"
                 }
-              ],
-              "notes": "Requires absolute URLs for manifests and manifest IDs."
+              ]
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -36,6 +35,82 @@
             "experimental": true,
             "standard_track": false,
             "deprecated": false
+          }
+        },
+        "manifest": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "154",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-app-install-element",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Requires an absolute URL."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
+        "manifestId": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "154",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-app-install-element",
+                    "value_to_set": "Enabled"
+                  }
+                ],
+                "notes": "Requires an absolute URL."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
           }
         }
       }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome/Edge 154 are shipping the experimental [`Navigator.install()`](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/WebInstall/explainer.md) method and [`<install>`](https://github.com/WICG/install-element/blob/main/explainer-manifest-url.md) element, which provide programmatic/declarative ways of creating in-page PWA install buttons.

See also the ChromeStatus entries:

- https://chromestatus.com/feature/5183481574850560
- https://chromestatus.com/feature/5152834368700416

These contain some useful demo links.

Both are currently behind a pref.

This PR adds a data point for each feature.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
