### PR TITLE
Permission API periodic-background-sync permission

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -754,6 +754,41 @@
           }
         }
       },
+      "permission_periodic-background-sync": {
+        "__compat": {
+          "description": "`periodic-background-sync` permission",
+          "spec_url": "https://wicg.github.io/periodic-background-sync/#permission",
+          "support": {
+            "chrome": {
+              "version_added": "80",
+              "notes": "This permission is only granted to installed Progressive Web Apps (PWAs)."
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": {
+              "version_added": false
+            },
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "permission_persistent-storage": {
         "__compat": {
           "description": "`persistent-storage` permission",


### PR DESCRIPTION
This adds a subfeature for the `periodic-background-sync`. Its supported in chrome only (the interface that uses it isn't supported on the other platforms) - https://developer.mozilla.org/en-US/docs/Web/API/PeriodicSyncManager/register

I've put that it is supported since release, which is extremely likely but untested.

The spec allows a browser to manage granting the permission however it likes. Chrome requires an installed PWA and some kinds of site engagement https://developer.chrome.com/docs/capabilities/periodic-background-sync#getting_user_engagement_right - I'v eonly mentioned the PWA thing.

Fell out of https://github.com/mdn/content/issues/33692#issuecomment-5406018257