### PR TITLE
Add `IntersectionObserver` `trackVisibility` option

### DIFF
--- a/api/IntersectionObserver.json
+++ b/api/IntersectionObserver.json
@@ -110,6 +110,41 @@
               "deprecated": false
             }
           }
+        },
+        "options_trackVisibility_parameter": {
+          "__compat": {
+            "description": "`options.trackVisibility` parameter",
+            "spec_url": "https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility",
+            "tags": [
+              "web-features:intersection-observer"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "74"
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "delay": {


### PR DESCRIPTION
Adds compatibility data for the `options.trackVisibility` parameter of the `IntersectionObserver()` constructor.

This completes the remaining missing BCD entry from #22862.

Fixes #22862 