### PR TITLE
[WebExtensions] Chrome 152+ extension action badge text limit

### DIFF
--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -622,9 +622,7 @@
             "support": {
               "chrome": {
                 "version_added": "88",
-                "notes": [
-                  "From Chrome 152, action badges are limited to 100 bytes."
-                ]
+                "notes": "From Chrome 152, action badges are limited to 100 bytes."
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -621,7 +621,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/action/setBadgeText",
             "support": {
               "chrome": {
-                "version_added": "88"
+                "version_added": "88",
+                "notes": [
+                  "From Chrome 152, action badges are limited to 100 bytes."
+                ]
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/action.json
+++ b/webextensions/api/action.json
@@ -622,7 +622,7 @@
             "support": {
               "chrome": {
                 "version_added": "88",
-                "notes": "From Chrome 152, action badges are limited to 100 bytes."
+                "notes": "From Chrome 152, action badge text is limited to 100 bytes."
               },
               "edge": "mirror",
               "firefox": {

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -719,7 +719,7 @@
             "support": {
               "chrome": {
                 "version_added": "4",
-                "notes": "From Chrome 152, action badges are limited to 100 bytes."
+                "notes": "From Chrome 152, action badge text is limited to 100 bytes."
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -718,7 +718,10 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeText",
             "support": {
               "chrome": {
-                "version_added": "4"
+                "version_added": "4",
+                "notes": [
+                  "From Chrome 152, action badges are limited to 100 bytes."
+                ]
               },
               "edge": {
                 "version_added": "14"

--- a/webextensions/api/browserAction.json
+++ b/webextensions/api/browserAction.json
@@ -719,9 +719,7 @@
             "support": {
               "chrome": {
                 "version_added": "4",
-                "notes": [
-                  "From Chrome 152, action badges are limited to 100 bytes."
-                ]
+                "notes": "From Chrome 152, action badges are limited to 100 bytes."
               },
               "edge": {
                 "version_added": "14"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Chrome 152+ throws an error when extension attempts to set action badge exceeding 100 bytes.
<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

Commit implementing this limit (with tests for `action.setBadgeText()`): https://github.com/chromium/chromium/commit/8170d1b52c226e2550811aefdca87ec35ba496e9
That commit landed in Chrome 152: https://chromiumdash.appspot.com/commit/8170d1b52c226e2550811aefdca87ec35ba496e9
Both `action.setBadgeText()` and `browserAction.setBadgeText()` are aliased to the same implementation `ExtensionActionSetBadgeTextFunction`, [former on line 209](https://github.com/chromium/chromium/blob/main/chrome/browser/extensions/api/extension_action/extension_action_api.h#L209) and [latter on line 367](https://github.com/chromium/chromium/blob/main/chrome/browser/extensions/api/extension_action/extension_action_api.h#L367).

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

WECG discussion: https://github.com/w3c/webextensions/issues/960
Chrome tracking bug: https://issues.chromium.org/issues/491158086
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
