### PR TITLE
ci(pr-review): drop `--comments` from `gh pr view --json comments`

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -69,7 +69,7 @@ jobs:
 
           ${COMMENT}"
 
-          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --comments --json comments \
+          COMMENT_ID=$(gh pr view "$PR_NUMBER" --repo "${{ github.repository }}" --json comments \
             --jq ".comments | sort_by(.createdAt) | map(select(.author.login == \"$AUTHOR\" and (.body | contains(\"$MARKER\")))) | .[0].id")
           if [ -n "$COMMENT_ID" ]; then
             gh api graphql -f query='


### PR DESCRIPTION
#### Summary

Drop the redundant `--comments` flag from the `gh pr view ... --json comments` call in the "Comment in PR" step of the PR review companion workflow. GitHub CLI 2.99.0 (now on the ubuntu-24.04 runner image) rejects combining `--comments` with `--json`:

```
specify only one of --comments or --json
```

#### Test results and supporting details

`--json comments` already returns the comments, so the `--comments` flag was a no-op on older `gh` versions. See cli/cli#14215.

#### Related issues

Part of mdn/fred#1873.

<!-- ✅ After submitting, review the results of the "Checks" tab! -->