### PR TITLE
Add missing CSS flexbox property values

### DIFF
--- a/css/properties/align-content.json
+++ b/css/properties/align-content.json
@@ -178,6 +178,76 @@
               }
             }
           },
+          "center": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-align/#valdef-self-position-center",
+              "support": {
+                "chrome": {
+                  "version_added": "21"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "28"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": "11"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "end": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-align/#valdef-self-position-end",
+              "support": {
+                "chrome": {
+                  "version_added": "93"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "45"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": {
+                  "version_added": "79",
+                  "notes": "Before version 79, this value is recognized, but has no effect."
+                },
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "15.6"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
           "first_baseline": {
             "__compat": {
               "description": "`first baseline`",
@@ -200,6 +270,78 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "11"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "flex-end": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-flexbox/#valdef-align-content-flex-end",
+              "support": {
+                "chrome": {
+                  "version_added": "21"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "28"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": "11"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "9"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "flex-start": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-flexbox/#valdef-align-content-flex-start",
+              "support": {
+                "chrome": {
+                  "version_added": "21"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "12"
+                },
+                "firefox": {
+                  "version_added": "28"
+                },
+                "firefox_android": "mirror",
+                "ie": {
+                  "version_added": "11"
+                },
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "9"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -259,13 +401,9 @@
               }
             }
           },
-          "safe_unsafe": {
+          "safe": {
             "__compat": {
-              "description": "`safe` and `unsafe`",
-              "spec_url": [
-                "https://drafts.csswg.org/css-align-3/#valdef-overflow-position-safe",
-                "https://drafts.csswg.org/css-align-3/#valdef-overflow-position-unsafe"
-              ],
+              "spec_url": "https://drafts.csswg.org/css-align-3/#valdef-overflow-position-safe",
               "tags": [
                 "web-features:flexbox"
               ],
@@ -285,6 +423,68 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "17.6"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "space-around": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-align/#valdef-align-content-space-around",
+              "support": {
+                "chrome": {
+                  "version_added": "60"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "11"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "space-between": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-align/#valdef-align-content-space-between",
+              "support": {
+                "chrome": {
+                  "version_added": "60"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "52"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "11"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",
@@ -332,16 +532,9 @@
               }
             }
           },
-          "start_end": {
+          "start": {
             "__compat": {
-              "description": "`start` and `end`",
-              "spec_url": [
-                "https://drafts.csswg.org/css-align-3/#valdef-self-position-start",
-                "https://drafts.csswg.org/css-align-3/#valdef-self-position-end"
-              ],
-              "tags": [
-                "web-features:flexbox"
-              ],
+              "spec_url": "https://drafts.csswg.org/css-align-3/#valdef-self-position-start",
               "support": {
                 "chrome": {
                   "version_added": "93"
@@ -357,10 +550,7 @@
                   "version_added": "79",
                   "notes": "Before version 79, this value is recognized, but has no effect."
                 },
-                "opera_android": {
-                  "version_added": false,
-                  "notes": "This value is recognized, but has no effect."
-                },
+                "opera_android": "mirror",
                 "safari": {
                   "version_added": "15.6"
                 },
@@ -397,6 +587,41 @@
                 "opera_android": "mirror",
                 "safari": {
                   "version_added": "9"
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": false,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "unsafe": {
+            "__compat": {
+              "spec_url": "https://drafts.csswg.org/css-align-3/#valdef-overflow-position-unsafe",
+              "tags": [
+                "web-features:flexbox"
+              ],
+              "support": {
+                "chrome": {
+                  "version_added": "115",
+                  "notes": "Before version 115, this value is recognized, but has no effect."
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "63"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": "17.6"
                 },
                 "safari_ios": "mirror",
                 "samsunginternet_android": "mirror",


### PR DESCRIPTION
Towards https://github.com/mdn/browser-compat-data/issues/30410

According to the Collector, support goes a long way back. I assume these values have been introduced with the initial Flexbox implementation which would make sense given BCD originally didn't have initial CSS values as sub features. They were mass-added by Vinyl in 2025. 

Also, these Flexbox sub-features probably weren't added back then because the structure is not simple: There is nesting going on here where values sit below `flex_context` and `grid_context`. You can also see  this in the compat table on MDN: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/align-content#browser_compatibility

I think we want the following structure, but it would be good to confirm it before I proceed with other CSS properties. Is it correct to put all these values under flex_context?

- css.properties.align-content:
  - block_context
  - flex_context
    - `baseline`
    - `center`
    - `end` (new from split)
    - `first baseline`
    - `flex-end` (new)
    - `flex-start` (new)
    - `last baseline`
    - `safe` (new from split)
    - `space-around` (new)
    - `space-between` (new)
    - `space-evenly`
    - `start` (new from split)
    - `stretch`
    - `unsafe` (new from split)
  - grid_context
  - multicol_context
  - `normal`

Alternatively, I guess, we could flatten this all out, leading to a few moves plus adding the missing values. That would mean less work for me on the Collector side, as I still have to teach the Collector that these values can be found in subtrees (flex_context in this case, grid_context in other cases).

What do we think?