### PR TITLE
Add `<template for>` MDN URL

### DIFF
--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -39,7 +39,7 @@
         },
         "for": {
           "__compat": {
-            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#for",
+            "mdn_url": "https://developer.mozilla.org/docs/Web/HTML/Reference/Elements/template#for",
             "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-for",
             "tags": [
               "web-features:template-for"

--- a/html/elements/template.json
+++ b/html/elements/template.json
@@ -39,6 +39,7 @@
         },
         "for": {
           "__compat": {
+            "mdn_url": "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/template#for",
             "spec_url": "https://html.spec.whatwg.org/multipage/scripting.html#attr-template-for",
             "tags": [
               "web-features:template-for"


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

Add `<template for>` MDN URL

The `HTMLTemplateElement` equivalent was updated in #30374 but this one wasn't. I think it's because this doesn't get pulled in automatically from MDN as an attribute on the main element page, rather than a separate page?

#### Test results and supporting details

N/A

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Original PR: #30292
Content PR: https://github.com/mdn/content/pull/45315

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
