### PR TITLE
Add Samsung Browser 30

### DIFF
--- a/browsers/samsunginternet_android.json
+++ b/browsers/samsunginternet_android.json
@@ -309,9 +309,15 @@
         },
         "29.0": {
           "release_date": "2025-10-25",
-          "status": "current",
+          "status": "retired",
           "engine": "Blink",
           "engine_version": "136"
+        },
+        "30.0": {
+          "release_date": "2026-05-11",
+          "status": "current",
+          "engine": "Blink",
+          "engine_version": "143"
         }
       }
     }


### PR DESCRIPTION
#### Summary

Samsung Browser 30 is released.  Still no release notes are being published for this on https://developer.samsung.com/internet/release-note/android-release-note.html. They have a date for the latest PC release on https://developer.samsung.com/internet/release-note/windows-release-note.html, but that is not a guarantee that the same date had the Android release, and it only shows the latest release date.

#### Test results and supporting details

Earliest release date from https://www.apkmirror.com/apk/samsung-electronics-co-ltd/samsung-internet-for-android/samsung-internet-browser-30-0-2-30-release/. It's installed on my Android and https://chromiumchecker.com says 143 (and Samsung Internet for Windows 30.0.0.48 says Web engine upgrade (M143) on https://developer.samsung.com/internet/release-note/windows-release-note.html).

#### Related issues

None