### PR TITLE
Label pull requests that add partial implementations

### DIFF
--- a/.github/workflows/pr-partial-labeler.yml
+++ b/.github/workflows/pr-partial-labeler.yml
@@ -1,0 +1,82 @@
+# Labels pull requests that add a partial implementation, so that they can be
+# picked up for discussion in the weekly BCD call.
+name: Partial Implementation Labeler
+
+on:
+  pull_request_target:
+  # Allows labeling all open pull requests, e.g. after changing this workflow.
+  workflow_dispatch:
+
+permissions:
+  contents: read # to determine the added partial implementations
+  pull-requests: write # to label pull requests
+
+concurrency:
+  group: pr-partial-labeler-${{ github.event.pull_request.number || 'all' }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+      LABEL: sets partial
+      REPO: ${{ github.repository }}
+
+    steps:
+      # Note: This deliberately checks out the base branch, rather than the code
+      # of the pull request, which must not be run with a writable token.
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          package-manager-cache: false
+
+      - name: Install
+        run: npm ci
+
+      - name: Determine pull requests
+        id: prs
+        shell: bash
+        run: |
+          if [ -n "$PR_NUMBER" ]; then
+            numbers="$PR_NUMBER"
+          else
+            numbers=$(gh pr list --repo "$REPO" --state open --limit 500 --json number --jq 'map(.number) | join(" ")')
+          fi
+          echo "numbers=$numbers" >> "$GITHUB_OUTPUT"
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+
+      - name: Label pull requests that add partial implementations
+        shell: bash
+        run: |
+          for pr in $NUMBERS; do
+            if ! added=$(node scripts/diff-partials.js "$pr" --json | jq -r '.added[]'); then
+              echo "::warning::Could not diff #$pr, skipping. Does it have merge conflicts?"
+              continue
+            fi
+
+            if gh pr view "$pr" --repo "$REPO" --json labels --jq '.labels[].name' | grep -Fxq "$LABEL"; then
+              labeled=true
+            else
+              labeled=false
+            fi
+
+            if [ -n "$added" ] && [ "$labeled" = "false" ]; then
+              echo "Labeling #$pr, which adds a partial implementation for:"
+              echo "$added" | sed 's/^/  /'
+              gh pr edit "$pr" --repo "$REPO" --add-label "$LABEL"
+            elif [ -z "$added" ] && [ "$labeled" = "true" ]; then
+              echo "Unlabeling #$pr, which no longer adds a partial implementation."
+              gh pr edit "$pr" --repo "$REPO" --remove-label "$LABEL"
+            fi
+          done
+        env:
+          NUMBERS: ${{ steps.prs.outputs.numbers }}

--- a/docs/labels.md
+++ b/docs/labels.md
@@ -76,3 +76,15 @@ Do not set this label on a pull request when it:
 - Only performs a migration that does not break backwards compatibility
 
 Remove this label upon committing a release note to a release note pull request (see [_Publishing a new version of `@mdn/browser-compat-data`_](./publishing.md#publishing-a-new-version-of-mdnbrowser-compat-data)).
+
+## sets partial
+
+| Pulls | Issues | Blocker |
+| ----- | ------ | ------- |
+| Yes   | No     | No      |
+
+This label indicates that a pull request adds a `partial_implementation` flag to at least one support statement.
+
+The [Partial Implementation Labeler](../.github/workflows/pr-partial-labeler.yml) workflow sets and removes this label automatically, so don't set or remove it manually: the label is synchronized again whenever the pull request is updated.
+
+Because partial implementations often need discussion, [open pull requests with this label](https://github.com/mdn/browser-compat-data/pulls?q=is%3Apr+is%3Aopen+label%3A%22sets+partial%22) are reviewed in the weekly BCD call.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,3 +48,13 @@ The `-b` or `--browser` argument may be any browser in the [`browsers/` folder](
 The `-f` or `--filter` argument may be any value accepted by `version_added` or `version_removed`. This argument may be repeated to test multiple values. By default, the script will traverse all features regardless of their value.
 
 Examples: to search for all Safari entries that are not supported, run `npm run traverse -- -b safari -f false`. To search for all WebView entries that are mirroring from upstream in `api` and `javascript`, run `npm run traverse api,javascript -- -b webview_android -f mirror`. To search for all Firefox entries supported since `10` across all folders, run `npm run traverse -- -b firefox -f 10`.
+
+## Diff partial implementations
+
+To see which partial implementations a change adds or removes, you can run `npm run diff:partials -- [base] [head]`. The script prints one `<feature>.<browser>` path per line, prefixed with `+` for added and `-` for removed partial implementations.
+
+Pass a pull request number as the only argument to diff that pull request against `main`, for example `npm run diff:partials -- 30261`. Pass `--json` to print the diff as JSON instead.
+
+Unresolved `"mirror"` values are ignored, so a partial implementation mirrored from an upstream browser is only reported for the upstream browser itself.
+
+The [Partial Implementation Labeler](../.github/workflows/pr-partial-labeler.yml) workflow uses this script to label pull requests that add a partial implementation (see [_Label usage_](./labels.md#sets-partial)).

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "prepare": "npm run gentypes && npm run build",
     "diff": "node scripts/diff.js",
     "diff:flat": "node scripts/diff-flat.js",
+    "diff:partials": "node scripts/diff-partials.js",
     "unittest": "NODE_ENV=test FORCE_COLOR=1 c8 node --test --test-reporter=spec --test-isolation=none '**/*.test.js'",
     "coverage": "c8 report -r lcov && open-cli coverage/lcov-report/index.html",
     "format": "eslint --cache . && prettier --check --cache . && tsc --noEmit",

--- a/scripts/diff-flat.js
+++ b/scripts/diff-flat.js
@@ -17,10 +17,15 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
 import bcd from '../index.js';
-import { spawn, walk } from '../utils/index.js';
+import { walk } from '../utils/index.js';
 
 import { addVersionLast, applyMirroring, transformMD } from './build/index.js';
-import { getMergeBase, getFileContent, getGitDiffStatuses } from './lib/git.js';
+import {
+  getMergeBase,
+  getFileContent,
+  getGitDiffStatuses,
+  resolveDiffRefs,
+} from './lib/git.js';
 import dataFolders from './lib/data-folders.js';
 
 const BROWSER_NAMES = Object.keys(bcd.browsers);
@@ -637,71 +642,8 @@ if (esMain(import.meta)) {
     })
     .parseSync();
 
-  const options = argv;
-
-  if (/^\d+$/.test(options.base)) {
-    options.head = `pull/${options.base}/merge`;
-    options.base = 'origin/main';
-  }
-
-  const remote =
-    spawn('git', ['remote', '-v'])
-      .split('\n')
-      .find((line) => line.includes('mdn/browser-compat-data'))
-      ?.split(/\s+/, 2)
-      .at(0) ?? 'origin';
-
-  /**
-   * Runs `git fetch` for a reference.
-   * @param {string} ref - the reference to fetch.
-   * @returns {string} Combined standard output/error of the command.
-   */
-  const gitFetch = (ref) => spawn('git', ['fetch', remote, ref]);
-
-  /**
-   * Runs `git rev-parse` for a reference.
-   * @param {string} ref - the reference to parse.
-   * @returns {string} Standard output of the command.
-   */
-  const gitRevParse = (ref) => spawn('git', ['rev-parse', ref]);
-
-  /**
-   * Resolves and fetches the reference.
-   * @param {string} ref - the reference to fetch and resolve.
-   * @returns {string} Commit hash corresponding to the reference.
-   */
-  const fetchAndResolve = (ref) => {
-    if (ref.startsWith('origin/')) {
-      const remoteRef = ref.slice('origin/'.length);
-      gitFetch(remoteRef);
-      return gitRevParse(ref);
-    } else if (ref.startsWith(`${remote}/`)) {
-      const remoteRef = ref.slice(`${remote}/`.length);
-      gitFetch(remoteRef);
-      return gitRevParse(ref);
-    } else if (ref.startsWith('pull/')) {
-      gitFetch(ref);
-      return gitRevParse('FETCH_HEAD');
-    } else if (ref.includes(':')) {
-      const remoteRef = `gh pr view ${ref} --json headRefOid -q '.headRefOid'`;
-      gitFetch(remoteRef);
-      return remoteRef;
-    } else if (/^[0-9a-f]{40}$/.test(ref)) {
-      try {
-        gitRevParse(ref);
-      } catch {
-        gitFetch(ref);
-      }
-      return ref;
-    }
-
-    return gitRevParse(ref);
-  };
-
-  options.base = fetchAndResolve(options.base);
-  options.head = fetchAndResolve(options.head);
-
-  const { base, head, group, format, mirror, transform } = options;
+  const { base, head } = resolveDiffRefs(argv.base, argv.head);
+  const { group, format, mirror, transform } = argv;
 
   printDiffs(getMergeBase(base, head), head, {
     group,

--- a/scripts/diff-partials.js
+++ b/scripts/diff-partials.js
@@ -1,0 +1,169 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+/** @import {BrowserName, InternalDataType} from '../types/index.js' */
+
+import esMain from 'es-main';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import { iterSupport, walk } from '../utils/index.js';
+
+import {
+  getFileContent,
+  getGitDiffStatuses,
+  getMergeBase,
+  resolveDiffRefs,
+} from './lib/git.js';
+import { dataFoldersMinusBrowsers } from './lib/data-folders.js';
+
+/**
+ * @typedef {object} PartialsDiff
+ * @property {string[]} added The paths that gained a partial implementation
+ * @property {string[]} removed The paths that lost a partial implementation
+ */
+
+/**
+ * Check whether a file path is a compat data file
+ * @param {string} path The file path to check
+ * @returns {boolean} Whether the path is a compat data file
+ */
+const isDataFile = (path) =>
+  path.endsWith('.json') &&
+  dataFoldersMinusBrowsers.some((folder) => path.startsWith(`${folder}/`));
+
+/**
+ * Collect the paths of all support statements marked as partial implementations.
+ * Unresolved `"mirror"` statements are ignored, so only explicit partial
+ * implementations are collected.
+ * @param {InternalDataType} data The compat data to collect from
+ * @returns {Set<string>} The `<feature>.<browser>` paths with a partial implementation
+ */
+export const collectPartials = (data) => {
+  /** @type {Set<string>} */
+  const partials = new Set();
+
+  for (const { path, compat } of walk(undefined, data)) {
+    for (const browser of /** @type {BrowserName[]} */ (
+      Object.keys(compat.support)
+    )) {
+      if (
+        iterSupport(compat, browser).some(
+          (statement) => statement.partial_implementation,
+        )
+      ) {
+        partials.add(`${path}.${browser}`);
+      }
+    }
+  }
+
+  return partials;
+};
+
+/**
+ * Collect the partial implementations of compat data files at a given commit
+ * @param {string} commit The commit to collect at
+ * @param {string[]} paths The file paths to collect from
+ * @returns {Set<string>} The `<feature>.<browser>` paths with a partial implementation
+ */
+const collectPartialsAt = (commit, paths) => {
+  /** @type {Set<string>} */
+  const partials = new Set();
+
+  for (const path of paths) {
+    const contents = /** @type {InternalDataType} */ (
+      JSON.parse(getFileContent(commit, path))
+    );
+
+    for (const partial of collectPartials(contents)) {
+      partials.add(partial);
+    }
+  }
+
+  return partials;
+};
+
+/**
+ * Compare two sets of partial implementations
+ * @param {Set<string>} before The partial implementations before the change
+ * @param {Set<string>} after The partial implementations after the change
+ * @returns {PartialsDiff} The added and removed partial implementations
+ */
+export const comparePartials = (before, after) => ({
+  added: [...after].filter((path) => !before.has(path)).sort(),
+  removed: [...before].filter((path) => !after.has(path)).sort(),
+});
+
+/**
+ * Diff the partial implementations between two commits
+ * @param {string} base The base commit
+ * @param {string} head The head commit that changes are applied to
+ * @returns {PartialsDiff} The added and removed partial implementations
+ */
+export const diffPartials = (base, head) => {
+  const statuses = getGitDiffStatuses(base, head).filter((status) =>
+    isDataFile(status.headPath),
+  );
+
+  return comparePartials(
+    collectPartialsAt(
+      base,
+      statuses
+        .filter((status) => status.value !== 'A')
+        .map((status) => status.basePath),
+    ),
+    collectPartialsAt(
+      head,
+      statuses
+        .filter((status) => status.value !== 'D')
+        .map((status) => status.headPath),
+    ),
+  );
+};
+
+if (esMain(import.meta)) {
+  const argv = yargs(hideBin(process.argv))
+    .command(
+      '$0 [base] [head]',
+      'Print the partial implementations added and removed between base and head commits',
+    )
+    .positional('base', {
+      describe:
+        'The base commit; may be a pull request number, commit hash or other git ref (e.g. "origin/main")',
+      type: 'string',
+      default: 'origin/main',
+    })
+    .positional('head', {
+      describe:
+        'The head commit that changes are applied to; may be commit hash or other git ref (e.g. "origin/main")',
+      type: 'string',
+      default: 'HEAD',
+    })
+    .option('json', {
+      describe: 'Print the diff as JSON, rather than as plain text',
+      type: 'boolean',
+      default: false,
+    })
+    .example(
+      'npm run diff:partials -- 30261',
+      'Print the partial implementations added and removed by pull request 30261',
+    )
+    .parseSync();
+
+  const { base, head } = resolveDiffRefs(argv.base, argv.head);
+
+  const diff = diffPartials(getMergeBase(base, head), head);
+
+  if (argv.json) {
+    console.log(JSON.stringify(diff));
+  } else if (diff.added.length === 0 && diff.removed.length === 0) {
+    console.log('✔ No partial implementation added or removed.');
+  } else {
+    for (const path of diff.added) {
+      console.log(`+ ${path}`);
+    }
+    for (const path of diff.removed) {
+      console.log(`- ${path}`);
+    }
+  }
+}

--- a/scripts/diff-partials.test.js
+++ b/scripts/diff-partials.test.js
@@ -1,0 +1,145 @@
+/* This file is a part of @mdn/browser-compat-data
+ * See LICENSE file for more information. */
+
+/** @import {InternalDataType, InternalSupportBlock} from '../types/index.js' */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { collectPartials, comparePartials } from './diff-partials.js';
+
+/**
+ * Build compat data for a single feature
+ * @param {InternalSupportBlock} support The support block of the feature
+ * @returns {InternalDataType} The compat data
+ */
+const feature = (support) =>
+  /** @type {*} */ ({
+    css: { properties: { fries: { __compat: { support } } } },
+  });
+
+/** @type {{ name: string; data: InternalDataType; expected: string[] }[]} */
+const collectTests = [
+  {
+    name: 'a simple statement with a partial implementation',
+    data: feature({
+      chrome: { version_added: '20', partial_implementation: true },
+    }),
+    expected: ['css.properties.fries.chrome'],
+  },
+  {
+    name: 'a simple statement without a partial implementation',
+    data: feature({ chrome: { version_added: '20' } }),
+    expected: [],
+  },
+  {
+    name: 'one partial implementation among multiple statements',
+    data: feature({
+      chrome: [
+        { version_added: '20' },
+        {
+          version_added: '10',
+          version_removed: '20',
+          partial_implementation: true,
+        },
+      ],
+    }),
+    expected: ['css.properties.fries.chrome'],
+  },
+  {
+    name: 'multiple browsers',
+    data: feature({
+      chrome: { version_added: '20', partial_implementation: true },
+      firefox: { version_added: '20' },
+      safari: { version_added: '20', partial_implementation: true },
+    }),
+    expected: ['css.properties.fries.chrome', 'css.properties.fries.safari'],
+  },
+  {
+    name: 'an unresolved "mirror" statement',
+    data: feature({
+      chrome: { version_added: '20', partial_implementation: true },
+      chrome_android: 'mirror',
+    }),
+    expected: ['css.properties.fries.chrome'],
+  },
+  {
+    name: 'subfeatures',
+    data: /** @type {*} */ ({
+      css: {
+        properties: {
+          fries: {
+            __compat: { support: { chrome: { version_added: '20' } } },
+            crispy: {
+              __compat: {
+                support: {
+                  chrome: { version_added: '20', partial_implementation: true },
+                },
+              },
+            },
+          },
+        },
+      },
+    }),
+    expected: ['css.properties.fries.crispy.chrome'],
+  },
+];
+
+describe('collectPartials', () => {
+  for (const { name, data, expected } of collectTests) {
+    it(`should collect ${name}`, () => {
+      assert.deepEqual([...collectPartials(data)].sort(), expected);
+    });
+  }
+});
+
+/** @type {{ name: string; before: string[]; after: string[]; expected: { added: string[]; removed: string[] } }[]} */
+const compareTests = [
+  {
+    name: 'an added partial implementation',
+    before: [],
+    after: ['css.properties.fries.chrome'],
+    expected: { added: ['css.properties.fries.chrome'], removed: [] },
+  },
+  {
+    name: 'a removed partial implementation',
+    before: ['css.properties.fries.chrome'],
+    after: [],
+    expected: { added: [], removed: ['css.properties.fries.chrome'] },
+  },
+  {
+    name: 'an unchanged partial implementation',
+    before: ['css.properties.fries.chrome'],
+    after: ['css.properties.fries.chrome'],
+    expected: { added: [], removed: [] },
+  },
+  {
+    name: 'a partial implementation moved to another browser',
+    before: ['css.properties.fries.chrome'],
+    after: ['css.properties.fries.safari'],
+    expected: {
+      added: ['css.properties.fries.safari'],
+      removed: ['css.properties.fries.chrome'],
+    },
+  },
+  {
+    name: 'sorted results',
+    before: [],
+    after: ['css.properties.fries.safari', 'css.properties.fries.chrome'],
+    expected: {
+      added: ['css.properties.fries.chrome', 'css.properties.fries.safari'],
+      removed: [],
+    },
+  },
+];
+
+describe('comparePartials', () => {
+  for (const { name, before, after, expected } of compareTests) {
+    it(`should report ${name}`, () => {
+      assert.deepEqual(
+        comparePartials(new Set(before), new Set(after)),
+        expected,
+      );
+    });
+  }
+});

--- a/scripts/lib/git.js
+++ b/scripts/lib/git.js
@@ -69,10 +69,89 @@ const getBranchName = () => spawn('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
  */
 const getHashOfHEAD = () => spawn('git', ['rev-parse', 'HEAD']);
 
+/**
+ * Get the name of the git remote that points at the upstream repository
+ * @returns {string} The remote name, or "origin" if there is no such remote
+ */
+const getUpstreamRemote = () =>
+  spawn('git', ['remote', '-v'])
+    .split('\n')
+    .find((line) => line.includes('mdn/browser-compat-data'))
+    ?.split(/\s+/, 2)
+    .at(0) ?? 'origin';
+
+/**
+ * Fetch a git reference and resolve it to a commit hash
+ * @param {string} ref The reference to fetch and resolve
+ * @returns {string} The commit hash corresponding to the reference
+ */
+const fetchAndResolveRef = (ref) => {
+  const remote = getUpstreamRemote();
+
+  /**
+   * Runs `git fetch` for a reference.
+   * @param {string} ref - the reference to fetch.
+   * @returns {string} Combined standard output/error of the command.
+   */
+  const gitFetch = (ref) => spawn('git', ['fetch', remote, ref]);
+
+  /**
+   * Runs `git rev-parse` for a reference.
+   * @param {string} ref - the reference to parse.
+   * @returns {string} Standard output of the command.
+   */
+  const gitRevParse = (ref) => spawn('git', ['rev-parse', ref]);
+
+  if (ref.startsWith('origin/')) {
+    const remoteRef = ref.slice('origin/'.length);
+    gitFetch(remoteRef);
+    return gitRevParse(ref);
+  } else if (ref.startsWith(`${remote}/`)) {
+    const remoteRef = ref.slice(`${remote}/`.length);
+    gitFetch(remoteRef);
+    return gitRevParse(ref);
+  } else if (ref.startsWith('pull/')) {
+    gitFetch(ref);
+    return gitRevParse('FETCH_HEAD');
+  } else if (ref.includes(':')) {
+    const remoteRef = `gh pr view ${ref} --json headRefOid -q '.headRefOid'`;
+    gitFetch(remoteRef);
+    return remoteRef;
+  } else if (/^[0-9a-f]{40}$/.test(ref)) {
+    try {
+      gitRevParse(ref);
+    } catch {
+      gitFetch(ref);
+    }
+    return ref;
+  }
+
+  return gitRevParse(ref);
+};
+
+/**
+ * Resolve the base and head references of a diff, expanding a pull request
+ * number given as base into the pull request's merge commit
+ * @param {string} base The base reference, or a pull request number
+ * @param {string} head The head reference
+ * @returns {{ base: string; head: string }} The resolved commit hashes
+ */
+const resolveDiffRefs = (base, head) => {
+  if (/^\d+$/.test(base)) {
+    head = `pull/${base}/merge`;
+    base = 'origin/main';
+  }
+
+  return { base: fetchAndResolveRef(base), head: fetchAndResolveRef(head) };
+};
+
 export {
   getMergeBase,
   getGitDiffStatuses,
   getFileContent,
+  getUpstreamRemote,
+  fetchAndResolveRef,
+  resolveDiffRefs,
   getBranchName,
   getHashOfHEAD,
 };


### PR DESCRIPTION
#### Summary

Add a "sets partial" label to pull requests that add a `partial_implementation` flag, and remove it again when they no longer do.

- `npm run diff:partials -- [base] [head]` prints the `<feature>.<browser>` paths that gain (`+`) or lose (`-`) a partial implementation between two references, or for a pull request number. `--json` prints the same as JSON.
- A new `Partial Implementation Labeler` workflow runs it per pull request and synchronizes the label. It can also be dispatched manually to (re-)label all open pull requests.
- The ref resolution of `diff:flat` (remote lookup, pull request number shorthand) moved to `scripts/lib/git.js` for reuse, without behavior change.

The label needs to be created in the repository before this is merged, and does not exist yet.

#### Test results and supporting details

`diff:partials` compares the set of paths carrying `partial_implementation`, rather than grepping the diff for added `partial_implementation` lines. Of the last 300 commits on `main`, 17 add such a line, but 4 of those should not be labeled, and the structural comparison gets all 4 right:

| Pull request | `+`/`-` partial lines in diff | `diff:partials` | Reality |
| --- | --- | --- | --- |
| #30290 | 1 / 1 | no change | existing partial implementation modified |
| #30246 | 1 / 1 | no change | existing partial implementation modified |
| #30170 | 1 / 1 | no change | existing partial implementation modified |
| #29986 | 319 / 326 | `+1` / `-8` | mostly reformatting, net removal |
| #30255 | 1 / 0 | `+ api.PublicKeyCredential.isConditionalMediationAvailable_static.webview_android` | added |
| #30212 | 1 / 0 | `+ css.properties.mask-image.svg_masks.safari` | added |
| #30221 | 2 / 0 | `+ css.properties.text-box{,-trim}.inline_elements.safari` | added |

Unresolved `"mirror"` values are ignored, so a partial implementation is only reported for the browser whose data states it.

The labeling logic was run locally (with the API calls stubbed out) against #30320 (adds a partial implementation, gets labeled), #30384 and #30353 (no change), and against a pull request with merge conflicts, where the missing `pull/N/merge` ref results in a warning and a skip, rather than a failure. Since `pull_request_target` workflows run from the base branch, the workflow itself cannot run on this pull request; after merging, a manual dispatch labels the open pull requests.

Unit tests cover the collection and comparison of partial implementations.

#### Related issues

Fixes #30261.