### PR TITLE
added height-based clamping to line-clamp property

### DIFF
--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -110,7 +110,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": false,
+              "standard_track": true,
               "deprecated": false
             }
           }
@@ -150,8 +150,8 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": false,
-              "standard_track": true,
+              "experimental": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -115,6 +115,47 @@
             }
           }
         },
+        "height": {
+          "__compat": {
+            "description": "`height-based clamping`",
+            "tags": [
+              "web-features:line-clamp"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "no-ellipsis": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-overflow-4/#valdef-block-ellipsis-no-ellipsis",
@@ -216,47 +257,6 @@
               "opera_android": "mirror",
               "safari": {
                 "version_added": "preview"
-              },
-              "safari_ios": "mirror",
-              "samsunginternet_android": "mirror",
-              "webview_android": "mirror",
-              "webview_ios": "mirror"
-            },
-            "status": {
-              "experimental": false,
-              "standard_track": true,
-              "deprecated": false
-            }
-          }
-        },
-        "height": {
-          "__compat": {
-            "description": "`height-based clamping`",
-            "tags": [
-              "web-features:line-clamp"
-            ],
-            "support": {
-              "chrome": {
-                "version_added": "preview",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features",
-                    "value_to_set": "Enabled"
-                  }
-                ]
-              },
-              "chrome_android": "mirror",
-              "edge": "mirror",
-              "firefox": {
-                "version_added": false
-              },
-              "firefox_android": "mirror",
-              "oculus": "mirror",
-              "opera": "mirror",
-              "opera_android": "mirror",
-              "safari": {
-                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -228,6 +228,47 @@
               "deprecated": false
             }
           }
+        },
+        "height": {
+          "__compat": {
+            "description": "`height-based clamping`",
+            "tags": [
+              "web-features:line-clamp"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "#enable-experimental-web-platform-features",
+                    "value_to_set": "Enabled"
+                  }
+                ]
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       }
     }

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -256,7 +256,7 @@
               "opera": "mirror",
               "opera_android": "mirror",
               "safari": {
-                "version_added": "preview"
+                "version_added": false
               },
               "safari_ios": "mirror",
               "samsunginternet_android": "mirror",

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -110,7 +110,7 @@
             },
             "status": {
               "experimental": true,
-              "standard_track": true,
+              "standard_track": false,
               "deprecated": false
             }
           }

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -117,7 +117,7 @@
         },
         "height": {
           "__compat": {
-            "description": "`height-based clamping`",
+            "description": "Content clamped by the height of a container",
             "tags": [
               "web-features:line-clamp"
             ],

--- a/css/properties/line-clamp.json
+++ b/css/properties/line-clamp.json
@@ -115,7 +115,7 @@
             }
           }
         },
-        "height": {
+        "height-based_clamping": {
           "__compat": {
             "description": "Content clamped by the height of a container",
             "tags": [


### PR DESCRIPTION
#### Summary

- Added support for `line-clamp` property for height-based clamping

#### Test results and supporting details

- Tested with [this pen](https://codepen.io/editor/CodeRedDigital/pen/01a066eb-b512-75dd-a6ce-9b8fdfdcc67b) in the following browsers:
  - Firefox Nightly 157 (with flag `layout.css.line-clamp.enabled`) - fails
  - Chrome Canary 155.0.8040.0 (with Experimental Web Platform features enabled) - works
  - Safari Tech Preview 251 - fails
- More information in this [CSSWG Issue](https://github.com/w3c/csswg-drafts/issues/13670#issuecomment-5430505904)

#### Related issues

- [Content PR](https://github.com/mdn/content/pull/45007)
- [Previous BCD PR](https://github.com/mdn/browser-compat-data/pull/30166)
- [Firefox Release PR](https://github.com/mdn/content/pull/45008)
