### PR TITLE
build(npm): make the manifest forward-compatible with npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,5 +123,9 @@
     "bcd": "node scripts/bulk-editor/index.js",
     "split": "node scripts/split.js",
     "tag-web-features": "node scripts/tag-web-features.js"
+  },
+  "allowScripts": {
+    "lefthook": true,
+    "unrs-resolver": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "types": "./build/require.d.ts",
   "packageManager": "npm@11.12.1",
   "engines": {
-    "node": ">=24",
-    "npm": "^11"
+    "node": ">=24"
   },
   "devEngines": {
     "packageManager": {


### PR DESCRIPTION
#### Summary

Add an `allowScripts` allowlist for `lefthook` and `unrs-resolver`, and drop the `engines.npm: "^11"` constraint.

#### Test results and supporting details

- npm 12 no longer runs dependency install scripts unless the root `package.json` allowlists them. `lefthook`'s `postinstall` registers the git hooks, so without the entry contributors silently lose them.
- Combined with `engine-strict=true` in `.npmrc`, `engines.npm: "^11"` makes any install here fail outright with `EBADENGINE` under npm 12. `devEngines.packageManager` (`npm >=11.8.0`) already states what local development expects, and it accepts npm 12.
- Downstream consumers were never affected: the published package is built from a generated `build/package.json` carrying only `name` and `version`.
- Entries are name-only (`--no-allow-scripts-pin`), so Dependabot bumps need no re-approval commits, at the cost of trusting future versions of the listed packages.
- Verified: `npm ci --strict-allow-scripts` passes on npm 12.0.2.

#### Related issues

Part of mdn/fred#1868.
