### PR TITLE
More updates for Safari TP 251

### DIFF
--- a/css/properties/white-space.json
+++ b/css/properties/white-space.json
@@ -114,6 +114,138 @@
             }
           }
         },
+        "discard-after": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-trim-discard-after",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "discard-before": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-trim-discard-before",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "discard-inner": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#valdef-white-space-trim-discard-inner",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-4/#propdef-white-space-trim",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": {
+                "version_added": false
+              },
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "normal": {
           "__compat": {
             "spec_url": "https://drafts.csswg.org/css-text/#valdef-white-space-normal",


### PR DESCRIPTION
Followup to https://github.com/mdn/browser-compat-data/pull/30347 (either forgotten in the previous run, or the values weren't available in the Collector/webref back then).

See https://webkit.org/blog/18194/release-notes-for-safari-technology-preview-251/#:~:text=Added%20support%20for%20white%2Dspace%2Dtrim%20in%20the%20white%2Dspace%20shorthand.%20(318486@main)%20(182739052)

https://github.com/WebKit/WebKit/commit/dd490d605c8f089877ac86a95aa348387e514892