### PR TITLE
Unmark `focusin` + `focusout` event implementations as partial

### DIFF
--- a/api/Element.json
+++ b/api/Element.json
@@ -5024,40 +5024,6 @@
             "standard_track": true,
             "deprecated": false
           }
-        },
-        "onfocusin": {
-          "__compat": {
-            "description": "`onfocusin` event handler property - nonstandard",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "5"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
-          }
         }
       },
       "focusout_event": {
@@ -5102,40 +5068,6 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
-          }
-        },
-        "onfocusout": {
-          "__compat": {
-            "description": "`onfocusout` event handler property - nonstandard",
-            "support": {
-              "chrome": {
-                "version_added": false
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "ie": {
-                "version_added": "9"
-              },
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": "5"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": false,
-              "deprecated": false
-            }
           }
         }
       },

--- a/api/Element.json
+++ b/api/Element.json
@@ -4991,20 +4991,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "partial_implementation": true,
-              "notes": "The `onfocusin` event handler property is not supported. To listen to this event, use `element.addEventListener('focusin', function() {});`."
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "The `onfocusin` event handler property is not supported. To listen to this event, use `element.addEventListener('focusin', function() {});`."
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "52",
-              "partial_implementation": true,
-              "notes": "The `onfocusin` event handler property is not supported. To listen to this event, use `element.addEventListener('focusin', function() {});`."
+              "version_added": "52"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5030,6 +5024,40 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "onfocusin": {
+          "__compat": {
+            "description": "`onfocusin` event handler property - nonstandard",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
+          }
         }
       },
       "focusout_event": {
@@ -5042,20 +5070,14 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "1",
-              "partial_implementation": true,
-              "notes": "The `onfocusout` event handler property is not supported. To listen to this event, use `element.addEventListener('focusout', function() {});`."
+              "version_added": "1"
             },
             "chrome_android": "mirror",
             "edge": {
-              "version_added": "12",
-              "partial_implementation": true,
-              "notes": "The `onfocusout` event handler property is not supported. To listen to this event, use `element.addEventListener('focusout', function() {});`."
+              "version_added": "12"
             },
             "firefox": {
-              "version_added": "52",
-              "partial_implementation": true,
-              "notes": "The `onfocusout` event handler property is not supported. To listen to this event, use `element.addEventListener('focusout', function() {});`."
+              "version_added": "52"
             },
             "firefox_android": "mirror",
             "ie": {
@@ -5080,6 +5102,40 @@
             "experimental": false,
             "standard_track": true,
             "deprecated": false
+          }
+        },
+        "onfocusout": {
+          "__compat": {
+            "description": "`onfocusout` event handler property - nonstandard",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "9"
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "5"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": false,
+              "deprecated": false
+            }
           }
         }
       },


### PR DESCRIPTION
This is a bit of a weird one. These are currently marked 'partial' in Chrome & Firefox because they don't support the `onfocusout` event handler property. However, those properties are nonstandard - [they're not defined in the HTML spec](https://html.spec.whatwg.org/multipage/webappapis.html#globaleventhandlers).

These events [are somewhat spec'd in UI Events](https://w3c.github.io/uievents/#interface-inputevent), but the handler properties are not.

Although [the data guidelines explicitly recommend using partial in these cases](https://github.com/jakearchibald/browser-compat-data/blob/fb9e4f0b5e66064a41b58b0d1dbd4b8737b37620/docs/data-guidelines/api.md#L124), it seems incorrect to apply this rule in cases where the handler property is nonstandard.

Marking other browsers as 'partial' because one browser implements a nonstandard extension to the feature seems… bad.

There was an attempt to add these to the spec, but it stalled in 2024 https://github.com/whatwg/html/pull/10235.