### PR TITLE
Add guideline for handling A/B tests and feature rollouts

### DIFF
--- a/docs/data-guidelines/README.md
+++ b/docs/data-guidelines/README.md
@@ -126,6 +126,18 @@ However, this guideline does not apply to features where the browser's expected 
 
 This guideline was proposed in [#6906](https://github.com/mdn/browser-compat-data/issues/6906).
 
+## Randomized trials imply the support status of least surprise
+
+If a feature's support is subject to randomized selection into experimental and control groups (as in A/B testing), then assume that browser behaviors are stable with respect to their past behavior.
+
+For new features gradually rolled out, update data with the expectation that the browser will _not_ be enrolled into the feature-enabled group until the very last cohort.
+In other words, such features remain `{ "version_added": false }` until the roll out is complete.
+
+For deprecated features being gradually removed, update data with the expectation that the browser will _not_ be enrolled into the feature-removed group until the very last cohort.
+In other words, such features remain `{ "version_added": "…" }` until the removal is complete.
+
+This guideline was proposed in [#30486](https://github.com/mdn/browser-compat-data/pull/30486) and inspired by [#30433](https://github.com/mdn/browser-compat-data/pull/30433).
+
 ## Removal of irrelevant features
 
 Features can be removed from BCD if it is considered irrelevant. A feature can be considered irrelevant if any of these conditions are met:


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

Document our approach to setting `version_added` or `version_removed`, when a feature is subject to a randomized trial (A/B test, phase in, phase out, etc.).

<!-- ✍️ In a sentence or two, describe your changes. -->

#### Test results and supporting details

This was inspired by the discussion Florian and I had on https://github.com/mdn/browser-compat-data/pull/30433. The guideline evolved a little when I had to to put it into our typical style.

Alternatives considered:

- Assume least capability. This makes sense for feature additions, but is probably confusing for feature removals, which tend to have very small percentage removals at first (e.g., where a fraction of a percent lose the feature) and therefore not caught by the Collector or noticed by developers.
- Assume most capability. This is hardest to test for as you have to be aware of and enrolled in all (potentially very low-percentage) feature roll outs but never enrolled in a feature removal.
- Majority rule, where we take the larger of the experimental and control groups. This requires knowing the distribution of the experiment (which may not be public information), assumes predictable and stable experiments (i.e., that experiments aren't dynamically adjusted and never terminate early), and requires a tie breaker.

#### Related issues

- https://github.com/mdn/browser-compat-data/pull/30433

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
