### PR TITLE
Update partial implementation note for Firefox’s ::-webkit-scrollbar

### DIFF
--- a/css/selectors/-webkit-scrollbar.json
+++ b/css/selectors/-webkit-scrollbar.json
@@ -15,7 +15,7 @@
               "version_added": "153",
               "version_removed": "155",
               "partial_implementation": true,
-              "notes": "The `@supports selector(::-webkit-scrollbar)` returns `true` but this pseudo-element cannot be used to style scrollbars. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
+              "notes": "The `@supports selector(::-webkit-scrollbar)` check returns `true`, but only `display: none` (hides the scrollbar) and a non-zero `width` or `height` (turns off overlay scrollbars) have any effect. This behavior prevents nested scrollable content from becoming unreachable (see [bug 1977511](https://bugzil.la/1977511))"
             },
             "firefox_android": "mirror",
             "oculus": "mirror",


### PR DESCRIPTION
#### Summary

The note says the pseudo-element can’t be used to style scrollbars, but `display: none` hides the scrollbar, and a non-zero `width` or `height` turns off overlay scrollbars. Which counts as styling, if you ask me.

Same thing as the `safari_ios` note right below it.

#### Test results and supporting details

- Tested in Firefox Nightly 157.0a1 (on a domain from the list)
- `display: none` hides the scrollbar, `width: 30px` leaves it 15px wide
- Colors, `border-radius`, and `-thumb`/`-track`/`-corner`/`-resizer` do nothing

#### Related issues

- https://bugzilla.mozilla.org/show_bug.cgi?id=2038877
- https://github.com/mdn/content/pull/45589