### PR TITLE
Container timing `toJSON()` is now part of the spec

### DIFF
--- a/api/PerformanceContainerTiming.json
+++ b/api/PerformanceContainerTiming.json
@@ -428,6 +428,10 @@
       },
       "toJSON": {
         "__compat": {
+          "spec_url": "https://wicg.github.io/container-timing/#dom-performancecontainertiming-tojson",
+          "tags": [
+            "web-features:container-timing"
+          ],
           "support": {
             "chrome": {
               "version_added": "145",
@@ -465,7 +469,7 @@
           },
           "status": {
             "experimental": true,
-            "standard_track": false,
+            "standard_track": true,
             "deprecated": false
           }
         }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary

<!-- ✍️ In a sentence or two, describe your changes. -->

`PerformanceContainerTiming.toJSON()` was missed from the spec but was in implementations and added to BCD by @hamishwillee  in #30451 as non-standard in the meantime.

We since [got it added to the spec](https://github.com/WICG/container-timing/pull/77) so can change this to "standard" with the spec link.

#### Test results and supporting details

<!-- 👩‍🔬 If you tested your changes, describe how. Include or link to test cases. -->

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Already tested in #30451

#### Related issues

<!-- 🔨 If applicable, use "Fixes #XYZ" -->

<!-- ✅ After submitting, review the results of the "Checks" tab! -->
