### PR TITLE
FF154 HTTP `No-Vary-Search` header for HTTP cache

### DIFF
--- a/http/headers/No-Vary-Search.json
+++ b/http/headers/No-Vary-Search.json
@@ -36,8 +36,7 @@
             ],
             "edge": "mirror",
             "firefox": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/1967294"
+              "version_added": "154"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -56,7 +55,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }
@@ -74,8 +73,7 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1967294"
+                "version_added": "154"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -93,7 +91,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
FF154 adds support for [No-Vary-Search](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/No-Vary-Search) in https://bugzilla.mozilla.org/show_bug.cgi?id=2038013

This is just the HTTP cache aspect, not the speculation rules.


Related docs work can be tracked in https://github.com/mdn/content/issues/45298