### PR TITLE
added support for specific named-features

### DIFF
--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -163,7 +163,15 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "preview",
+                "flags": [
+                  {
+                    "type": "preference",
+                    "name": "layout.css.anchor-positioning.follows-transforms.enabled",
+                    "value_to_set": "true"
+                  }
+                ],
+                "impl_url": "https://bugzil.la/2042977"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -181,6 +189,80 @@
               "experimental": true,
               "standard_track": true,
               "deprecated": false
+            }
+          },
+          "anchor-position-follows-transforms": {
+            "__compat": {
+              "description": "`named-feature(anchor-position-follows-transforms)`",
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#anchor-position-follows-transforms",
+              "support": {
+                "chrome": {
+                  "version_added": "150"
+                },
+                "chrome_android": "mirror",
+                "edge": "mirror",
+                "firefox": {
+                  "version_added": "preview",
+                  "flags": [
+                    {
+                      "type": "preference",
+                      "name": "layout.css.anchor-positioning.follows-transforms.enabled",
+                      "value_to_set": "true"
+                    }
+                  ],
+                  "impl_url": "https://bugzil.la/2055354"
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
+            }
+          },
+          "single-axis-scroll-container": {
+            "__compat": {
+              "description": "`named-feature(single-axis-scroll-container)`",
+              "spec_url": "https://drafts.csswg.org/css-conditional-5/#single-axis-scroll-container",
+              "support": {
+                "chrome": {
+                  "version_added": "152"
+                },
+                "chrome_android": "mirror",
+                "edge": {
+                  "version_added": "preview"
+                },
+                "firefox": {
+                  "version_added": false
+                },
+                "firefox_android": "mirror",
+                "oculus": "mirror",
+                "opera": "mirror",
+                "opera_android": "mirror",
+                "safari": {
+                  "version_added": false
+                },
+                "safari_ios": "mirror",
+                "samsunginternet_android": "mirror",
+                "webview_android": "mirror",
+                "webview_ios": "mirror"
+              },
+              "status": {
+                "experimental": true,
+                "standard_track": true,
+                "deprecated": false
+              }
             }
           }
         },

--- a/css/at-rules/supports.json
+++ b/css/at-rules/supports.json
@@ -241,7 +241,7 @@
                 },
                 "chrome_android": "mirror",
                 "edge": {
-                  "version_added": "preview"
+                  "version_added": "155"
                 },
                 "firefox": {
                   "version_added": false


### PR DESCRIPTION
#### Summary

- Added firefox support for `@supports named-features()`
- Added `@supports named-features(anchor-position-follows-transforms)`
- Added `@supports named-features(single-axis-scroll-container)`

#### Test results and supporting details

- Tested using this [codepen](https://codepen.io/editor/CodeRedDigital/pen/01a08168-9989-7174-8e4e-d3ab07faed6f)
- Chrome versions:
  - 150 - only `anchor-position-follows-transforms`
  - 152 - both work
  - Beta
  - Canary
- Edge versions:
  - 150 - only `anchor-position-follows-transforms`
  - 152 - only `anchor-position-follows-transforms`
  - Beta - only `anchor-position-follows-transforms`
  - Canary 155 - both work
- Safari versions - no support
  - 26.1
  - Tech Preview 251
- Firefox (with flag `layout.css.anchor-positioning.follows-transforms.enabled`)
  - Nightly - only `anchor-position-follows-transforms`
  - Beta - no suppport

#### Related issues

- [Content PR](https://github.com/mdn/content/pull/45593)
- [Firefox Release PR](https://github.com/mdn/content/pull/45357)