### PR TITLE
Safari 10 / Safari iOS 9 added CryptoKey

### DIFF
--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -40,7 +40,7 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "7"
+            "version_added": "10.1"
           },
           "safari_ios": "mirror",
           "samsunginternet_android": "mirror",
@@ -85,7 +85,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -139,7 +139,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -185,7 +185,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -231,7 +231,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "7"
+              "version_added": "10.1"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -141,7 +141,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -40,9 +40,11 @@
           "opera": "mirror",
           "opera_android": "mirror",
           "safari": {
-            "version_added": "10.1"
+            "version_added": "10"
           },
-          "safari_ios": "mirror",
+          "safari_ios": {
+            "version_added": "9"
+          },
           "samsunginternet_android": "mirror",
           "webview_android": "mirror",
           "webview_ios": "mirror"
@@ -85,7 +87,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -185,7 +187,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",
@@ -231,7 +233,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": "10.1"
+              "version_added": "10"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/api/CryptoKey.json
+++ b/api/CryptoKey.json
@@ -89,7 +89,9 @@
             "safari": {
               "version_added": "10"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "9"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -143,7 +145,9 @@
             "safari": {
               "version_added": "10"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "9"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -189,7 +193,9 @@
             "safari": {
               "version_added": "10"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "9"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"
@@ -235,7 +241,9 @@
             "safari": {
               "version_added": "10"
             },
-            "safari_ios": "mirror",
+            "safari_ios": {
+              "version_added": "9"
+            },
             "samsunginternet_android": "mirror",
             "webview_android": "mirror",
             "webview_ios": "mirror"


### PR DESCRIPTION
## Summary

- Correct Safari support data for `CryptoKey` and its properties.
- Update Safari support from 7 to 10.
- Set Safari iOS support for `CryptoKey` to 9.
- Keep Safari iOS mirroring for properties where the data can be automatically mirrored.

## Related issue

Fixes #26448

## Testing

- `npm run lint api/CryptoKey.json` passes.
- `npx prettier --check api/CryptoKey.json` passes.
- GitHub CI checks pass.