### PR TITLE
Add `import defer` JavaScript proposal

### DIFF
--- a/javascript/statements.json
+++ b/javascript/statements.json
@@ -1543,6 +1543,38 @@
             }
           }
         },
+        "defer": {
+          "__compat": {
+            "description": "`import defer`",
+            "spec_url": "https://tc39.es/proposal-defer-import-eval/#sec-left-hand-side-expressions",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "import_assertions": {
           "__compat": {
             "description": "Import attributes with `assert` syntax (formerly import assertions)",


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Add the `import defer` JavaScript statement also known as "deferred imports evaluation."

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

The Safari TP 251 release notes [mentions this feature](https://webkit.org/blog/18194/release-notes-for-safari-technology-preview-251/#:~:text=Added%20support%20for%20deferred%20module%20evaluation%20with). Also, https://github.com/WebKit/WebKit/pull/64053.

See also: https://github.com/tc39/proposal-defer-import-eval/

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Incited by: https://github.com/web-platform-dx/web-features/issues/3947

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
