### PR TITLE
Document Chrome bfcache support for websockets and unload

### DIFF
--- a/api/NotRestoredReasonDetails.json
+++ b/api/NotRestoredReasonDetails.json
@@ -67,6 +67,79 @@
             "standard_track": true,
             "deprecated": false
           }
+        },
+        "unload-listener": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reason-details-reason",
+            "tags": [
+              "web-features:bfcache-blocking-reasons"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125",
+                "notes": "From version 135, Chrome started deprecating the unload handler completing this in Chrome 154."
+              },
+              "chrome_android": {
+                "version_added": "125",
+                "notes": "Unload was never a bocking reason on mobile."
+              },
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "websocket": {
+          "__compat": {
+            "spec_url": "https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reason-details-reason",
+            "tags": [
+              "web-features:bfcache-blocking-reasons"
+            ],
+            "support": {
+              "chrome": {
+                "version_added": "125",
+                "notes": "From version 149, pages with active WebSockets can enter the bfcache; the WebSocket connections are disconnected upon entry."
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
         }
       },
       "toJSON": {

--- a/api/PerformanceNavigationTiming.json
+++ b/api/PerformanceNavigationTiming.json
@@ -409,8 +409,7 @@
           ],
           "support": {
             "chrome": {
-              "version_added": "125",
-              "notes": "From version 149, pages with active WebSockets can enter the bfcache; the WebSocket connections are disconnected upon entry."
+              "version_added": "125"
             },
             "chrome_android": "mirror",
             "edge": "mirror",


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

A follow on from #30179. See discussion with @chrisdavidmills there.

I've avoided listing ALL the specced bfcache reasons as [there are a lot of them](https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-not-restored-reason-details-reason) (especially when you include the user-agent specific blocking reasons in the second list). Instead I've just detailed the ones were browser support differs from the overall `NotRestoredReasons` parent, but I'm up for discussion on this one.

We could document them all (but it's a BIG list!).
Or document the 6 non-browser-specific ones and any (like `unload-listener`) where browser support differs.

But both of those may be more confusing.

WDYT?

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

websocket - https://chromestatus.com/feature/5068439115923456.

unload:
- https://chromestatus.com/feature/5579556305502208
- https://developer.chrome.com/docs/web-platform/deprecating-unload
- https://developer.chrome.com/docs/web-platform/page-lifecycle-api#the_unload_event

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#30179

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
