### PR TITLE
Edge 121 supports `display: ruby/ruby-text`

### DIFF
--- a/css/properties/display.json
+++ b/css/properties/display.json
@@ -986,10 +986,15 @@
                 "version_added": "121"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "121"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "38"
               },
@@ -1106,10 +1111,15 @@
                 "version_added": "121"
               },
               "chrome_android": "mirror",
-              "edge": {
-                "version_added": "12",
-                "version_removed": "79"
-              },
+              "edge": [
+                {
+                  "version_added": "121"
+                },
+                {
+                  "version_added": "12",
+                  "version_removed": "79"
+                }
+              ],
               "firefox": {
                 "version_added": "38"
               },


### PR DESCRIPTION
## Summary

- Add Edge 121 support for `display: ruby`.
- Add Edge 121 support for `display: ruby-text`.
- Preserve the existing EdgeHTML support data for Edge 12–78.

## Related issue

Closes #26721