### PR TITLE
Bug 2067229 alarms.clearAll returns undefined note

### DIFF
--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -82,7 +82,7 @@
               "edge": "mirror",
               "firefox": {
                 "version_added": "45",
-                "notes": "From Firefox 157, returns undefined rather than boolean."
+                "notes": "Until Firefox 156, returned a boolean rather than undefined."
               },
               "firefox_android": {
                 "version_added": "48"

--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -77,7 +77,8 @@
             "mdn_url": "https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/alarms/clearAll",
             "support": {
               "chrome": {
-                "version_added": "22"
+                "version_added": "22",
+                "notes": "Returns a boolean rather than undefined. See [w3c/webextensions#1055](https://github.com/w3c/webextensions/issues/1055) for details."
               },
               "edge": "mirror",
               "firefox": {
@@ -85,14 +86,17 @@
                 "notes": "Until Firefox 156, returned a boolean rather than undefined."
               },
               "firefox_android": {
-                "version_added": "48"
+                "version_added": "48",
+                "notes": "Until Firefox 156, returned a boolean rather than undefined."
               },
               "opera": "mirror",
               "safari": {
-                "version_added": "14"
+                "version_added": "14",
+                "notes": "Returns undefined."
               },
               "safari_ios": {
-                "version_added": "15"
+                "version_added": "15",
+                "notes": "Returns undefined."
               }
             }
           }

--- a/webextensions/api/alarms.json
+++ b/webextensions/api/alarms.json
@@ -81,7 +81,8 @@
               },
               "edge": "mirror",
               "firefox": {
-                "version_added": "45"
+                "version_added": "45",
+                "notes": "From Firefox 157, returns undefined rather than boolean."
               },
               "firefox_android": {
                 "version_added": "48"


### PR DESCRIPTION
#### Summary

Addresses the dev-docs-needed requirements of [Bug 2067229](https://bugzilla.mozilla.org/show_bug.cgi?id=2067229) "alarms.clearAll should return undefined instead of a boolean" with a note about how the promise is fulfilled from Firefox 157.

#### Related issues

Content changes in https://github.com/mdn/content/pull/45554
