### PR TITLE
Updates for Safari TP 252

### DIFF
--- a/api/CSSMediaRule.json
+++ b/api/CSSMediaRule.json
@@ -46,6 +46,39 @@
           "deprecated": false
         }
       },
+      "matches": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-conditional-3/#dom-cssmediarule-matches",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
+      },
       "media": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/CSSMediaRule/media",

--- a/api/CSSSupportsRule.json
+++ b/api/CSSSupportsRule.json
@@ -45,6 +45,39 @@
           "standard_track": true,
           "deprecated": false
         }
+      },
+      "matches": {
+        "__compat": {
+          "spec_url": "https://drafts.csswg.org/css-conditional-3/#dom-csssupportsrule-matches",
+          "support": {
+            "chrome": {
+              "version_added": false
+            },
+            "chrome_android": "mirror",
+            "edge": "mirror",
+            "firefox": {
+              "version_added": false
+            },
+            "firefox_android": "mirror",
+            "oculus": "mirror",
+            "opera": "mirror",
+            "opera_android": "mirror",
+            "safari": {
+              "version_added": "preview"
+            },
+            "safari_ios": {
+              "version_added": false
+            },
+            "samsunginternet_android": "mirror",
+            "webview_android": "mirror",
+            "webview_ios": "mirror"
+          },
+          "status": {
+            "experimental": true,
+            "standard_track": true,
+            "deprecated": false
+          }
+        }
       }
     }
   }

--- a/api/Request.json
+++ b/api/Request.json
@@ -1281,8 +1281,7 @@
             "opera": "mirror",
             "opera_android": "mirror",
             "safari": {
-              "version_added": false,
-              "impl_url": "https://webkit.org/b/245671"
+              "version_added": "preview"
             },
             "safari_ios": "mirror",
             "samsunginternet_android": "mirror",

--- a/css/properties/user-select.json
+++ b/css/properties/user-select.json
@@ -56,6 +56,9 @@
             "opera_android": "mirror",
             "safari": [
               {
+                "version_added": "preview"
+              },
+              {
                 "prefix": "-webkit-",
                 "version_added": "3"
               },


### PR DESCRIPTION
#### Summary

The https://collector.openwebdocs.org/ project (v10.20.10) found new features shipping in Safari Technical Preview 252 on macOS 27 which was released today. Currently, the collector covers about 90% of BCD, so the following list might not be exhaustive.

- api.CSSMediaRule.matches
- api.CSSSupportsRule.matches
- api.Request.duplex
- css.properties.user-select

Release notes: https://webkit.org/blog/18304/release-notes-for-safari-technology-preview-252/