### PR TITLE
Updates for Chrome 154 beta

### DIFF
--- a/api/FencedFrameConfig.json
+++ b/api/FencedFrameConfig.json
@@ -43,7 +43,8 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "126"
+              "version_added": "126",
+              "version_removed": "154"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/api/Window.json
+++ b/api/Window.json
@@ -5105,13 +5105,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "149",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
+              "version_added": "154"
             },
             "chrome_android": "mirror",
             "edge": "mirror",

--- a/css/properties/frame-sizing.json
+++ b/css/properties/frame-sizing.json
@@ -10,13 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "149",
-              "flags": [
-                {
-                  "type": "preference",
-                  "name": "#enable-experimental-web-platform-features"
-                }
-              ]
+              "version_added": "154"
             },
             "chrome_android": "mirror",
             "edge": "mirror",
@@ -49,13 +43,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "149",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "154"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -89,13 +77,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "149",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "154"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -129,13 +111,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "149",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "154"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -169,13 +145,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "149",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "154"
               },
               "chrome_android": "mirror",
               "edge": "mirror",
@@ -209,13 +179,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": "149",
-                "flags": [
-                  {
-                    "type": "preference",
-                    "name": "#enable-experimental-web-platform-features"
-                  }
-                ]
+                "version_added": "154"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/html/elements/meta.json
+++ b/html/elements/meta.json
@@ -504,13 +504,7 @@
               ],
               "support": {
                 "chrome": {
-                  "version_added": "149",
-                  "flags": [
-                    {
-                      "type": "preference",
-                      "name": "#enable-experimental-web-platform-features"
-                    }
-                  ]
+                  "version_added": "154"
                 },
                 "chrome_android": "mirror",
                 "edge": "mirror",

--- a/javascript/builtins/Iterator.json
+++ b/javascript/builtins/Iterator.json
@@ -530,7 +530,7 @@
                 "version_added": "1.4.0"
               },
               "chrome": {
-                "version_added": false
+                "version_added": "154"
               },
               "chrome_android": "mirror",
               "deno": {
@@ -556,7 +556,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
The https://collector.openwebdocs.org/ project (v10.20.10) found new features shipping in Chromium 154 beta which was released this week. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive. Also, if a feature is in Canary/behind flags, it is not considered here. If a feature is missing, one reason can be that the IDL is not yet in a specification or in webref.

Chrome 154 stable releases on September 22, 2026. This PR needs to be merged before/with the BCD release on September 17, 2026.

With this PR, BCD will consider the following features as shipping in Chromium 154:

FencedFrame Shared Storage removal ([ref](https://chromiumdash.appspot.com/commits?commit=14292f3a61221a3e8cf54dd70286e4c9c68f3cde))
- api.FencedFrameConfig.setSharedStorageContext (removal) 

Frame sizing [(ref)](https://chromestatus.com/feature/5108373464547328)
- api.Window.requestResize
- css.properties.frame-sizing
- css.properties.frame-sizing.auto
- css.properties.frame-sizing.content-block-size
- css.properties.frame-sizing.content-height
- css.properties.frame-sizing.content-inline-size
- css.properties.frame-sizing.content-width
- html.elements.meta.name.responsive-embedded-sizing

Iterator includes ([ref](https://chromestatus.com/feature/5205192866922496))
- javascript.builtins.Iterator.includes

See also https://developer.chrome.com/blog/chrome-154-beta and https://chromestatus.com/roadmap