### PR TITLE
`css.properties.position-anchor.auto`: clean up Chrome partial

### DIFF
--- a/css/properties/position-anchor.json
+++ b/css/properties/position-anchor.json
@@ -79,11 +79,17 @@
               "web-features:anchor-positioning"
             ],
             "support": {
-              "chrome": {
-                "version_added": "125",
-                "partial_implementation": true,
-                "notes": "The generic `auto` value exists, but it does not yet have the effect described in the spec."
-              },
+              "chrome": [
+                {
+                  "version_added": "127"
+                },
+                {
+                  "version_added": "125",
+                  "version_removed": "127",
+                  "partial_implementation": true,
+                  "notes": "The generic `auto` value exists, but it does not yet have the effect described in the spec."
+                }
+              ],
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Close out the partial in `css.properties.position-anchor.auto` on Chrome.

#### Test results and supporting details

The original PR and note never explained what the precise deviation from spec was and did not link to a Chrome issue, so I don't know what exactly was improper there.

Instead, I ran https://wpt.live/css/css-anchor-position/position-anchor-basics.html and it started passing the test consistently from Chrome 127, not long after the original PR.

See also: https://wpt.fyi/results/css/css-anchor-position/position-anchor-basics.html?label=experimental&label=master&aligned where other tests started passing around the same time.

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

- Previously: https://github.com/mdn/browser-compat-data/pull/23254
- Incited by: https://github.com/web-platform-dx/web-features/issues/3558

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
