### PR TITLE
Firefox 156 supports RTCPeerConnection() alwaysNegotiateDataChannels …

### DIFF
--- a/api/RTCPeerConnection.json
+++ b/api/RTCPeerConnection.json
@@ -140,7 +140,7 @@
               "chrome_android": "mirror",
               "edge": "mirror",
               "firefox": {
-                "version_added": false
+                "version_added": "156"
               },
               "firefox_android": "mirror",
               "oculus": "mirror",
@@ -155,7 +155,7 @@
               "webview_ios": "mirror"
             },
             "status": {
-              "experimental": true,
+              "experimental": false,
               "standard_track": true,
               "deprecated": false
             }


### PR DESCRIPTION
…constructor option

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Firefox 156 now supports the `RTCPeerConnection()` constructor's `alwaysNegotiateDataChannels` option. See https://bugzilla.mozilla.org/show_bug.cgi?id=2062561.

This PR updates the data for this option to show support in Fx 156.

You can test this using the following sample: https://webrtc.github.io/samples/src/content/peerconnection/always-negotiate-datachannels/. It works in Firefox beta 156 without requiring any flags to be set.

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
