### PR TITLE
Navigator.install() and <install> element permissions

### DIFF
--- a/api/Permissions.json
+++ b/api/Permissions.json
@@ -990,6 +990,44 @@
           }
         }
       },
+      "permission_web-app-installation": {
+        "__compat": {
+          "description": "`web-app-installation` permission",
+          "support": {
+            "chrome": {
+              "version_added": "154",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#web-app-installation-api",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
+      },
       "permission_window-management": {
         "__compat": {
           "description": "`window-management` permission",

--- a/http/headers/Permissions-Policy.json
+++ b/http/headers/Permissions-Policy.json
@@ -1692,6 +1692,48 @@
             }
           }
         },
+        "web-app-installation": {
+          "__compat": {
+            "support": {
+              "chrome": {
+                "version_added": "154",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#web-app-install-element",
+                    "value_to_set": "Enabled"
+                  },
+                  {
+                    "type": "preference",
+                    "name": "#web-app-installation-api",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
+        },
         "web-share": {
           "__compat": {
             "mdn_url": "https://developer.mozilla.org/docs/Web/HTTP/Reference/Headers/Permissions-Policy/web-share",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

This is a follow-on from https://github.com/mdn/browser-compat-data/pull/30366, in which I added BCD for the `Navigator.install()` method and the `<install>` element (and related DOM interfaces).

Afterwards, I discovered that these features also use the Permissions API permissions system, and have Permissions-Policy directive to control their use. 

This PR adds data points for those features.

Note:

- The Permissions-Policy is used by the API and the element, so I've added both flags in for that one.
- The Permissions API permission is used only by the API, so I've included only the API flag in that case. 

cc'ing @LiaHiscock to help with any technical questions we might have.


<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
