### PR TITLE
Update data for MathML <a> element and MathMLAnchorElement

### DIFF
--- a/api/MathMLAnchorElement.json
+++ b/api/MathMLAnchorElement.json
@@ -10,7 +10,8 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview"
+            "version_added": "preview",
+            "impl_url": "https://bugzil.la/2059312"
           },
           "firefox_android": {
             "version_added": false
@@ -42,7 +43,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -75,7 +77,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -108,7 +111,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -141,7 +145,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -174,7 +179,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -207,7 +213,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -240,7 +247,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -273,7 +281,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -306,7 +315,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -339,7 +349,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -372,7 +383,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -405,7 +417,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false
@@ -441,7 +454,8 @@
               "version_added": "preview"
             },
             "firefox_android": {
-              "version_added": false
+              "version_added": false,
+              "impl_url": "https://bugzil.la/2059312"
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -471,7 +485,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview"
+              "version_added": "preview",
+              "impl_url": "https://bugzil.la/2059312"
             },
             "firefox_android": {
               "version_added": false

--- a/api/MathMLAnchorElement.json
+++ b/api/MathMLAnchorElement.json
@@ -10,8 +10,7 @@
           "chrome_android": "mirror",
           "edge": "mirror",
           "firefox": {
-            "version_added": "preview",
-            "impl_url": "https://bugzil.la/2059312"
+            "version_added": "preview"
           },
           "firefox_android": {
             "version_added": false
@@ -43,8 +42,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -77,8 +75,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -111,8 +108,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -145,8 +141,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -179,8 +174,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -213,8 +207,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -247,8 +240,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -281,8 +273,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -315,8 +306,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -349,8 +339,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -383,8 +372,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -417,8 +405,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false
@@ -454,8 +441,7 @@
               "version_added": "preview"
             },
             "firefox_android": {
-              "version_added": false,
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": false
             },
             "oculus": "mirror",
             "opera": "mirror",
@@ -485,8 +471,7 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "preview",
-              "impl_url": "https://bugzil.la/2059312"
+              "version_added": "preview"
             },
             "firefox_android": {
               "version_added": false

--- a/mathml/elements/a.json
+++ b/mathml/elements/a.json
@@ -14,7 +14,8 @@
             "chrome_android": "mirror",
             "edge": "mirror",
             "firefox": {
-              "version_added": "152"
+              "version_added": "152",
+              "notes": "DOM interface is the generic `MathMLElement` rather than `MathMLAnchorElement`."
             },
             "firefox_android": "mirror",
             "oculus": "mirror",
@@ -37,6 +38,108 @@
         "href": {
           "__compat": {
             "spec_url": "https://w3c.github.io/mathml-core/#dfn-href",
+            "tags": [
+              "web-features:mathml"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "152"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "hreflang": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#dfn-hreflang",
+            "tags": [
+              "web-features:mathml"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "152"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "target": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#dfn-target",
+            "tags": [
+              "web-features:mathml"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "152"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "type": {
+          "__compat": {
+            "spec_url": "https://w3c.github.io/mathml-core/#dfn-type",
             "tags": [
               "web-features:mathml"
             ],


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 155 adds support for the MathML [`<a>` element's](https://w3c.github.io/mathml-core/#the-a-element) DOM interface, [`MathMLAnchorElement`](https://w3c.github.io/mathml-core/#dom-mathmlanchorelement). It is currently enabled in Nightly only (the pref is `mathml.a.element.enabled`). See https://bugzilla.mozilla.org/show_bug.cgi?id=2059312.

This PR:

- Adds subentries for the MathML `<a>` element attributes that were missing. Note that this doesn't include `download`, `ping`, `rel`, and `referrerpolicy` — they are being implemented in a separate bug (https://bugzilla.mozilla.org/show_bug.cgi?id=2064612).
- Adds a note to the `<a>` element saying that its DOM interface is currently the `MathMLElement` interface, not `MathMLAnchorElement`. This will be the case until `MathMLAnchorElement` is enabled by default.
- Updates the `MathMLAnchorElement` data to include the `impl_url` for all features. This is still listed as supported in `preview` only.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
