### PR TITLE
Fix inconsistent standard_track for HTML webkitdirectory attribute

### DIFF
--- a/html/elements/input.json
+++ b/html/elements/input.json
@@ -1494,6 +1494,7 @@
         },
         "webkitdirectory": {
           "__compat": {
+            "spec_url": "https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory",
             "tags": [
               "web-features:input-file-webkitdirectory"
             ],
@@ -1540,7 +1541,7 @@
             },
             "status": {
               "experimental": false,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }


### PR DESCRIPTION
#### Summary

`html.elements.input.webkitdirectory` had `standard_track: false` and no `spec_url`, while `api.HTMLInputElement.webkitdirectory` has `standard_track: true` with a `spec_url` pointing to the same [File and Directory Entries API](https://wicg.github.io/entries-api/#dom-htmlinputelement-webkitdirectory) definition (the spec defines the content attribute and IDL attribute at the same anchor). This aligns the HTML attribute entry with the IDL attribute entry.

This surfaced from [mdn/content#45474](https://github.com/mdn/content/pull/45474), where a reviewer noted the content docs and the live `HTMLInputElement.webkitdirectory` page were giving conflicting standard/non-standard signals for the same attribute.

#### Test results and supporting details

`node lint/lint.js` and `prettier --check` both pass on `html/elements/input.json`.

#### Related issues

N/A