### PR TITLE
Add Chrome note for `contenteditable="plaintext-only"`

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -438,7 +438,8 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "51"
+                "version_added": "51",
+                "notes": "Chrome overrides the specified or implicit `white-space` style to `pre-wrap` or `pre` when `contenteditable` is set to `plaintext-only`."
               },
               "chrome_android": "mirror",
               "edge": {

--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -439,7 +439,7 @@
             "support": {
               "chrome": {
                 "version_added": "51",
-                "notes": "Chrome overrides the specified or implicit `white-space` style to `pre-wrap` or `pre` when `contenteditable` is set to `plaintext-only`."
+                "notes": "Chrome overrides the specified or implicit `white-space` style to `pre-wrap` or `pre` when `contenteditable` is set to `plaintext-only`. See [bug 413427424](https://crbug.com/413427424)."
               },
               "chrome_android": "mirror",
               "edge": {


### PR DESCRIPTION
## Summary

- Add a Chrome-specific BCD note for `contenteditable="plaintext-only"`.
- Document Chrome's `white-space` behavior for the `plaintext-only` value.

Fixes #26719