### PR TITLE
Remove api.HTMLMediaElement.seekToNextFrame

### DIFF
--- a/api/HTMLMediaElement.json
+++ b/api/HTMLMediaElement.json
@@ -2856,38 +2856,6 @@
           }
         }
       },
-      "seekToNextFrame": {
-        "__compat": {
-          "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/seekToNextFrame",
-          "support": {
-            "chrome": {
-              "version_added": false
-            },
-            "chrome_android": "mirror",
-            "edge": "mirror",
-            "firefox": {
-              "version_added": "56",
-              "version_removed": "128"
-            },
-            "firefox_android": "mirror",
-            "oculus": "mirror",
-            "opera": "mirror",
-            "opera_android": "mirror",
-            "safari": {
-              "version_added": false
-            },
-            "safari_ios": "mirror",
-            "samsunginternet_android": "mirror",
-            "webview_android": "mirror",
-            "webview_ios": "mirror"
-          },
-          "status": {
-            "experimental": false,
-            "standard_track": false,
-            "deprecated": true
-          }
-        }
-      },
       "setMediaKeys": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/HTMLMediaElement/setMediaKeys",


### PR DESCRIPTION
#### Summary

This data can be removed per the 2-year irrelevance guideline. 
Fixes this linting info:

```
Obsolete - 1 problem (0 errors, 0 warnings, 1 info):
  ✖ api.HTMLMediaElement.seekToNextFrame - Info → feature was implemented and has since been removed from all browsers dating back two or more years ago.
```

#### Test results and supporting details

None

#### Related issues

None. Needs a content page removal, too.