### PR TITLE
Firefox 155 preview support for @supports at-rule()

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -60,8 +60,8 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false,
-                "impl_url": "https://bugzil.la/1751188"
+                "version_added": "preview",
+                "impl_url": "https://bugzil.la/2060754"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 155 adds support for the `@supports` [`at-rule()`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@supports#at-rule) function, currently only enabled by default in Nightly. In other versions, it is behind the `layout.css.supports.at-rule.enabled` pref. See https://bugzilla.mozilla.org/show_bug.cgi?id=2060754.

This PR updates the support data for `at-rule()` to "preview", and updates the `impl_url` to point to https://bugzilla.mozilla.org/show_bug.cgi?id=2060754. Does that make sense?

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
