### PR TITLE
PerformanceContainerTiming.toJSON() redefined

### DIFF
--- a/api/PerformanceContainerTiming.json
+++ b/api/PerformanceContainerTiming.json
@@ -425,6 +425,50 @@
             "deprecated": false
           }
         }
+      },
+      "toJSON": {
+        "__compat": {
+          "support": {
+            "chrome": {
+              "version_added": "145",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "#enable-experimental-web-platform-features",
+                  "value_to_set": "Enabled"
+                }
+              ]
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": "156",
+              "flags": [
+                {
+                  "type": "preference",
+                  "name": "dom.enable_container_timing",
+                  "value_to_set": "true"
+                }
+              ]
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": false,
+            "deprecated": false
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
FF156 adds support for `PerformanceContainerTiming` behind a pref. Most features were updated already, but omits `toJSON()` which has been defined on the object too.

This is not in the spec, but testing shows it is has been redefined on the object in FF (in devtools) and in the Chromium source code. This is non-standard because the redefinition is not indicated by the spec IDL. Claude tells me this is likely a spec ommission.
As such I have marked this as non-standard.

Note that the errors on the tagging predate my change.


Related docs work can be tracked in https://github.com/mdn/content/issues/45428