### PR TITLE
Add options parameter to SVGGraphicsElement.getBBox()

### DIFF
--- a/api/SVGGraphicsElement.json
+++ b/api/SVGGraphicsElement.json
@@ -155,6 +155,39 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "options_parameter": {
+          "__compat": {
+            "description": "`options` parameter",
+            "spec_url": "https://w3c.github.io/svgwg/svg2-draft/types.html#SVGBoundingBoxOptions",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": "155"
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false,
+                "impl_url": "https://webkit.org/b/227107"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "getCTM": {


### PR DESCRIPTION
#### Summary

Adds the `options` parameter of `getBBox()` in Firefox 155

#### Test results and supporting details

- Bugzilla: https://bugzilla.mozilla.org/show_bug.cgi?id=2060873
- Chrome 152 returns the same box whatever the options
- WebKit bug: https://webkit.org/b/227107

#### Related issues

- https://github.com/mdn/content/issues/45193