### PR TITLE
Remove exception for not validating SVG types spec_urls

### DIFF
--- a/lint/common/spec-urls-exceptions.txt
+++ b/lint/common/spec-urls-exceptions.txt
@@ -59,8 +59,5 @@ https://tc39.es/proposal-async-explicit-resource-management
 # Remove once https://github.com/w3c/trusted-types/issues/605 is resolved
 https://w3c.github.io/trusted-types/dist/spec
 
-# Remove once https://github.com/w3c/reffy/issues/2102 is resolved
-https://w3c.github.io/svgwg/svg2-draft/types.html
-
 # Remove once the CHIPS draft is in a proper Cookies specification.
 https://www.ietf.org/archive/id/draft-cutler-httpbis-partitioned-cookies-01.html#section-2.1


### PR DESCRIPTION
#### Summary

https://github.com/w3c/reffy/issues/2102 was resolved. 
We can now validate spec_urls under https://w3c.github.io/svgwg/svg2-draft/types.html

#### Test results and supporting details

Lint will pass once we have the new xref package (Sept 9).

#### Related issues

None.