### PR TITLE
FF155 GPUSupportedFeatures - feature_dual-source-blending

### DIFF
--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -426,9 +426,11 @@
             },
             "edge": "mirror",
             "firefox": {
+              "version_added": "155"
+            },
+            "firefox_android": {
               "version_added": false
             },
-            "firefox_android": "mirror",
             "oculus": "mirror",
             "opera": "mirror",
             "opera_android": "mirror",

--- a/api/GPUSupportedFeatures.json
+++ b/api/GPUSupportedFeatures.json
@@ -443,7 +443,7 @@
             "webview_ios": "mirror"
           },
           "status": {
-            "experimental": true,
+            "experimental": false,
             "standard_track": true,
             "deprecated": false
           }


### PR DESCRIPTION
FF155 supports the [dual-source blending](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedFeatures#available_features) feature in https://bugzilla.mozilla.org/show_bug.cgi?id=1924328

I added the feature itself in #30257 but I missed the "feature detection reporting" feature in GPUSupportedFeatures. This adds it.

Related docs work can be tracked in https://github.com/mdn/content/issues/45176