### PR TITLE
Update html.global_attr.autocorrect: Chrome 152 -> 153

### DIFF
--- a/html/global_attributes.json
+++ b/html/global_attributes.json
@@ -134,7 +134,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "152"
+              "version_added": "153"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
#### Summary

The `autocorrect` attribute shipped in Chrome 153.

#### Test results and supporting details

https://chromiumdash.appspot.com/commits?commit=25a6eb59d05e8188b8328bc4765c1abbf2c14ae0&platform=Android

#### Related issues

Disovered by @ddbeck in https://github.com/web-platform-dx/web-features/pull/4314#discussion_r3925913799