### PR TITLE
Document CSS progress(no-clamp, …)

### DIFF
--- a/css/types/progress.json
+++ b/css/types/progress.json
@@ -35,6 +35,38 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "no-clamp": {
+          "__compat": {
+            "description": "`no-clamp` keyword",
+            "spec_url": "https://drafts.csswg.org/css-values-5/#valdef-progress-no-clamp",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Evidence https://wpt.fyi/results/css/css-values/progress-computed.html?label=master&product=chrome%5Bexperimental%5D&product=firefox%5Bbeta%5D&product=safari%5Bexperimental%5D&product=safari%5Bstable%5D&aligned

I can't decide if this should be a sub-feature (as in this PR), or just mark Chrome & Safari as partial support.