### PR TITLE
Updates for Chrome Canary, 04 Sept 2026

### DIFF
--- a/css/properties/list-style-type.json
+++ b/css/properties/list-style-type.json
@@ -3107,7 +3107,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/list-style.json
+++ b/css/properties/list-style.json
@@ -165,7 +165,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false
+                "version_added": "preview"
               },
               "chrome_android": "mirror",
               "edge": "mirror",

--- a/css/properties/margin-trim.json
+++ b/css/properties/margin-trim.json
@@ -10,7 +10,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": false,
+              "version_added": "preview",
               "impl_url": "https://crbug.com/40886857"
             },
             "chrome_android": "mirror",
@@ -45,7 +45,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
@@ -81,7 +81,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
@@ -117,7 +117,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",
@@ -252,7 +252,7 @@
             ],
             "support": {
               "chrome": {
-                "version_added": false,
+                "version_added": "preview",
                 "impl_url": "https://crbug.com/40886857"
               },
               "chrome_android": "mirror",


### PR DESCRIPTION
Updates from a Collector run (v10.20.10) in today's Chrome Canary (04 Sept. 2026).

CSS symbols() https://chromestatus.com/feature/5146996093616128
- css.properties.list-style-type.symbols
- css.properties.list-style.symbols

CSS margin-trim, https://chromestatus.com/feature/5197863732772864

- css.properties.margin-trim
- css.properties.margin-trim.block
- css.properties.margin-trim.block-end
- css.properties.margin-trim.block-start
- css.properties.margin-trim.none