### PR TITLE
Updates for Chrome Canary, 11 Sept. 2026

### DIFF
--- a/css/properties/text-decoration-skip-spaces.json
+++ b/css/properties/text-decoration-skip-spaces.json
@@ -1,0 +1,181 @@
+{
+  "css": {
+    "properties": {
+      "text-decoration-skip-spaces": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-text-decor-4/#propdef-text-decoration-skip-spaces",
+          "support": {
+            "chrome": {
+              "version_added": "preview"
+            },
+            "chrome_android": {
+              "version_added": false
+            },
+            "edge": {
+              "version_added": false
+            },
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": false
+            },
+            "safari_ios": "mirror",
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        },
+        "all": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-skip-spaces-all",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "end": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-skip-spaces-end",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "none": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-skip-spaces-none",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "start": {
+          "__compat": {
+            "spec_url": "https://drafts.csswg.org/css-text-decor-4/#valdef-text-decoration-skip-spaces-start",
+            "support": {
+              "chrome": {
+                "version_added": "preview"
+              },
+              "chrome_android": {
+                "version_added": false
+              },
+              "edge": {
+                "version_added": false
+              },
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": false
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror",
+              "webview_ios": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### Summary

Updates from a Collector run (v10.20.10) in today's Chrome Canary (11 Sept. 2026).

New keys:

- css.properties.text-decoration-skip-spaces
- css.properties.text-decoration-skip-spaces.all
- css.properties.text-decoration-skip-spaces.end
- css.properties.text-decoration-skip-spaces.none
- css.properties.text-decoration-skip-spaces.start

#### Test results and supporting details

https://chromestatus.com/feature/4832783806627840

#### Related issues

None.